### PR TITLE
implemented url assembly utility

### DIFF
--- a/src/utilities/createRouter.ts
+++ b/src/utilities/createRouter.ts
@@ -14,6 +14,7 @@ export type Router<
 }
 
 function createRouteMethods<T extends Routes>(_routes: T): RouteMethods<T> {
+  // use assembleUrl(route, args) to generate string URL
   return {} as any
 }
 

--- a/src/utilities/urlAssembly.spec.ts
+++ b/src/utilities/urlAssembly.spec.ts
@@ -1,0 +1,86 @@
+import { describe, expect, test } from 'vitest'
+import { InvalidRouteParamValueError, Route } from '@/types'
+import { path, resolveRoutes } from '@/utilities'
+import { assembleUrl } from '@/utilities/urlAssembly'
+
+const component = { template: '<div>This is component</div>' }
+
+describe('assembleUrl', () => {
+  test.each([
+    ['/simple'],
+    [path('/simple', {})],
+  ])('given simple route with string path and without params, returns route path', (path) => {
+    const route = {
+      name: 'simple',
+      path,
+      component,
+    } satisfies Route
+    const [resolved] = resolveRoutes([route])
+
+    const url = assembleUrl(resolved, {})
+
+    expect(url).toBe('/simple')
+  })
+
+  test.each([
+    ['/simple/:?simple'],
+    [path('/simple/:?simple', { simple: String })],
+  ])('given route with optional string param NOT provided, returns route Path with string without values interpolated', (path) => {
+    const route = {
+      name: 'simple',
+      path,
+      component,
+    } satisfies Route
+    const [resolved] = resolveRoutes([route])
+
+    const url = assembleUrl(resolved, {})
+
+    expect(url).toBe('/simple/')
+  })
+
+  test.each([
+    ['/simple/:?simple'],
+    [path('/simple/:?simple', { simple: String })],
+  ])('given route with optional string param provided, returns route Path with string with values interpolated', (path) => {
+    const route = {
+      name: 'simple',
+      path,
+      component,
+    } satisfies Route
+    const [resolved] = resolveRoutes([route])
+
+    const url = assembleUrl(resolved, { simple: ['ABC'] })
+
+    expect(url).toBe('/simple/ABC')
+  })
+
+  test.each([
+    ['/simple/:simple'],
+    [path('/simple/:simple', { simple: String })],
+  ])('given route with required string param NOT provided, throws error', (path) => {
+    const route = {
+      name: 'simple',
+      path,
+      component,
+    } satisfies Route
+    const [resolved] = resolveRoutes([route])
+
+    expect(() => assembleUrl(resolved, {})).toThrowError(InvalidRouteParamValueError)
+  })
+
+  test.each([
+    ['/simple/:simple'],
+    [path('/simple/:simple', { simple: String })],
+  ])('given route with required string param provided, returns route Path with string with values interpolated', (path) => {
+    const route = {
+      name: 'simple',
+      path,
+      component,
+    } satisfies Route
+    const [resolved] = resolveRoutes([route])
+
+    const url = assembleUrl(resolved, { simple: ['ABC'] })
+
+    expect(url).toBe('/simple/ABC')
+  })
+})

--- a/src/utilities/urlAssembly.ts
+++ b/src/utilities/urlAssembly.ts
@@ -1,0 +1,10 @@
+import { Param, Resolved, Route } from '@/types'
+import { setParamValuesOnUrl } from '@/utilities/paramsFinder'
+
+export function assembleUrl<T extends Resolved<Route>>(route: T, values: Record<string, unknown[]>): string {
+  const params = Object.entries<Param[]>(route.params)
+
+  return params.reduce((url, [name, params]) => {
+    return setParamValuesOnUrl(url, { name, params, values: values[name] })
+  }, route.path)
+}


### PR DESCRIPTION
utilizes `setParamValuesOnUrl` to take `Resolved<Route>` and `Param` arguments to assembly complete URL string. Will eventually be part of the implementation of RouteMethods