### PR TITLE
Router types

### DIFF
--- a/src/types/routeMethods.ts
+++ b/src/types/routeMethods.ts
@@ -11,7 +11,7 @@ export type RouteMethod<
 
 export type RouteMethods<
   TRoutes extends Routes,
-  TParams extends Record<string, unknown>
+  TParams extends Record<string, unknown> = Record<never, never>
 > = UnionToIntersection<RouteMethodsTuple<TRoutes, TParams>[number]>
 
 type RouteMethodsTuple<

--- a/src/utilities/createRouter.ts
+++ b/src/utilities/createRouter.ts
@@ -12,7 +12,7 @@ export type Router<T extends Routes> = {
 }
 
 function createRouteMethods<T extends Routes>(_routes: T): RouteMethods<T> {
-  throw 'not implemented'
+  return {} as any
 }
 
 export function createRouter<T extends Routes>(routes: T): Router<T> {

--- a/src/utilities/createRouter.ts
+++ b/src/utilities/createRouter.ts
@@ -2,8 +2,17 @@ import { RouteFlat, RouteMethods, Routes } from '@/types'
 import { flattenRoutes } from '@/utilities/flattenRoutes'
 
 export type Router<T extends Routes> = {
-  routes: RouteMethods<T, Record<never, never>>,
+  routes: RouteMethods<T>,
+  push: (url: string) => void,
+  replace: (url: string) => void,
+  back: () => void,
+  forward: () => void,
+  go: (number: number) => void,
   routeMatch: (path: string) => RouteFlat[],
+}
+
+function createRouteMethods<T extends Routes>(_routes: T): RouteMethods<T> {
+  throw 'not implemented'
 }
 
 export function createRouter<T extends Routes>(routes: T): Router<T> {
@@ -13,7 +22,35 @@ export function createRouter<T extends Routes>(routes: T): Router<T> {
     return flattened.filter(route => route.regex.test(path))
   }
 
-  return {
+  const push: Router<T>['push'] = (_url) => {
+    throw 'not implemented'
+  }
+
+  const replace: Router<T>['replace'] = (_url) => {
+    throw 'not implemented'
+  }
+
+  const forward: Router<T>['forward'] = () => {
+    throw 'not implemented'
+  }
+
+  const back: Router<T>['forward'] = () => {
+    throw 'not implemented'
+  }
+
+  const go: Router<T>['go'] = (_number) => {
+    throw 'not implemented'
+  }
+
+  const router = {
+    routes: createRouteMethods(routes),
+    push,
+    replace,
+    forward,
+    back,
+    go,
     routeMatch,
-  } as Router<T>
+  }
+
+  return router
 }


### PR DESCRIPTION
# Description
Fills out the `Router` type. Decided to leave the `routeMatch` method as part of the router for now to avoid making this change bigger. 