### PR TITLE
Path types

### DIFF
--- a/src/types/routeMethods.ts
+++ b/src/types/routeMethods.ts
@@ -58,20 +58,20 @@ export type ExtractRouteMethodParams<T> = T extends RouteMethod<infer Params>
 export type ExtractParamsFromPath<
   TPath extends Route['path']
 > = TPath extends Path
-  ? ExtractParamsFromPathString<UnifyParamEnds<TPath['path']>, TPath['params']>
+  ? TPath['params']
   : TPath extends string
-    ? ExtractParamsFromPathString<UnifyParamEnds<TPath>>
+    ? Path<TPath, {}>['params']
     : never
 
 type ParamEnd = '/'
 
-type UnifyParamEnds<
+export type UnifyParamEnds<
   TPath extends string
 > = ReplaceAll<ReplaceAll<TPath, '-', ParamEnd>, '_', ParamEnd>
 
 export type ExtractParamsFromPathString<
   TPath extends string,
-  TParams extends Record<string, Param> = Record<never, never>
+  TParams extends Record<string, Param | undefined> = Record<never, never>
 > = TPath extends `${infer Path}${ParamEnd}`
   ? ExtractParamsFromPathString<Path, TParams>
   : TPath extends `${string}:${infer Param}${ParamEnd}${infer Rest}`
@@ -115,7 +115,7 @@ type ExtractParamName<
 
 type ExtractPathParamType<
   TParam extends string,
-  TParams extends Record<string, Param>
+  TParams extends Record<string, Param | undefined>
 > = TParam extends `?${infer OptionalParam}`
   ? OptionalParam extends keyof TParams
     ? ExtractParamType<TParams[OptionalParam]> | undefined
@@ -124,7 +124,7 @@ type ExtractPathParamType<
     ? ExtractParamType<TParams[TParam]>
     : string
 
-type ExtractParamType<TParam extends Param> = TParam extends ParamGetSet<infer Type>
+type ExtractParamType<TParam extends Param | undefined> = TParam extends ParamGetSet<infer Type>
   ? Type
   : TParam extends ParamGetter
     ? ReturnType<TParam>

--- a/src/types/routeMethods.ts
+++ b/src/types/routeMethods.ts
@@ -65,18 +65,18 @@ export type ExtractParamsFromPath<
 
 type ParamEnd = '/'
 
-export type UnifyParamEnds<
+type UnifyParamEnds<
   TPath extends string
 > = ReplaceAll<ReplaceAll<TPath, '-', ParamEnd>, '_', ParamEnd>
 
 export type ExtractParamsFromPathString<
   TPath extends string,
   TParams extends Record<string, Param | undefined> = Record<never, never>
-> = TPath extends `${infer Path}${ParamEnd}`
+> = UnifyParamEnds<TPath> extends `${infer Path}${ParamEnd}`
   ? ExtractParamsFromPathString<Path, TParams>
-  : TPath extends `${string}:${infer Param}${ParamEnd}${infer Rest}`
+  : UnifyParamEnds<TPath> extends `${string}:${infer Param}${ParamEnd}${infer Rest}`
     ? MergeParams<{ [P in ExtractParamName<Param>]: ExtractPathParamType<Param, TParams> }, ExtractParamsFromPathString<Rest, TParams>>
-    : TPath extends `${string}:${infer Param}`
+    : UnifyParamEnds<TPath> extends `${string}:${infer Param}`
       ? { [P in ExtractParamName<Param>]: ExtractPathParamType<Param, TParams> }
       : Record<never, never>
 

--- a/src/utilities/path.ts
+++ b/src/utilities/path.ts
@@ -1,5 +1,5 @@
 import { Param } from '@/types/params'
-import { ExtractParamsFromPathString } from '@/types/routeMethods'
+import { ExtractParamsFromPathString, UnifyParamEnds } from '@/types/routeMethods'
 import { Identity } from '@/types/utilities'
 
 type PathParams<T extends string> = {
@@ -11,7 +11,7 @@ export type Path<
   P extends PathParams<T> = any
 > = {
   path: T,
-  params: P,
+  params: Identity<ExtractParamsFromPathString<UnifyParamEnds<T>, P>>,
 }
 
 export function path<T extends string, P extends PathParams<T>>(_path: T, _params: Identity<P>): Path<T, P> {

--- a/src/utilities/path.ts
+++ b/src/utilities/path.ts
@@ -1,5 +1,5 @@
 import { Param } from '@/types/params'
-import { ExtractParamsFromPathString, UnifyParamEnds } from '@/types/routeMethods'
+import { ExtractParamsFromPathString } from '@/types/routeMethods'
 import { Identity } from '@/types/utilities'
 
 type PathParams<T extends string> = {
@@ -11,7 +11,7 @@ export type Path<
   P extends PathParams<T> = any
 > = {
   path: T,
-  params: Identity<ExtractParamsFromPathString<UnifyParamEnds<T>, P>>,
+  params: Identity<ExtractParamsFromPathString<T, P>>,
 }
 
 export function path<T extends string, P extends PathParams<T>>(_path: T, _params: Identity<P>): Path<T, P> {


### PR DESCRIPTION
# Description
Path originally just returned the same types as its arguments. Which was never really correct but allowed for all the other types to be written. Implementing the type path should actually return by having all route method types use Path and having Path be responsible for extracting param types. 