### PR TITLE
Update navigation and implement onLocationUpdate logic

### DIFF
--- a/src/utilities/routerNavigation.browser.spec.ts
+++ b/src/utilities/routerNavigation.browser.spec.ts
@@ -5,10 +5,11 @@ import * as utilities from '@/utilities/updateBrowserUrl'
 
 describe('createRouterNavigation', () => {
   test('when go is called, forwards call to window history', () => {
+    const onLocationUpdate = vi.fn()
     vi.spyOn(window.history, 'go')
 
     const delta = random.number({ min: 0, max: 100 })
-    const history = createRouterNavigation()
+    const history = createRouterNavigation({ onLocationUpdate })
 
     history.go(delta)
 
@@ -16,9 +17,10 @@ describe('createRouterNavigation', () => {
   })
 
   test('when back is called, forwards call to window history', () => {
+    const onLocationUpdate = vi.fn()
     vi.spyOn(window.history, 'back')
 
-    const history = createRouterNavigation()
+    const history = createRouterNavigation({ onLocationUpdate })
 
     history.back()
 
@@ -26,9 +28,10 @@ describe('createRouterNavigation', () => {
   })
 
   test('when forward is called, forwards call to window history', () => {
+    const onLocationUpdate = vi.fn()
     vi.spyOn(window.history, 'forward')
 
-    const history = createRouterNavigation()
+    const history = createRouterNavigation({ onLocationUpdate })
 
     history.forward()
 
@@ -36,13 +39,38 @@ describe('createRouterNavigation', () => {
   })
 
   test('when update is called, calls updateBrowserUrl', () => {
+    const onLocationUpdate = vi.fn()
     vi.spyOn(utilities, 'updateBrowserUrl')
 
     const url = random.number().toString()
-    const history = createRouterNavigation()
+    const history = createRouterNavigation({ onLocationUpdate })
 
     history.update(url)
 
     expect(utilities.updateBrowserUrl).toHaveBeenCalledWith(url)
+  })
+
+  test('when update is called and same origin calls onLocationUpdate', () => {
+    const onLocationUpdate = vi.fn()
+    vi.spyOn(utilities, 'isSameOrigin').mockReturnValue(true)
+
+    const url = random.number().toString()
+    const history = createRouterNavigation({ onLocationUpdate })
+
+    history.update(url)
+
+    expect(onLocationUpdate).toHaveBeenCalledWith(url)
+  })
+
+  test('when update is called and not same origin does not call onLocationUpdate ', () => {
+    const onLocationUpdate = vi.fn()
+    vi.spyOn(utilities, 'isSameOrigin').mockReturnValue(true)
+
+    const url = random.number().toString()
+    const history = createRouterNavigation({ onLocationUpdate })
+
+    history.update(url)
+
+    expect(onLocationUpdate).not.toHaveBeenCalled()
   })
 })

--- a/src/utilities/routerNavigation.browser.spec.ts
+++ b/src/utilities/routerNavigation.browser.spec.ts
@@ -47,17 +47,17 @@ describe('createRouterNavigation', () => {
 
     history.update(url)
 
-    expect(utilities.updateBrowserUrl).toHaveBeenCalledWith(url)
+    expect(utilities.updateBrowserUrl).toHaveBeenCalledWith(url, undefined)
   })
 
-  test('when update is called and same origin calls onLocationUpdate', () => {
+  test('when update is called and same origin calls onLocationUpdate', async () => {
     const onLocationUpdate = vi.fn()
     vi.spyOn(utilities, 'isSameOrigin').mockReturnValue(true)
 
-    const url = random.number().toString()
+    const url = '/foo'
     const history = createRouterNavigation({ onLocationUpdate })
 
-    history.update(url)
+    await history.update(url)
 
     expect(onLocationUpdate).toHaveBeenCalledWith(url)
   })

--- a/src/utilities/routerNavigation.browser.spec.ts
+++ b/src/utilities/routerNavigation.browser.spec.ts
@@ -54,7 +54,7 @@ describe('createRouterNavigation', () => {
     const onLocationUpdate = vi.fn()
     vi.spyOn(utilities, 'isSameOrigin').mockReturnValue(true)
 
-    const url = '/foo'
+    const url = random.number().toString()
     const history = createRouterNavigation({ onLocationUpdate })
 
     await history.update(url)

--- a/src/utilities/routerNavigation.browser.spec.ts
+++ b/src/utilities/routerNavigation.browser.spec.ts
@@ -5,9 +5,9 @@ import * as utilities from '@/utilities/updateBrowserUrl'
 
 describe('createRouterNavigation', () => {
   test('when go is called, forwards call to window history', () => {
-    const onLocationUpdate = vi.fn()
     vi.spyOn(window.history, 'go')
 
+    const onLocationUpdate = vi.fn()
     const delta = random.number({ min: 0, max: 100 })
     const history = createRouterNavigation({ onLocationUpdate })
 
@@ -17,9 +17,9 @@ describe('createRouterNavigation', () => {
   })
 
   test('when back is called, forwards call to window history', () => {
-    const onLocationUpdate = vi.fn()
     vi.spyOn(window.history, 'back')
 
+    const onLocationUpdate = vi.fn()
     const history = createRouterNavigation({ onLocationUpdate })
 
     history.back()
@@ -28,9 +28,9 @@ describe('createRouterNavigation', () => {
   })
 
   test('when forward is called, forwards call to window history', () => {
-    const onLocationUpdate = vi.fn()
     vi.spyOn(window.history, 'forward')
 
+    const onLocationUpdate = vi.fn()
     const history = createRouterNavigation({ onLocationUpdate })
 
     history.forward()
@@ -39,9 +39,9 @@ describe('createRouterNavigation', () => {
   })
 
   test('when update is called, calls updateBrowserUrl', () => {
-    const onLocationUpdate = vi.fn()
     vi.spyOn(utilities, 'updateBrowserUrl')
 
+    const onLocationUpdate = vi.fn()
     const url = random.number().toString()
     const history = createRouterNavigation({ onLocationUpdate })
 
@@ -51,9 +51,9 @@ describe('createRouterNavigation', () => {
   })
 
   test('when update is called and same origin calls onLocationUpdate', async () => {
-    const onLocationUpdate = vi.fn()
     vi.spyOn(utilities, 'isSameOrigin').mockReturnValue(true)
 
+    const onLocationUpdate = vi.fn()
     const url = random.number().toString()
     const history = createRouterNavigation({ onLocationUpdate })
 

--- a/src/utilities/routerNavigation.spec.ts
+++ b/src/utilities/routerNavigation.spec.ts
@@ -1,8 +1,24 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { createRouterNavigation } from '@/utilities/routerNavigation'
+import { random } from '@/utilities/testHelpers'
 
 describe('createRouterNavigation', () => {
-  test('is not implemented, and throws exception', () => {
-    expect(() => createRouterNavigation()).toThrowError('not implemented')
+  test('Browser like navigation is not supported', () => {
+    const onLocationUpdate = vi.fn()
+    const navigation = createRouterNavigation({ onLocationUpdate })
+
+    expect(() => navigation.back()).toThrowError()
+    expect(() => navigation.forward()).toThrowError()
+    expect(() => navigation.go(1)).toThrowError()
+  })
+
+  test('when update is called and same origin calls onLocationUpdate', () => {
+    const onLocationUpdate = vi.fn()
+    const url = random.number().toString()
+    const history = createRouterNavigation({ onLocationUpdate })
+
+    history.update(url)
+
+    expect(onLocationUpdate).toHaveBeenCalledWith(url)
   })
 })

--- a/src/utilities/routerNavigation.ts
+++ b/src/utilities/routerNavigation.ts
@@ -1,30 +1,79 @@
 import { isBrowser } from '@/utilities/isBrowser'
 import { updateBrowserUrl } from '@/utilities/updateBrowserUrl'
 
+type RouterNavigationOptions = {
+  onLocationUpdate: (url: string) => Promise<void>,
+}
+
 type RouterNavigationUpdateOptions = {
   replace?: boolean,
 }
 
+type NavigationForward = () => void
+type NavigationBack = () => void
+type NavigationGo = (delta: number) => void
+type NavigationUpdate = (url: string, options?: RouterNavigationUpdateOptions) => Promise<void>
+type NavigationCleanup = () => void
+
 type RouterNavigation = {
-  forward: () => void,
-  back: () => void,
-  go: (delta: number) => void,
-  update: (url: string, options?: RouterNavigationUpdateOptions) => void,
+  forward: NavigationForward,
+  back: NavigationBack,
+  go: NavigationGo,
+  update: NavigationUpdate,
+  cleanup?: () => void,
 }
 
-export function createRouterNavigation(): RouterNavigation {
-  return isBrowser() ? createWebNavigation() : createMemoryNavigation()
+export function createRouterNavigation(options: RouterNavigationOptions): RouterNavigation {
+  if (isBrowser()) {
+    return createBrowserNavigation(options)
+  }
+
+  return createNodeNavigation(options)
 }
 
-function createWebNavigation(): RouterNavigation {
+function createBrowserNavigation({ onLocationUpdate }: RouterNavigationOptions): RouterNavigation {
+
+  const update: NavigationUpdate = async (url, options) => {
+    await updateBrowserUrl(url, options)
+
+    return await onLocationUpdate(url)
+  }
+
+  const cleanup: NavigationCleanup = () => {
+    removeEventListener('popstate', onPopstate)
+  }
+
+  const onPopstate = (): void => {
+    onLocationUpdate(window.location.toString())
+  }
+
+  addEventListener('popstate', onPopstate)
+
   return {
-    go: window.history.go,
-    back: window.history.back,
-    forward: window.history.forward,
-    update: updateBrowserUrl,
+    forward: history.forward,
+    back: history.back,
+    go: history.go,
+    update,
+    cleanup,
   }
 }
 
-function createMemoryNavigation(): RouterNavigation {
-  throw 'not implemented'
+function createNodeNavigation({ onLocationUpdate }: RouterNavigationOptions): RouterNavigation {
+  const notSupported = (): void => {
+    throw new Error('Browser like navigation is not supported outside of a browser context')
+  }
+
+  const update: NavigationUpdate = async (url) => {
+    return await onLocationUpdate(url)
+  }
+
+  const cleanup: NavigationCleanup = () => {}
+
+  return {
+    forward: notSupported,
+    back: notSupported,
+    go: notSupported,
+    cleanup,
+    update,
+  }
 }

--- a/src/utilities/updateBrowserUrl.spec.ts
+++ b/src/utilities/updateBrowserUrl.spec.ts
@@ -1,6 +1,0 @@
-import { expect, test } from 'vitest'
-import { updateBrowserUrl } from '@/utilities/updateBrowserUrl'
-
-test('does nothing when the window is not available', () => {
-  expect(() => updateBrowserUrl('http://example.com2/foo')).not.toThrowError()
-})

--- a/src/utilities/updateBrowserUrl.ts
+++ b/src/utilities/updateBrowserUrl.ts
@@ -1,19 +1,19 @@
-import { isBrowser } from '@/utilities/isBrowser'
-
 type UpdateBrowserUrlOptions = {
   replace?: boolean,
 }
 
-export function updateBrowserUrl(url: string, options: UpdateBrowserUrlOptions = {}): void {
-  if (!isBrowser()) {
-    return
-  }
-
+export function updateBrowserUrl(url: string, options: UpdateBrowserUrlOptions = {}): Promise<void> {
   if (isSameOrigin(url)) {
-    return updateHistory(url, options)
+    return new Promise(resolve => {
+      updateHistory(url, options)
+      resolve()
+    })
   }
 
-  return updateWindow(url, options)
+  // intentionally never resolves because we want the router to just stall until window.location takes over
+  return new Promise(() => {
+    updateWindow(url, options)
+  })
 }
 
 function updateHistory(url: string, options: UpdateBrowserUrlOptions): void {
@@ -32,7 +32,7 @@ function updateWindow(url: string, options: UpdateBrowserUrlOptions): void {
   return window.location.assign(url)
 }
 
-function isSameOrigin(url: string): boolean {
+export function isSameOrigin(url: string): boolean {
   const { origin } = new URL(url, window.location.origin)
 
   return origin === window.location.origin


### PR DESCRIPTION
# Description
Makes `updateBrowserUrl` a promise. Never resolves when the update is not same origin. 

Updates `createRouterNavigation` to better support both node and browser environments

Updates `createRouter` to implement navigation and simplify implementation of router navigation methods. 