### PR TITLE
Fix types for RouteMethodResponse

### DIFF
--- a/src/types/routeMethods.test-d.ts
+++ b/src/types/routeMethods.test-d.ts
@@ -426,3 +426,18 @@ test('param names must be alphanumeric', () => {
     param4: string,
   }>()
 })
+
+test('route method returns correct typ when called', async () => {
+  const routes = [
+    {
+      name: 'foo',
+      path: '/foo',
+      component,
+    },
+  ] as const satisfies Routes
+
+  const router = createRouter(routes)
+
+  expectTypeOf(router.routes.foo()).toMatchTypeOf<{ url: string }>()
+  expectTypeOf(await router.routes.foo()).toEqualTypeOf<{ url: string }>()
+})

--- a/src/types/routeMethods.test-d.ts
+++ b/src/types/routeMethods.test-d.ts
@@ -427,7 +427,7 @@ test('param names must be alphanumeric', () => {
   }>()
 })
 
-test('route method returns correct typ when called', async () => {
+test('route method returns correct type when called', async () => {
   const routes = [
     {
       name: 'foo',

--- a/src/types/routeMethods.ts
+++ b/src/types/routeMethods.ts
@@ -14,9 +14,10 @@ export type RouteMethodOptions = {
   skipRouting: boolean,
 }
 
-export type RouteMethodResponse = PromiseLike<{
+export type RouteMethodResponse = {
   url: string,
-}>
+  then: PromiseLike<Omit<RouteMethodResponse, 'then'>>['then'],
+}
 
 export type RouteMethods<
   TRoutes extends Routes,

--- a/src/types/routeMethods.ts
+++ b/src/types/routeMethods.ts
@@ -1,6 +1,6 @@
 import { Param, ParamGetSet, ParamGetter } from '@/types/params'
 import { Route, Routes } from '@/types/routes'
-import { Identity, IsEmptyObject, ReplaceAll, TupleCanBeAllUndefined, UnionToIntersection } from '@/types/utilities'
+import { Identity, IsEmptyObject, ReplaceAll, Thenable, TupleCanBeAllUndefined, UnionToIntersection } from '@/types/utilities'
 import { Path } from '@/utilities/path'
 
 export type RouteMethod<
@@ -14,10 +14,9 @@ export type RouteMethodOptions = {
   skipRouting: boolean,
 }
 
-export type RouteMethodResponse = {
+export type RouteMethodResponse = Thenable<{
   url: string,
-  then: PromiseLike<Omit<RouteMethodResponse, 'then'>>['then'],
-}
+}>
 
 export type RouteMethods<
   TRoutes extends Routes,

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -50,3 +50,5 @@ export type ReplaceAll<
 > = Input extends `${infer Head}${Search}${infer Tail}`
   ? `${Head}${Replacement}${ReplaceAll<Tail, Search, Replacement>}`
   : Input
+
+export type Thenable<T> = T & PromiseLike<T>


### PR DESCRIPTION
# Description
Fixes the types for `RouteMethodResponse` so that both the sync and async values are the same. 

An example of implementing this type is [here](https://www.typescriptlang.org/play?#code/C4TwDgpgBASg9gV2BAshYALOATGEDOYcAdvtALxQDeAUFPVAgE4A2AXFPsEwJbEDmdBpgjEOABSZwAtjzIAZHgGsIAHgDys4KvhJU6LLgJFSEADRQA5COKWAfHYDa1jKMsBdGgF8aNAGYIxADGwDwkUFJ6ABQAlBy6yGiYOHiEJGTUQvRB6cARxukQHJo82gn6yUZpphYubnZQlLQMLYysHJZ+cHCWWVA+fTmkeTYAhgBGLEWwiIkGKQWmjZmtDMzsVl09Zn0tNhxQUUwEMY0NxBAA7lCSMnJqJWWzFYapJmS1NvZ2UUcEcCwAG4QU7kBpkYAAFR40ggs1+oIax3wAOBf2qZBiFgAjAAGfExGIAOhs6KxfQGLWOwGYxCgY0mEG8viGXGobRY-WWkWQsRorIBECJLDg-CilnwIGClgs6xivgA3FFRpLgodESsGKy8lQOV5lqNLqNShFnrEFYN0oLhaLxSqpUEZRz5V4YuagA)