### PR TITLE
created setParamValue function in paramsFinder service

### DIFF
--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -12,8 +12,16 @@ export type ParamGetSet<T = any> = {
 
 export type Param = ParamGetter | ParamGetSet | RegExp | BooleanConstructor | NumberConstructor | StringConstructor
 
+function isNotConstructor(value: Param): boolean {
+  return value !== String && value !== Boolean && value !== Number
+}
+
 export function isParamGetter(value: Param): value is ParamGetter {
-  return typeof value === 'function' && value !== Boolean && value !== Number
+  return typeof value === 'function' && isNotConstructor(value)
+}
+
+export function isParamSetter(value: Param): value is ParamSetter {
+  return typeof value === 'function' && isNotConstructor(value)
 }
 
 export function isParamGetSet(value: Param): value is ParamGetSet {

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -20,10 +20,6 @@ export function isParamGetter(value: Param): value is ParamGetter {
   return typeof value === 'function' && isNotConstructor(value)
 }
 
-export function isParamSetter(value: Param): value is ParamSetter {
-  return typeof value === 'function' && isNotConstructor(value)
-}
-
 export function isParamGetSet(value: Param): value is ParamGetSet {
   return typeof value === 'object'
     && 'get' in value

--- a/src/utilities/paramValidation.ts
+++ b/src/utilities/paramValidation.ts
@@ -1,11 +1,11 @@
 import { Param, Resolved, Route } from '@/types'
-import { getParamValue, getParamValues } from '@/utilities'
+import { getParamValue, getParamValuesFromUrl } from '@/utilities'
 
 export function routeParamsAreValid(url: string, route: Resolved<Route>): boolean {
   const params = Object.entries<Param[]>(route.params)
 
   for (const [key, paramsTuple] of params) {
-    const stringValues = getParamValues(url, route.path, key)
+    const stringValues = getParamValuesFromUrl(url, route.path, key)
 
     try {
       paramsTuple.forEach((param, index) => getParamValue(stringValues[index], param))

--- a/src/utilities/paramValidation.ts
+++ b/src/utilities/paramValidation.ts
@@ -1,11 +1,11 @@
 import { Param, Resolved, Route } from '@/types'
-import { getParamValue, findParamValues } from '@/utilities'
+import { getParamValue, getParamValues } from '@/utilities'
 
 export function routeParamsAreValid(url: string, route: Resolved<Route>): boolean {
   const params = Object.entries<Param[]>(route.params)
 
   for (const [key, paramsTuple] of params) {
-    const stringValues = findParamValues(url, route.path, key)
+    const stringValues = getParamValues(url, route.path, key)
 
     try {
       paramsTuple.forEach((param, index) => getParamValue(stringValues[index], param))

--- a/src/utilities/params.spec.ts
+++ b/src/utilities/params.spec.ts
@@ -4,19 +4,19 @@ import { getParamValue, setParamValue } from '@/utilities/params'
 
 describe('getParamValue', () => {
 
-  test('returns for correct value for Boolean', () => {
+  test('given Boolean constructor Param, returns for correct value for Boolean', () => {
     expect(getParamValue('true', Boolean)).toBe(true)
     expect(getParamValue('false', Boolean)).toBe(false)
     expect(() => getParamValue('foo', Boolean)).toThrowError()
   })
 
-  test('returns for correct value for Number', () => {
+  test('given  Number constructor Param, returns for correct value for Number', () => {
     expect(getParamValue('1', Number)).toBe(1)
     expect(getParamValue('1.5', Number)).toBe(1.5)
     expect(() => getParamValue('foo', Number)).toThrowError()
   })
 
-  test('returns for correct value for RegExp', () => {
+  test('Given Regex Param, returns for correct value for RegExp', () => {
     const param = /yes/
 
     expect(getParamValue('yes', param)).toBe('yes')
@@ -24,7 +24,7 @@ describe('getParamValue', () => {
     expect(() => getParamValue('foo', param)).toThrowError()
   })
 
-  test('returns for correct value for ParamGetter', () => {
+  test('Given Custom Getter Param, returns for correct value for ParamGetter', () => {
     const param: ParamGetter<'yes'> = (value, { invalid }) => {
       if (value !== 'yes') {
         invalid()
@@ -38,7 +38,7 @@ describe('getParamValue', () => {
     expect(() => getParamValue('foo', param)).toThrowError()
   })
 
-  test('returns correct value for ParamGetSet', () => {
+  test('Given Custom GetSet, returns correct value for ParamGetSet', () => {
     const getter: ParamGetSet<'yes'> = {
       get: (value, { invalid }) => {
         if (value !== 'yes') {
@@ -58,27 +58,25 @@ describe('getParamValue', () => {
 })
 
 describe('setParamValue', () => {
-  test('returns for correct value for Boolean', () => {
+  test('Given Boolean Param, returns for correct value for Boolean', () => {
     expect(setParamValue(true, Boolean)).toBe('true')
     expect(setParamValue(false, Boolean)).toBe('false')
     expect(() => setParamValue('foo', Boolean)).toThrowError()
   })
 
-  test('returns for correct value for Number', () => {
+  test('Given Number Param, returns for correct value for Number', () => {
     expect(setParamValue(1, Number)).toBe('1')
     expect(setParamValue(1.5, Number)).toBe('1.5')
     expect(() => setParamValue('foo', Number)).toThrowError()
   })
 
-  test('returns for correct value for RegExp', () => {
+  test('Given Regex Param, returns value as String', () => {
     const param = /yes/
 
     expect(setParamValue('yes', param)).toBe('yes')
-    expect(() => setParamValue('no', param)).toThrowError()
-    expect(() => setParamValue('foo', param)).toThrowError()
   })
 
-  test('returns for correct value for ParamGetter', () => {
+  test('Given Getter Custom Param, returns value as String', () => {
     const param: ParamGetter = (value, { invalid }) => {
       if (value !== 'yes') {
         invalid()
@@ -88,11 +86,9 @@ describe('setParamValue', () => {
     }
 
     expect(setParamValue('yes', param)).toBe('yes')
-    expect(() => setParamValue('no', param)).toThrowError()
-    expect(() => setParamValue('foo', param)).toThrowError()
   })
 
-  test('returns correct value for ParamGetSet', () => {
+  test('Given Custom GetSet Param, returns correct value for ParamGetSet', () => {
     const param: ParamGetSet = {
       get: (value, { invalid }) => {
         if (value !== 'yes') {

--- a/src/utilities/params.ts
+++ b/src/utilities/params.ts
@@ -1,4 +1,4 @@
-import { Param, ParamGetSet, ParamExtras, isParamGetSet, isParamGetter, ExtractParamType, isParamSetter } from '@/types'
+import { Param, ParamGetSet, ParamExtras, isParamGetSet, isParamGetter, ExtractParamType } from '@/types'
 import { InvalidRouteParamValueError } from '@/types/invalidRouteParamValueError'
 
 const extras: ParamExtras = {
@@ -102,20 +102,8 @@ export function setParamValue(value: unknown, param: Param): string {
     return numberParam.set(value, extras)
   }
 
-  if (isParamSetter(param)) {
-    return param(value, extras)
-  }
-
   if (isParamGetSet(param)) {
     return param.set(value, extras)
-  }
-
-  if (param instanceof RegExp) {
-    if (typeof value === 'string' && param.test(value)) {
-      return value
-    }
-
-    throw new InvalidRouteParamValueError()
   }
 
   try {

--- a/src/utilities/params.ts
+++ b/src/utilities/params.ts
@@ -1,4 +1,4 @@
-import { Param, ParamGetSet, ParamExtras, isParamGetSet, isParamGetter, ExtractParamType } from '@/types'
+import { Param, ParamGetSet, ParamExtras, isParamGetSet, isParamGetter, ExtractParamType, isParamSetter } from '@/types'
 import { InvalidRouteParamValueError } from '@/types/invalidRouteParamValueError'
 
 const extras: ParamExtras = {
@@ -102,12 +102,8 @@ export function setParamValue(value: unknown, param: Param): string {
     return numberParam.set(value, extras)
   }
 
-  if (isParamGetter(param)) {
-    const stringValue = (value as any).toString()
-
-    param(stringValue, extras)
-
-    return stringValue
+  if (isParamSetter(param)) {
+    return param(value, extras)
   }
 
   if (isParamGetSet(param)) {

--- a/src/utilities/paramsFinder.spec.ts
+++ b/src/utilities/paramsFinder.spec.ts
@@ -1,76 +1,76 @@
 import { describe, expect, test } from 'vitest'
 import { InvalidRouteParamValueError } from '@/types'
-import { getParamValues, optional, setParamValues } from '@/utilities'
+import { getParamValuesFromUrl, optional, setParamValuesOnUrl } from '@/utilities'
 
-describe('getParamValues', () => {
+describe('getParamValuesFromUrl', () => {
   test('given path WITHOUT params, always returns empty array', () => {
-    const response = getParamValues('/no-params', '/no-params', 'key')
+    const response = getParamValuesFromUrl('/no-params', '/no-params', 'key')
 
     expect(response).toHaveLength(0)
   })
 
   test('given paramName that does NOT match param on route, always returns empty array', () => {
-    const response = getParamValues('/key/ABC/not-in/123', '/key/:key/not-in/:route', 'fail')
+    const response = getParamValuesFromUrl('/key/ABC/not-in/123', '/key/:key/not-in/:route', 'fail')
 
     expect(response).toHaveLength(0)
   })
 
   test('given paramName that matches param on route but value is not present, always returns empty array', () => {
-    const response = getParamValues('/simple', '/simple/:simple', 'simple')
+    const response = getParamValuesFromUrl('/simple', '/simple/:simple', 'simple')
 
     expect(response).toHaveLength(0)
   })
 
   test('given paramName that matches param on route and value is not present, returns single value in array', () => {
-    const response = getParamValues('/simple/ABC', '/simple/:simple', 'simple')
+    const response = getParamValuesFromUrl('/simple/ABC', '/simple/:simple', 'simple')
 
     expect(response).toMatchObject(['ABC'])
   })
 
   test('given paramName that matches multiple param on route and value is present, returns each value in array', () => {
-    const response = getParamValues('/simple/ABC/DEF/gap/GHI', '/simple/:simple/:simple/gap/:simple', 'simple')
+    const response = getParamValuesFromUrl('/simple/ABC/DEF/gap/GHI', '/simple/:simple/:simple/gap/:simple', 'simple')
 
     expect(response).toMatchObject(['ABC', 'DEF', 'GHI'])
   })
 
   test('given paramName that matches multiple param on route value is present with some optional, returns each value in array including empty string', () => {
-    const response = getParamValues('/simple/ABC//gap/GHI', '/simple/:simple/:?simple/gap/:simple', 'simple')
+    const response = getParamValuesFromUrl('/simple/ABC//gap/GHI', '/simple/:simple/:?simple/gap/:simple', 'simple')
 
     expect(response).toMatchObject(['ABC', '', 'GHI'])
   })
 })
 
-describe('setParamValues', () => {
+describe('setParamValuesOnUrl', () => {
   test('given path WITHOUT params, always returns url as it was passed', () => {
-    const response = setParamValues('/no-params')
+    const response = setParamValuesOnUrl('/no-params')
 
     expect(response).toBe('/no-params')
   })
 
   test('given paramName that does NOT match param on route, always returns empty array', () => {
-    const response = setParamValues('/key/:key/not-in/:route', { name: 'fail', params: [String], values: ['ABC'] })
+    const response = setParamValuesOnUrl('/key/:key/not-in/:route', { name: 'fail', params: [String], values: ['ABC'] })
 
     expect(response).toBe('/key/:key/not-in/:route')
   })
 
   test('given paramName that matches param on route but value is not present, always returns empty array', () => {
-    const response = setParamValues('/simple/:simple', { name: 'simple', params: [String], values: ['ABC'] })
+    const response = setParamValuesOnUrl('/simple/:simple', { name: 'simple', params: [String], values: ['ABC'] })
 
     expect(response).toBe('/simple/ABC')
   })
 
   test('given paramName that matches param on route and value is not present, returns single value in array', () => {
-    expect(() => setParamValues('/simple/:simple', { name: 'simple', params: [String], values: [] })).toThrowError(InvalidRouteParamValueError)
+    expect(() => setParamValuesOnUrl('/simple/:simple', { name: 'simple', params: [String], values: [] })).toThrowError(InvalidRouteParamValueError)
   })
 
   test('given paramName that matches multiple param on route and value is present, returns each value in array', () => {
-    const response = setParamValues('/simple/:simple/:simple/gap/:simple', { name: 'simple', params: [String, String, String], values: ['ABC', 'DEF', 'GHI'] })
+    const response = setParamValuesOnUrl('/simple/:simple/:simple/gap/:simple', { name: 'simple', params: [String, String, String], values: ['ABC', 'DEF', 'GHI'] })
 
     expect(response).toBe('/simple/ABC/DEF/gap/GHI')
   })
 
   test('given paramName that matches multiple param on route value is present with some optional, returns each value in array including empty string', () => {
-    const response = setParamValues('/simple/:simple/:?simple/gap/:simple', { name: 'simple', params: [String, optional(String), String], values: ['ABC', undefined, 'GHI'] })
+    const response = setParamValuesOnUrl('/simple/:simple/:?simple/gap/:simple', { name: 'simple', params: [String, optional(String), String], values: ['ABC', undefined, 'GHI'] })
 
     expect(response).toBe('/simple/ABC//gap/GHI')
   })

--- a/src/utilities/paramsFinder.spec.ts
+++ b/src/utilities/paramsFinder.spec.ts
@@ -1,40 +1,77 @@
 import { describe, expect, test } from 'vitest'
-import { findParamValues } from '@/utilities'
+import { InvalidRouteParamValueError } from '@/types'
+import { getParamValues, optional, setParamValues } from '@/utilities'
 
-describe('findParamValues', () => {
+describe('getParamValues', () => {
   test('given path WITHOUT params, always returns empty array', () => {
-    const response = findParamValues('/no-params', '/no-params', 'key')
+    const response = getParamValues('/no-params', '/no-params', 'key')
 
     expect(response).toHaveLength(0)
   })
 
   test('given paramName that does NOT match param on route, always returns empty array', () => {
-    const response = findParamValues('/key/ABC/not-in/123', '/key/:key/not-in/:route', 'fail')
+    const response = getParamValues('/key/ABC/not-in/123', '/key/:key/not-in/:route', 'fail')
 
     expect(response).toHaveLength(0)
   })
 
   test('given paramName that matches param on route but value is not present, always returns empty array', () => {
-    const response = findParamValues('/simple', '/simple/:simple', 'simple')
+    const response = getParamValues('/simple', '/simple/:simple', 'simple')
 
     expect(response).toHaveLength(0)
   })
 
   test('given paramName that matches param on route and value is not present, returns single value in array', () => {
-    const response = findParamValues('/simple/ABC', '/simple/:simple', 'simple')
+    const response = getParamValues('/simple/ABC', '/simple/:simple', 'simple')
 
     expect(response).toMatchObject(['ABC'])
   })
 
   test('given paramName that matches multiple param on route and value is present, returns each value in array', () => {
-    const response = findParamValues('/simple/ABC/DEF/gap/GHI', '/simple/:simple/:simple/gap/:simple', 'simple')
+    const response = getParamValues('/simple/ABC/DEF/gap/GHI', '/simple/:simple/:simple/gap/:simple', 'simple')
 
     expect(response).toMatchObject(['ABC', 'DEF', 'GHI'])
   })
 
   test('given paramName that matches multiple param on route value is present with some optional, returns each value in array including empty string', () => {
-    const response = findParamValues('/simple/ABC//gap/GHI', '/simple/:simple/:?simple/gap/:simple', 'simple')
+    const response = getParamValues('/simple/ABC//gap/GHI', '/simple/:simple/:?simple/gap/:simple', 'simple')
 
     expect(response).toMatchObject(['ABC', '', 'GHI'])
+  })
+})
+
+describe('setParamValues', () => {
+  test('given path WITHOUT params, always returns url as it was passed', () => {
+    const response = setParamValues('/no-params')
+
+    expect(response).toBe('/no-params')
+  })
+
+  test('given paramName that does NOT match param on route, always returns empty array', () => {
+    const response = setParamValues('/key/:key/not-in/:route', { name: 'fail', params: [String], values: ['ABC'] })
+
+    expect(response).toBe('/key/:key/not-in/:route')
+  })
+
+  test('given paramName that matches param on route but value is not present, always returns empty array', () => {
+    const response = setParamValues('/simple/:simple', { name: 'simple', params: [String], values: ['ABC'] })
+
+    expect(response).toBe('/simple/ABC')
+  })
+
+  test('given paramName that matches param on route and value is not present, returns single value in array', () => {
+    expect(() => setParamValues('/simple/:simple', { name: 'simple', params: [String], values: [] })).toThrowError(InvalidRouteParamValueError)
+  })
+
+  test('given paramName that matches multiple param on route and value is present, returns each value in array', () => {
+    const response = setParamValues('/simple/:simple/:simple/gap/:simple', { name: 'simple', params: [String, String, String], values: ['ABC', 'DEF', 'GHI'] })
+
+    expect(response).toBe('/simple/ABC/DEF/gap/GHI')
+  })
+
+  test('given paramName that matches multiple param on route value is present with some optional, returns each value in array including empty string', () => {
+    const response = setParamValues('/simple/:simple/:?simple/gap/:simple', { name: 'simple', params: [String, optional(String), String], values: ['ABC', undefined, 'GHI'] })
+
+    expect(response).toBe('/simple/ABC//gap/GHI')
   })
 })

--- a/src/utilities/paramsFinder.ts
+++ b/src/utilities/paramsFinder.ts
@@ -19,9 +19,7 @@ export function setParamValuesOnUrl(path: string, paramReplace?: ParamReplace): 
     return path
   }
 
-  const { name } = { ...paramReplace }
-  const params = paramReplace.params ?? []
-  const values = paramReplace.values ?? []
+  const { name, params = [], values = [] } = paramReplace
   const regexPattern = getParamRegexPattern(path, name)
   const captureGroups = getCaptureGroups(path, regexPattern)
 

--- a/src/utilities/paramsFinder.ts
+++ b/src/utilities/paramsFinder.ts
@@ -2,7 +2,7 @@ import { Param } from '@/types'
 import { setParamValue } from '@/utilities/params'
 import { stringHasValue } from '@/utilities/string'
 
-export function getParamValues(url: string, path: string, paramName: string): string[] {
+export function getParamValuesFromUrl(url: string, path: string, paramName: string): string[] {
   const regexPattern = getParamRegexPattern(path, paramName)
 
   return getCaptureGroups(url, regexPattern)
@@ -10,16 +10,18 @@ export function getParamValues(url: string, path: string, paramName: string): st
 
 export type ParamReplace = {
   name: string,
-  params: Param[],
-  values: unknown[],
+  params?: Param[],
+  values?: unknown[],
 }
 
-export function setParamValues(path: string, paramReplace?: ParamReplace): string {
+export function setParamValuesOnUrl(path: string, paramReplace?: ParamReplace): string {
   if (!paramReplace) {
     return path
   }
 
-  const { name, params, values } = paramReplace
+  const { name } = { ...paramReplace }
+  const params = paramReplace.params ?? []
+  const values = paramReplace.values ?? []
   const regexPattern = getParamRegexPattern(path, name)
   const captureGroups = getCaptureGroups(path, regexPattern)
 


### PR DESCRIPTION
works similar to what was named `findParamValues` but in reverse.
takes `path: string`, and an optional ParamReplace (solution to what would be 4 params and making all optional)
```ts
{
  name: string,
  params: Param[],
  values: unknown[],
}
```

finds that param in path and replaces with param setter value

I'm tempted to rename `paramsFinder` now that it has both `getParamValues` and `setParamValues`, any suggestions?