### PR TITLE
updated param logic on flatten routes utility

### DIFF
--- a/src/utilities/flattenRoutes.spec.ts
+++ b/src/utilities/flattenRoutes.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { Route, Routes } from '@/types'
-import { flattenRoutes, generateRouteRegexPattern } from '@/utilities/flattenRoutes'
+import { flattenRoutes, generateRouteRegexPattern, path } from '@/utilities'
 
 const component = { template: '<div>This is component</div>' }
 
@@ -77,11 +77,21 @@ describe('generateRouteRegexPattern', () => {
   })
 
   test('given path with params, returns value with params replaced with catchall', () => {
-    const input = 'parent/child/:child-param/grand-child/:grandChild123'
+    const input = 'parent/child/:childParam/grand-child/:grandChild123'
 
     const result = generateRouteRegexPattern(input)
 
     const catchAll = '([^/]+)'
+    const expected = new RegExp(`^parent/child/${catchAll}/grand-child/${catchAll}$`)
+    expect(result.toString()).toBe(expected.toString())
+  })
+
+  test('given path with optional params, returns value with params replaced with catchall', () => {
+    const input = 'parent/child/:?childParam/grand-child/:?grandChild123'
+
+    const result = generateRouteRegexPattern(input)
+
+    const catchAll = '([^/]*)'
     const expected = new RegExp(`^parent/child/${catchAll}/grand-child/${catchAll}$`)
     expect(result.toString()).toBe(expected.toString())
   })

--- a/src/utilities/flattenRoutes.spec.ts
+++ b/src/utilities/flattenRoutes.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { Route, Routes } from '@/types'
-import { flattenRoutes, generateRouteRegexPattern, path } from '@/utilities'
+import { flattenRoutes, generateRouteRegexPattern } from '@/utilities'
 
 const component = { template: '<div>This is component</div>' }
 

--- a/src/utilities/flattenRoutes.ts
+++ b/src/utilities/flattenRoutes.ts
@@ -24,8 +24,8 @@ export function flattenRoutes(routes: Routes, path = ''): RouteFlat[] {
 
 export function generateRouteRegexPattern(path: string): RegExp {
   const optionalParamRegex = /(:\?[\w]+)(?=\W|$)/g
-  const paramRegex = /(:[\w]+)(?=\W|$)/g
+  const requiredParamRegex = /(:[\w]+)(?=\W|$)/g
 
-  const routeRegex = path.replace(optionalParamRegex, '([^/]*)').replace(paramRegex, '([^/]+)')
+  const routeRegex = path.replace(optionalParamRegex, '([^/]*)').replace(requiredParamRegex, '([^/]+)')
   return new RegExp(`^${routeRegex}$`)
 }

--- a/src/utilities/flattenRoutes.ts
+++ b/src/utilities/flattenRoutes.ts
@@ -23,7 +23,9 @@ export function flattenRoutes(routes: Routes, path = ''): RouteFlat[] {
 }
 
 export function generateRouteRegexPattern(path: string): RegExp {
-  const paramRegex = /(:[\w-]+)(?=\W|$)/g
+  const optionalParamRegex = /(:\?[\w]+)(?=\W|$)/g
+  const paramRegex = /(:[\w]+)(?=\W|$)/g
 
-  return new RegExp(`^${path.replace(paramRegex, '([^/]+)')}$`)
+  const routeRegex = path.replace(optionalParamRegex, '([^/]*)').replace(paramRegex, '([^/]+)')
+  return new RegExp(`^${routeRegex}$`)
 }


### PR DESCRIPTION
adjusted logic for flatten routes regex, param names must be letters only and now support optional params