### PR TITLE
Fix route methods showing up in types with `never`

### DIFF
--- a/src/types/routeMethods.test-d.ts
+++ b/src/types/routeMethods.test-d.ts
@@ -376,7 +376,7 @@ test('all routes with a name can be called unless disabled', () => {
   expectTypeOf(router.routes.parent.child).toBeFunction()
   expectTypeOf(router.routes.parent2).not.toBeFunction()
   expectTypeOf(router.routes.parent2.child2).toBeFunction()
-  expectTypeOf(router.routes.parent2.child3).not.toBeFunction()
+  expectTypeOf(router.routes.parent2).not.toHaveProperty('child3')
   expectTypeOf(router.routes).not.toHaveProperty('parent3')
   expectTypeOf(router.routes.child4).toBeFunction()
 })

--- a/src/types/routeMethods.ts
+++ b/src/types/routeMethods.ts
@@ -21,7 +21,7 @@ export type RouteMethodResponse = Thenable<{
 export type RouteMethods<
   TRoutes extends Routes,
   TParams extends Record<string, unknown> = Record<never, never>
-> = UnionToIntersection<RouteMethodsTuple<TRoutes, TParams>[number]>
+> = Identity<UnionToIntersection<RouteMethodsTuple<TRoutes, TParams>[number]>>
 
 type RouteMethodsTuple<
   TRoutes extends Routes,

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -1,10 +1,10 @@
-// Utility type that converts types like `{ foo: string } & { bar: string }`
+// Utility type that converts types like `{ foo: string } & { bar: string, baz: never }`
 // into `{ foo: string, bar: string }`
 //
 // this is a magic type and don't wanna mess with the {}
 // eslint-disable-next-line @typescript-eslint/ban-types
 export type Identity<T> = T extends object ? {} & {
-  [P in keyof T]: T[P]
+  [P in keyof T as T[P] extends never ? never : P]: T[P]
 } : T
 
 export type IsAny<T> = 0 extends (1 & T) ? true : false


### PR DESCRIPTION
# Description
Previously if a leaf was not public it would still show up in the `RouteMethods` type but with the type of `never`. This tweaks the `Identity` utility type to remove properties if their type is `never` and wraps the `RouteMethods` type definition in `Identity` to remove these properties. 