### PR TITLE
Match alphanumeric params only

### DIFF
--- a/src/types/routeMethods.test-d.ts
+++ b/src/types/routeMethods.test-d.ts
@@ -406,3 +406,22 @@ test('public parent routes have correct type for parameters', () => {
     param3: boolean,
   }]>()
 })
+
+test('param names must be alphanumeric', () => {
+  const routes = [
+    {
+      name: 'foo',
+      path: '/:param1-:param2/:param3_:param4',
+      component,
+    },
+  ] as const satisfies Routes
+
+  const router = createRouter(routes)
+
+  expectTypeOf(router.routes.foo).parameters.toEqualTypeOf<[{
+    param1: string,
+    param2: string,
+    param3: string,
+    param4: string,
+  }]>()
+})

--- a/src/types/routeMethods.ts
+++ b/src/types/routeMethods.ts
@@ -1,6 +1,6 @@
 import { Param, ParamGetSet, ParamGetter } from '@/types/params'
 import { Route, Routes } from '@/types/routes'
-import { Identity, IsAny, IsEmptyObject, TupleCanBeAllUndefined, UnionToIntersection } from '@/types/utilities'
+import { Identity, IsAny, IsEmptyObject, ReplaceAll, TupleCanBeAllUndefined, UnionToIntersection } from '@/types/utilities'
 import { Path } from '@/utilities/path'
 
 export type RouteMethod<
@@ -58,17 +58,23 @@ export type ExtractRouteMethodParams<T> = T extends RouteMethod<infer Params>
 export type ExtractParamsFromPath<
   TPath extends Route['path']
 > = TPath extends Path
-  ? ExtractParamsFromPathString<TPath['path'], TPath['params']>
+  ? ExtractParamsFromPathString<UnifyParamEnds<TPath['path']>, TPath['params']>
   : TPath extends string
-    ? ExtractParamsFromPathString<TPath>
+    ? ExtractParamsFromPathString<UnifyParamEnds<TPath>>
     : never
+
+type ParamEnd = '/'
+
+type UnifyParamEnds<
+  TPath extends string
+> = ReplaceAll<ReplaceAll<TPath, '-', ParamEnd>, '_', ParamEnd>
 
 export type ExtractParamsFromPathString<
   TPath extends string,
   TParams extends Record<string, Param> = Record<never, never>
-> = TPath extends `${infer Path}/`
+> = TPath extends `${infer Path}${ParamEnd}`
   ? ExtractParamsFromPathString<Path, TParams>
-  : TPath extends `${string}:${infer Param}/${infer Rest}`
+  : TPath extends `${string}:${infer Param}${ParamEnd}${infer Rest}`
     ? MergeParams<{ [P in ExtractParamName<Param>]: ExtractPathParamType<Param, TParams> }, ExtractParamsFromPathString<Rest, TParams>>
     : TPath extends `${string}:${infer Param}`
       ? { [P in ExtractParamName<Param>]: ExtractPathParamType<Param, TParams> }

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -37,3 +37,12 @@ export type UnionToIntersection<Union> = (
   : never
 
 export type MaybeLazy<T> = T | (() => Promise<T>)
+
+// Copied and modified from [type-fest](https://github.com/sindresorhus/type-fest/blob/main/source/replace.d.ts)
+export type ReplaceAll<
+  Input extends string,
+  Search extends string,
+  Replacement extends string
+> = Input extends `${infer Head}${Search}${infer Tail}`
+  ? `${Head}${Replacement}${ReplaceAll<Tail, Search, Replacement>}`
+  : Input


### PR DESCRIPTION
# Description
Loosely conforms the types for route params to match params that end with a `/ `, `-`, or `_`. 

This is accomplished by replacing `-` and `_` with `/` on each path prior to parsing out the params. Then `/` is used same as before. Each character we want to support requires a `ReplaceAll<path, '-', '/'>` type to wrap the path. This is recursive template literal type. So I think there probably is some cost to doing this. 

For that reason there are some other special characters that I'm not accounting for here that are valid url characters are `.`, `!`, `~`, `*`, `'`, `(`,  and `)`. Which are not commonly used. I vote we only add this if necessary but I don't feel strongly. 