### PR TITLE
Make sure to always return a tuple for params in ExtractParamsFromPathString

### DIFF
--- a/src/types/routeMethods.ts
+++ b/src/types/routeMethods.ts
@@ -77,7 +77,7 @@ export type ExtractParamsFromPathString<
   : UnifyParamEnds<TPath> extends `${string}:${infer Param}${ParamEnd}${infer Rest}`
     ? MergeParams<{ [P in ExtractParamName<Param>]: ExtractPathParamType<Param, TParams> }, ExtractParamsFromPathString<Rest, TParams>>
     : UnifyParamEnds<TPath> extends `${string}:${infer Param}`
-      ? { [P in ExtractParamName<Param>]: ExtractPathParamType<Param, TParams> }
+      ? { [P in ExtractParamName<Param>]: [ExtractPathParamType<Param, TParams>] }
       : Record<never, never>
 
 type MergeParams<


### PR DESCRIPTION
# Description
Fixes single param not being a tuple