### PR TITLE
Update param type and write get/set utilities

### DIFF
--- a/src/types/invalidRouteParamValueError.ts
+++ b/src/types/invalidRouteParamValueError.ts
@@ -1,0 +1,1 @@
+export class InvalidRouteParamValueError extends Error {}

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -1,6 +1,25 @@
-export type ParamGetter<T = any> = (value: string) => T
+export type ParamExtras = {
+  invalid: (message?: string) => never,
+}
 
-export type Param<T = any> = {
+export type ParamGetter<T = any> = (value: string, extras: ParamExtras) => T
+export type ParamSetter<T = any> = (value: T, extras: ParamExtras) => string
+
+export type ParamGetSet<T = any> = {
   get: ParamGetter<T>,
-  set: (value: T) => string,
+  set: ParamSetter<T>,
+}
+
+export type Param = ParamGetter | ParamGetSet | RegExp | BooleanConstructor | NumberConstructor
+
+export function isParamGetter(value: Param): value is ParamGetter {
+  return typeof value === 'function' && value !== Boolean && value !== Number
+}
+
+export function isParamGetSet(value: Param): value is ParamGetSet {
+  return typeof value === 'object'
+    && 'get' in value
+    && typeof value.get === 'function'
+    && 'set' in value
+    && typeof value.set === 'function'
 }

--- a/src/types/routeMethods.test-d.ts
+++ b/src/types/routeMethods.test-d.ts
@@ -1,9 +1,9 @@
 import { test, expectTypeOf } from 'vitest'
-import { Param } from '@/types/params'
+import { ParamGetSet } from '@/types/params'
 import { Routes } from '@/types/routes'
 import { createRouter, path } from '@/utilities'
 
-const boolean: Param<boolean> = {
+const boolean: ParamGetSet<boolean> = {
   get: value => Boolean(value),
   set: value => value.toString(),
 }

--- a/src/utilities/params.test.ts
+++ b/src/utilities/params.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, test } from 'vitest'
+import { ParamGetSet, ParamGetter } from '@/types'
+import { getParamValue, setParamValue } from '@/utilities/params'
+
+describe('getParamValue', () => {
+
+  test('returns for correct value for Boolean', () => {
+    expect(getParamValue('true', Boolean)).toBe(true)
+    expect(getParamValue('false', Boolean)).toBe(false)
+    expect(() => getParamValue('', Boolean)).toThrowError()
+  })
+
+  test('returns for correct value for Number', () => {
+    expect(getParamValue('1', Number)).toBe(1)
+    expect(getParamValue('1.5', Number)).toBe(1.5)
+    expect(() => getParamValue('', Number)).toThrowError()
+  })
+
+  test('returns for correct value for RegExp', () => {
+    const param = /yes/
+
+    expect(getParamValue('yes', param)).toBe('yes')
+    expect(() => getParamValue('no', param)).toThrowError()
+    expect(() => getParamValue('', param)).toThrowError()
+  })
+
+  test('returns for correct value for ParamGetter', () => {
+    const param: ParamGetter<'yes'> = (value, { invalid }) => {
+      if (value !== 'yes') {
+        invalid()
+      }
+
+      return 'yes'
+    }
+
+    expect(getParamValue('yes', param)).toBe('yes')
+    expect(() => getParamValue('no', param)).toThrowError()
+    expect(() => getParamValue('', param)).toThrowError()
+  })
+
+  test('returns correct value for ParamGetSet', () => {
+    const getter: ParamGetSet<'yes'> = {
+      get: (value, { invalid }) => {
+        if (value !== 'yes') {
+          invalid()
+        }
+
+        return 'yes'
+      },
+      set: value => value,
+    }
+
+    expect(getParamValue('yes', getter)).toBe('yes')
+    expect(() => getParamValue('no', getter)).toThrowError()
+    expect(() => getParamValue('', getter)).toThrowError()
+  })
+
+})
+
+describe('setParamValue', () => {
+  test('returns for correct value for Boolean', () => {
+    expect(setParamValue(true, Boolean)).toBe('true')
+    expect(setParamValue(false, Boolean)).toBe('false')
+    expect(() => setParamValue('', Boolean)).toThrowError()
+  })
+
+  test('returns for correct value for Number', () => {
+    expect(setParamValue(1, Number)).toBe('1')
+    expect(setParamValue(1.5, Number)).toBe('1.5')
+    expect(() => setParamValue('', Number)).toThrowError()
+  })
+
+  test('returns for correct value for RegExp', () => {
+    const param = /yes/
+
+    expect(setParamValue('yes', param)).toBe('yes')
+    expect(() => setParamValue('no', param)).toThrowError()
+    expect(() => setParamValue('', param)).toThrowError()
+  })
+
+  test('returns for correct value for ParamGetter', () => {
+    const param: ParamGetter = (value, { invalid }) => {
+      if (value !== 'yes') {
+        invalid()
+      }
+
+      return 'yes'
+    }
+
+    expect(setParamValue('yes', param)).toBe('yes')
+    expect(() => setParamValue('no', param)).toThrowError()
+    expect(() => setParamValue('', param)).toThrowError()
+  })
+
+  test('returns correct value for ParamGetSet', () => {
+    const param: ParamGetSet = {
+      get: (value, { invalid }) => {
+        if (value !== 'yes') {
+          invalid()
+        }
+
+        return 'yes'
+      },
+      set: (value, { invalid }) => {
+        if (value !== 'yes') {
+          invalid()
+        }
+
+        return 'yes'
+      },
+    }
+
+    expect(setParamValue('yes', param)).toBe('yes')
+    expect(() => setParamValue('no', param)).toThrowError()
+    expect(() => setParamValue('', param)).toThrowError()
+  })
+})

--- a/src/utilities/params.ts
+++ b/src/utilities/params.ts
@@ -1,0 +1,117 @@
+import { Param, ParamGetSet, ParamExtras, isParamGetSet, isParamGetter } from '@/types'
+import { InvalidRouteParamValueError } from '@/types/invalidRouteParamValueError'
+
+const extras: ParamExtras = {
+  invalid: (message?: string) => {
+    throw new InvalidRouteParamValueError(message)
+  },
+}
+
+const booleanParam: ParamGetSet = {
+  get: (value, { invalid }) => {
+    if (value === 'true') {
+      return true
+    }
+
+    if (value === 'false') {
+      return false
+    }
+
+    throw invalid()
+  },
+  set: (value, { invalid }) => {
+    if (typeof value !== 'boolean') {
+      throw invalid()
+    }
+
+    return value.toString()
+  },
+}
+
+const numberParam: ParamGetSet = {
+  get: (value, { invalid }) => {
+    // Number('') === 0
+    if (value.length === 0) {
+      throw invalid()
+    }
+
+    const number = Number(value)
+
+    if (isNaN(number)) {
+      throw invalid()
+    }
+
+    return number
+  },
+  set: (value, { invalid }) => {
+    if (typeof value !== 'number') {
+      invalid()
+    }
+
+    return value.toString()
+  },
+}
+
+export function getParamValue(value: string, param: Param): unknown {
+  if (param === Boolean) {
+    return booleanParam.get(value, extras)
+  }
+
+  if (param === Number) {
+    return numberParam.get(value, extras)
+  }
+
+  if (isParamGetter(param)) {
+    return param(value, extras)
+  }
+
+  if (isParamGetSet(param)) {
+    return param.get(value, extras)
+  }
+
+  if (param instanceof RegExp) {
+    if (param.test(value)) {
+      return value
+    }
+
+    throw new InvalidRouteParamValueError()
+  }
+
+  return value
+}
+
+export function setParamValue(value: unknown, param: Param): string {
+  if (param === Boolean) {
+    return booleanParam.set(value, extras)
+  }
+
+  if (param === Number) {
+    return numberParam.set(value, extras)
+  }
+
+  if (isParamGetter(param)) {
+    const stringValue = (value as any).toString()
+
+    param(stringValue, extras)
+
+    return stringValue
+  }
+
+  if (isParamGetSet(param)) {
+    return param.set(value, extras)
+  }
+
+  if (param instanceof RegExp) {
+    if (typeof value === 'string' && param.test(value)) {
+      return value
+    }
+
+    throw new InvalidRouteParamValueError()
+  }
+
+  try {
+    return (value as any).toString()
+  } catch (error) {
+    throw new InvalidRouteParamValueError()
+  }
+}

--- a/src/utilities/path.ts
+++ b/src/utilities/path.ts
@@ -1,9 +1,9 @@
-import { Param, ParamGetter } from '@/types/params'
+import { Param } from '@/types/params'
 import { ExtractParamsFromPathString } from '@/types/routeMethods'
 import { Identity } from '@/types/utilities'
 
 type PathParams<T extends string> = {
-  [K in keyof ExtractParamsFromPathString<T>]?: Param | ParamGetter
+  [K in keyof ExtractParamsFromPathString<T>]?: Param
 }
 
 export type Path<


### PR DESCRIPTION
# Description
Introduces two new utilities `getParamValue` and `setParamValue`. These are intended to be used to transform a typed param to and from a string. 

`getParamValue` accepts a string value and a `Param` and then determines how to parse the string value based on the param given.

`setParamValue` accepts a typed value and a `Param` and then determines how to stringify the value based on the param given.

A `Param` can be `ParamGetter | ParamGetSet | RegExp | BooleanConstructor | NumberConstructor`. 