### PR TITLE
Add `component` property and types to `Route` types

### DIFF
--- a/src/types/routeMethods.test-d.ts
+++ b/src/types/routeMethods.test-d.ts
@@ -3,6 +3,8 @@ import { Param } from '@/types/params'
 import { Routes } from '@/types/routes'
 import { createRouter, path } from '@/utilities'
 
+const component = { template: '<div>This is component</div>' }
+
 const boolean: Param<boolean> = {
   get: value => Boolean(value),
   set: value => value.toString(),
@@ -13,6 +15,7 @@ test('requires no arguments when there are no parameters', () => {
     {
       name: 'foo',
       path: '',
+      component,
     },
   ] as const satisfies Routes
 
@@ -26,6 +29,7 @@ test('does not match single colons as params', () => {
     {
       name: 'foo',
       path: ':',
+      component,
     },
   ] as const satisfies Routes
 
@@ -39,6 +43,7 @@ test('does not match :? as params', () => {
     {
       name: 'foo',
       path: ':?',
+      component,
     },
   ] as const satisfies Routes
 
@@ -54,6 +59,7 @@ test('matches individual params', () => {
     {
       name: 'foo',
       path: ':foo',
+      component,
     },
   ] as const satisfies Routes
 
@@ -69,6 +75,7 @@ test('matches individual optional params', () => {
     {
       name: 'foo',
       path: ':?foo',
+      component,
     },
   ] as const satisfies Routes
 
@@ -84,6 +91,7 @@ test('matches multiple params with the same name', () => {
     {
       name: 'foo',
       path: ':foo/:?foo/:foo',
+      component,
     },
   ] as const satisfies Routes
 
@@ -99,6 +107,7 @@ test('matches multiple params with the same name as optional', () => {
     {
       name: 'foo',
       path: ':?foo/:?foo/:?foo',
+      component,
     },
   ] as const satisfies Routes
 
@@ -116,6 +125,7 @@ test('matches typed params using a Param', () => {
       path: path(':foo', {
         foo: boolean,
       }),
+      component,
     },
   ] as const satisfies Routes
 
@@ -133,6 +143,7 @@ test('matches typed params using a ParamGetter', () => {
       path: path(':foo', {
         foo: Boolean,
       }),
+      component,
     },
   ] as const satisfies Routes
 
@@ -150,6 +161,7 @@ test('matches multiple typed params', () => {
       path: path(':foo/:foo/:foo', {
         foo: Boolean,
       }),
+      component,
     },
   ] as const satisfies Routes
 
@@ -167,6 +179,7 @@ test('matches individual as optional when matching multiple params with the same
       path: path(':foo/:?foo/:foo', {
         foo: Boolean,
       }),
+      component,
     },
   ] as const satisfies Routes
 
@@ -186,6 +199,7 @@ test('matches params across children', () => {
         {
           name: 'bar',
           path: '/:bar',
+          component,
         },
       ],
     },
@@ -208,6 +222,7 @@ test('matches multiple params with the same name across children', () => {
         {
           name: 'bar',
           path: '/:?foo',
+          component,
         },
       ],
     },
@@ -229,6 +244,7 @@ test('matches multiple params with the same name as optional across children', (
         {
           name: 'bar',
           path: '/:?foo',
+          component,
         },
       ],
     },
@@ -250,12 +266,14 @@ test('multiple root routes produces multiple routes', () => {
         {
           name: 'bar',
           path: '/bar',
+          component,
         },
       ],
     },
     {
       name: 'bar',
       path: '/bar',
+      component,
     },
   ] as const satisfies Routes
 
@@ -277,6 +295,7 @@ test('parent routes without a name do not appear in the routes object', () => {
             {
               name: 'three',
               path: '/three',
+              component,
             },
             {
               path: '/four',
@@ -284,6 +303,7 @@ test('parent routes without a name do not appear in the routes object', () => {
                 {
                   name: 'five',
                   path: '/five',
+                  component,
                 },
               ],
             },
@@ -314,6 +334,7 @@ test('all routes with a name can be called unless disabled', () => {
             {
               name: 'grandchild',
               path: '/:grandchild',
+              component,
             },
           ],
         },
@@ -327,11 +348,13 @@ test('all routes with a name can be called unless disabled', () => {
         {
           name: 'child2',
           path: '/child',
+          component,
         },
         {
           name: 'child3',
           path: '/child3',
           public: false,
+          component,
         },
       ],
     },
@@ -341,6 +364,7 @@ test('all routes with a name can be called unless disabled', () => {
         {
           name: 'child4',
           path: '/child4',
+          component,
         },
       ],
     },
@@ -364,7 +388,13 @@ test('public parent routes have correct type for parameters', () => {
       path: path('/:param1/:param1/:param2/:param3', {
         param3: boolean,
       }),
-      children: [{ name: 'child', path: '/:param4' }],
+      children: [
+        {
+          name: 'child',
+          path: '/:param4',
+          component,
+        },
+      ],
     },
   ] as const satisfies Routes
 

--- a/src/types/routes.ts
+++ b/src/types/routes.ts
@@ -1,4 +1,8 @@
+import { Component, DefineComponent } from 'vue'
+import { MaybeLazy } from '@/types/utilities'
 import { Path } from '@/utilities/path'
+
+type RouteComponent = MaybeLazy<Component | DefineComponent>
 
 export type ParentRoute<
   TRoute extends string | Path = any
@@ -7,6 +11,7 @@ export type ParentRoute<
   path: TRoute,
   public?: boolean,
   children: Routes,
+  component?: RouteComponent,
 }
 
 export type ChildRoute<
@@ -15,13 +20,14 @@ export type ChildRoute<
   name: string,
   public?: boolean,
   path: TRoute,
+  component: RouteComponent,
 }
 
 export type Route<
   TRoute extends string | Path = any
 > = ParentRoute<TRoute> | ChildRoute<TRoute>
 
-export type Routes = Readonly<(ParentRoute | ChildRoute)[]>
+export type Routes = Readonly<Route[]>
 
 export function isParentRoute(value: Route): value is ParentRoute {
   return 'children' in value

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -35,3 +35,5 @@ export type UnionToIntersection<Union> = (
   // The `& Union` is to allow indexing by the resulting type
   ? Intersection & Union
   : never
+
+export type MaybeLazy<T> = T | (() => Promise<T>)

--- a/src/utilities/createRouter.spec.ts
+++ b/src/utilities/createRouter.spec.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from 'vitest'
 import { Routes } from '@/types'
 import { createRouter } from '@/utilities'
 
+const component = { template: '<div>This is component</div>' }
+
 describe('router.routeMatch', () => {
   test('given path without params, returns unmodified regex', () => {
     const routes = [
@@ -16,6 +18,7 @@ describe('router.routeMatch', () => {
               {
                 name: 'grandchild',
                 path: '/grandchild',
+                component,
               },
             ],
           },
@@ -43,6 +46,7 @@ describe('router.routeMatch', () => {
               {
                 name: 'namedGrandchild',
                 path: '/named-grandchild',
+                component,
               },
             ],
           },
@@ -64,6 +68,7 @@ describe('router.routeMatch', () => {
           {
             name: 'unnamed-child-root',
             path: '',
+            component,
           },
         ],
       },
@@ -89,6 +94,7 @@ describe('router.routeMatch', () => {
               {
                 name: 'namedGrandchild',
                 path: '',
+                component,
               },
             ],
           },

--- a/src/utilities/createRouter.ts
+++ b/src/utilities/createRouter.ts
@@ -2,7 +2,7 @@ import { RouteFlat, RouteMethods, Routes } from '@/types'
 import { flattenRoutes } from '@/utilities/flattenRoutes'
 
 export type Router<T extends Routes> = {
-  // routes: RouteMethods<T, Record<never, never>>,
+  routes: RouteMethods<T, Record<never, never>>,
   routeMatch: (path: string) => RouteFlat[],
 }
 
@@ -14,7 +14,6 @@ export function createRouter<T extends Routes>(routes: T): Router<T> {
   }
 
   return {
-    // routes: {} as RouteMethods<T, Record<never, never>>,
     routeMatch,
-  }
+  } as Router<T>
 }

--- a/src/utilities/flattenRoutes.spec.ts
+++ b/src/utilities/flattenRoutes.spec.ts
@@ -2,6 +2,8 @@ import { describe, expect, test } from 'vitest'
 import { Route, Routes } from '@/types'
 import { flattenRoutes, generateRouteRegexPattern } from '@/utilities/flattenRoutes'
 
+const component = { template: '<div>This is component</div>' }
+
 describe('flattenRoutes', () => {
   test('always returns 1 record per named route', () => {
     const routes = [
@@ -12,6 +14,7 @@ describe('flattenRoutes', () => {
           {
             name: 'bar',
             path: '/bar/:bparam',
+            component,
           },
         ],
       },
@@ -22,6 +25,7 @@ describe('flattenRoutes', () => {
           {
             name: 'new-account',
             path: '/new',
+            component,
           },
           {
             name: 'account',
@@ -30,6 +34,7 @@ describe('flattenRoutes', () => {
               {
                 name: 'edit-account',
                 path: '/edit',
+                component,
               },
             ],
           },
@@ -46,6 +51,7 @@ describe('flattenRoutes', () => {
     const childRoute: Route = {
       name: 'new-account',
       path: '/new',
+      component,
     }
 
     const parentRoute: Route = {


### PR DESCRIPTION
# Description
Makes component a required property of a `ChildRoute` and an optional property on `ParentRoute`. Updates tests to add components where necessary. 