### PR TITLE
Implement RouterView

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,14 +10,14 @@
       "devDependencies": {
         "@prefecthq/eslint-config": "^1.0.31",
         "@vitejs/plugin-vue": "^5.0.2",
+        "@vue/test-utils": "^2.4.3",
         "eslint": "^8.54.0",
         "happy-dom": "^12.10.3",
         "typescript": "^5.0.2",
         "vite": "^5.0.11",
         "vite-plugin-dts": "^3.6.3",
         "vitest": "^0.34.6",
-        "vue": "^3.4.5",
-        "vue-tsc": "^1.8.27"
+        "vue": "^3.4.5"
       },
       "peerDependencies": {
         "vue": "^3.4.5"
@@ -545,6 +545,50 @@
       "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
       "dev": true
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -661,6 +705,22 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@one-ini/wasm": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
+      "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw==",
+      "dev": true
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@prefecthq/eslint-config": {
@@ -1678,6 +1738,34 @@
       "integrity": "sha512-6XptuzlMvN4l4cDnDw36pdGEV+9njYkQ1ZE0Q6iZLwrKefKaOJyiFmcP3/KBDHbt72cJZGtllAc1GaHe6XGAyg==",
       "dev": true
     },
+    "node_modules/@vue/test-utils": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/@vue/test-utils/-/test-utils-2.4.3.tgz",
+      "integrity": "sha512-F4K7mF+ad++VlTrxMJVRnenKSJmO6fkQt2wpRDiKDesQMkfpniGWsqEi/JevxGBo2qEkwwjvTUAoiGJLNx++CA==",
+      "dev": true,
+      "dependencies": {
+        "js-beautify": "^1.14.9",
+        "vue-component-type-helpers": "^1.8.21"
+      },
+      "peerDependencies": {
+        "@vue/server-renderer": "^3.0.1",
+        "vue": "^3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "@vue/server-renderer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
@@ -2052,6 +2140,16 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/config-chain": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+      "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+      "dev": true,
+      "dependencies": {
+        "ini": "^1.3.4",
+        "proto-list": "~1.2.1"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2194,6 +2292,60 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/editorconfig": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/editorconfig/-/editorconfig-1.0.4.tgz",
+      "integrity": "sha512-L9Qe08KWTlqYMVvMcTIvMAdl1cDUubzRNYL+WfA4bLDMHe4nemKkpmYzkznE1FwLKu0EEmy6obgQKzMJrg4x9Q==",
+      "dev": true,
+      "dependencies": {
+        "@one-ini/wasm": "0.1.1",
+        "commander": "^10.0.0",
+        "minimatch": "9.0.1",
+        "semver": "^7.5.3"
+      },
+      "bin": {
+        "editorconfig": "bin/editorconfig"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/editorconfig/node_modules/minimatch": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.1.tgz",
+      "integrity": "sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
     },
     "node_modules/enhanced-resolve": {
       "version": "5.15.0",
@@ -2847,6 +2999,22 @@
         "is-callable": "^1.1.3"
       }
     },
+    "node_modules/foreground-child": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.1.1.tgz",
+      "integrity": "sha512-TMKDUnIte6bfb5nWv7V/caI169OHgvwjb7V4WkeUvbQQdjr5rWKqHFiKWb/fcOwB+CzBT+qbWjvj+DVwRskpIg==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.0",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/fs-extra": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
@@ -3272,6 +3440,12 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true
+    },
     "node_modules/internal-slot": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.0.6.tgz",
@@ -3374,6 +3548,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -3530,11 +3713,71 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/jackspeak": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-2.3.6.tgz",
+      "integrity": "sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/jju": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/jju/-/jju-1.4.0.tgz",
       "integrity": "sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==",
       "dev": true
+    },
+    "node_modules/js-beautify": {
+      "version": "1.14.11",
+      "resolved": "https://registry.npmjs.org/js-beautify/-/js-beautify-1.14.11.tgz",
+      "integrity": "sha512-rPogWqAfoYh1Ryqqh2agUpVfbxAhbjuN1SmU86dskQUKouRiggUTCO4+2ym9UPXllc2WAp0J+T5qxn7Um3lCdw==",
+      "dev": true,
+      "dependencies": {
+        "config-chain": "^1.1.13",
+        "editorconfig": "^1.0.3",
+        "glob": "^10.3.3",
+        "nopt": "^7.2.0"
+      },
+      "bin": {
+        "css-beautify": "js/bin/css-beautify.js",
+        "html-beautify": "js/bin/html-beautify.js",
+        "js-beautify": "js/bin/js-beautify.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/js-beautify/node_modules/glob": {
+      "version": "10.3.10",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.3.10.tgz",
+      "integrity": "sha512-fa46+tv1Ak0UPK1TOy/pZrIybNNt4HCv7SDzwyfiOZkvZLEbjsZkJBPtDHVshZjbecAoAGSC20MjLDG/qr679g==",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^2.3.5",
+        "minimatch": "^9.0.1",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0",
+        "path-scurry": "^1.10.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -3751,6 +3994,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/minipass": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.0.4.tgz",
+      "integrity": "sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/mlly": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.4.2.tgz",
@@ -3804,6 +4056,21 @@
       "resolved": "https://registry.npmjs.org/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz",
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
+    },
+    "node_modules/nopt": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.0.tgz",
+      "integrity": "sha512-CVDtwCdhYIvnAzFoJ6NJ6dX3oga9/HyciQDnG1vQDjSLMeKLJ4A93ZqYKDrgYSr1FBY5/hMYC+2VCi24pgpkGA==",
+      "dev": true,
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -4006,6 +4273,31 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/path-scurry": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.10.1.tgz",
+      "integrity": "sha512-MkhCqzzBEpPvxxQ71Md0b1Kk51W01lrYvlMzSUaIzNsODdd7mqhiimSZlr+VegAz5Z6Vzt9Xg2ttE//XBhH3EQ==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^9.1.1 || ^10.0.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.1.0.tgz",
+      "integrity": "sha512-/1clY/ui8CzjKFyjdvwPWJUYKiFVXG2I2cY0ssG7h4+hwk+XOIX7ZSG9Q7TW8TW3Kp3BUSqgFWBLgL4PJ+Blag==",
+      "dev": true,
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
@@ -4134,6 +4426,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/proto-list": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+      "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+      "dev": true
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -4425,6 +4723,18 @@
       "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
       "dev": true
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -4479,6 +4789,71 @@
         "node": ">=0.6.19"
       }
     },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/string-width/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/string.prototype.trim": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.8.tgz",
@@ -4525,6 +4900,19 @@
       }
     },
     "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
@@ -5062,6 +5450,12 @@
         }
       }
     },
+    "node_modules/vue-component-type-helpers": {
+      "version": "1.8.27",
+      "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-1.8.27.tgz",
+      "integrity": "sha512-0vOfAtI67UjeO1G6UiX5Kd76CqaQ67wrRZiOe7UAb9Jm6GzlUr/fC7CV90XfwapJRjpCMaZFhv1V0ajWRmE9Dg==",
+      "dev": true
+    },
     "node_modules/vue-eslint-parser": {
       "version": "9.3.2",
       "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-9.3.2.tgz",
@@ -5207,6 +5601,100 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-regex": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.0.1.tgz",
+      "integrity": "sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
+      "integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/strip-ansi": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
+      "integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
     "node_modules/wrappy": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   },
   "homepage": "https://github.com/kitbagjs/router#readme",
   "scripts": {
-    "build": "vue-tsc && vite build",
+    "build": "vite build",
     "test": "vitest",
     "test:types": "vitest typecheck",
     "lint": "eslint ./src",
@@ -29,14 +29,14 @@
   "devDependencies": {
     "@prefecthq/eslint-config": "^1.0.31",
     "@vitejs/plugin-vue": "^5.0.2",
+    "@vue/test-utils": "^2.4.3",
     "eslint": "^8.54.0",
     "happy-dom": "^12.10.3",
     "typescript": "^5.0.2",
     "vite": "^5.0.11",
     "vite-plugin-dts": "^3.6.3",
     "vitest": "^0.34.6",
-    "vue": "^3.4.5",
-    "vue-tsc": "^1.8.27"
+    "vue": "^3.4.5"
   },
   "peerDependencies": {
     "vue": "^3.4.5"

--- a/src/components/RouterView.vue
+++ b/src/components/RouterView.vue
@@ -1,5 +1,0 @@
-<template>
-  <div class="router-view">
-    router-view
-  </div>
-</template>

--- a/src/components/helloWorld.ts
+++ b/src/components/helloWorld.ts
@@ -1,0 +1,7 @@
+import { defineComponent } from 'vue'
+
+export default defineComponent({
+  name: 'HelloWorld',
+  template: 'hello world',
+  expose: [],
+})

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,4 +1,4 @@
-import RouterView from '@/components/RouterView.vue'
+import RouterView from '@/components/routerView'
 
 export { RouterView }
 

--- a/src/components/routerView.browser.spec.ts
+++ b/src/components/routerView.browser.spec.ts
@@ -1,0 +1,107 @@
+import { mount } from '@vue/test-utils'
+import { expect, test } from 'vitest'
+import { Route } from '@/types'
+import { createRouter } from '@/utilities'
+
+test('renders component for initial route', () => {
+  const route = {
+    name: 'parent',
+    path: '/',
+    component: { template: 'hello world' },
+  } as const satisfies Route
+
+  const router = createRouter([route], {
+    initialUrl: route.path,
+  })
+
+  const root = {
+    template: '<RouterView/>',
+  }
+
+  const app = mount(root, {
+    global: {
+      plugins: [router],
+    },
+  })
+
+  expect(app.html()).toBe(route.component.template)
+})
+
+test('renders components for initial route', () => {
+  const childRoute = {
+    name: 'child',
+    path: 'child',
+    component: { template: 'Child' },
+  } as const satisfies Route
+
+  const parentRoute = {
+    name: 'parent',
+    path: '',
+    component: { template: '<RouterView />' },
+    children: [childRoute],
+  } as const satisfies Route
+
+  const router = createRouter([parentRoute], {
+    initialUrl: childRoute.path,
+  })
+
+  const root = {
+    template: '<RouterView />',
+  }
+
+  const app = mount(root, {
+    global: {
+      plugins: [router],
+    },
+  })
+
+  expect(app.html()).toBe(childRoute.component.template)
+})
+
+test('updates components when route changes', async () => {
+  const childA = {
+    name: 'childA',
+    path: 'childA',
+    component: { template: 'ChildA' },
+  } as const satisfies Route
+
+  const childB = {
+    name: 'childB',
+    path: 'childB',
+    component: { template: 'ChildB' },
+  } as const satisfies Route
+
+  const childC = {
+    name: 'childC',
+    path: 'childC',
+    component: { template: 'ChildC' },
+  } as const satisfies Route
+
+  const router = createRouter([childA, childB, childC], {
+    initialUrl: childA.path,
+  })
+
+  const root = {
+    template: '<RouterView />',
+  }
+
+  const app = mount(root, {
+    global: {
+      plugins: [router],
+    },
+  })
+
+  expect(app.html()).toBe(childA.component.template)
+
+  await router.push(childB.path)
+
+  expect(app.html()).toBe(childB.component.template)
+
+  await router.push(childC.path)
+
+  expect(app.html()).toBe(childC.component.template)
+
+  await router.push(childA.path)
+
+  expect(app.html()).toBe(childA.component.template)
+})

--- a/src/components/routerView.browser.spec.ts
+++ b/src/components/routerView.browser.spec.ts
@@ -1,5 +1,7 @@
-import { mount } from '@vue/test-utils'
-import { expect, test } from 'vitest'
+import { mount, flushPromises } from '@vue/test-utils'
+import { expect, it, test } from 'vitest'
+import { defineAsyncComponent } from 'vue'
+import helloWorld from '@/components/helloWorld'
 import { Route } from '@/types'
 import { createRouter } from '@/utilities'
 
@@ -103,4 +105,33 @@ test('updates components when route changes', async () => {
   await router.push(childA.path)
 
   expect(app.html()).toBe(childA.component.template)
+})
+
+it.each([
+  defineAsyncComponent(() => import('./helloWorld')),
+  () => import('./helloWorld'),
+])('resolves async components', async (component) => {
+  const route = {
+    name: 'parent',
+    path: '/',
+    component,
+  } as const satisfies Route
+
+  const router = createRouter([route], {
+    initialUrl: route.path,
+  })
+
+  const root = {
+    template: '<suspense><RouterView/></suspense>',
+  }
+
+  const app = mount(root, {
+    global: {
+      plugins: [router],
+    },
+  })
+
+  await flushPromises()
+
+  expect(app.html()).toBe(helloWorld.template)
 })

--- a/src/components/routerView.browser.spec.ts
+++ b/src/components/routerView.browser.spec.ts
@@ -37,7 +37,6 @@ test('renders components for initial route', () => {
   const parentRoute = {
     name: 'parent',
     path: '',
-    component: { template: '<RouterView />' },
     children: [childRoute],
   } as const satisfies Route
 

--- a/src/components/routerView.ts
+++ b/src/components/routerView.ts
@@ -1,5 +1,4 @@
 import { AsyncComponentLoader, InjectionKey, computed, defineAsyncComponent, defineComponent, h, inject, provide, resolveComponent } from 'vue'
-import { RouteComponent } from '@/types'
 import { routerInjectionKey } from '@/utilities'
 
 const depthInjectionKey: InjectionKey<number> = Symbol()
@@ -26,7 +25,7 @@ export default defineComponent({
           return defineAsyncComponent(routeComponent as AsyncComponentLoader)
         }
 
-        return routeComponent as RouteComponent
+        return routeComponent
       }
 
       return routerView

--- a/src/components/routerView.ts
+++ b/src/components/routerView.ts
@@ -1,0 +1,30 @@
+import { InjectionKey, computed, defineComponent, h, inject, provide, resolveComponent } from 'vue'
+import { routerInjectionKey } from '@/utilities'
+
+const depthInjectionKey: InjectionKey<number> = Symbol()
+
+export default defineComponent({
+  name: 'RouterView',
+  expose: [],
+  setup() {
+    const router = inject(routerInjectionKey)
+    const depth = inject(depthInjectionKey, 0)
+
+    if (!router) {
+      throw new Error('Router not installed')
+    }
+
+    provide(depthInjectionKey, depth + 1)
+
+    const routerView = resolveComponent('RouterView')
+
+    const component = computed(() => {
+      const route = router.route.matches[depth]
+
+      return route.component ?? routerView
+    })
+
+    // @ts-expect-error
+    return () => h(component.value)
+  },
+})

--- a/src/types/routes.ts
+++ b/src/types/routes.ts
@@ -1,9 +1,9 @@
-import { Component, DefineComponent } from 'vue'
+import { AsyncComponentLoader, Component, DefineComponent } from 'vue'
 import { RouteMiddleware } from '@/types/middleware'
-import { MaybeArray, MaybeLazy } from '@/types/utilities'
+import { MaybeArray } from '@/types/utilities'
 import { Path } from '@/utilities/path'
 
-export type RouteComponent = MaybeLazy<Component | DefineComponent>
+export type RouteComponent = Component | DefineComponent | AsyncComponentLoader
 
 export interface RouteMeta {
 

--- a/src/types/routes.ts
+++ b/src/types/routes.ts
@@ -3,7 +3,7 @@ import { RouteMiddleware } from '@/types/middleware'
 import { MaybeArray, MaybeLazy } from '@/types/utilities'
 import { Path } from '@/utilities/path'
 
-type RouteComponent = MaybeLazy<Component | DefineComponent>
+export type RouteComponent = MaybeLazy<Component | DefineComponent | string>
 
 export interface RouteMeta {
 

--- a/src/types/routes.ts
+++ b/src/types/routes.ts
@@ -3,7 +3,7 @@ import { RouteMiddleware } from '@/types/middleware'
 import { MaybeArray, MaybeLazy } from '@/types/utilities'
 import { Path } from '@/utilities/path'
 
-export type RouteComponent = MaybeLazy<Component | DefineComponent | string>
+export type RouteComponent = MaybeLazy<Component | DefineComponent>
 
 export interface RouteMeta {
 

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -36,8 +36,6 @@ export type UnionToIntersection<Union> = (
   ? Intersection & Union
   : never
 
-export type MaybeLazy<T> = T | (() => Promise<T>)
-
 export type MaybeArray<T> = T | T[]
 
 export type MaybePromise<T> = T | Promise<T>

--- a/src/utilities/createRouter.ts
+++ b/src/utilities/createRouter.ts
@@ -53,7 +53,7 @@ export function createRouter<T extends Routes>(routes: T, options: RouterOptions
       throw 'not implemented'
     }
 
-    return route
+    return { ...route }
   }
 
   async function onLocationUpdate(url: string): Promise<void> {

--- a/src/utilities/createRouter.ts
+++ b/src/utilities/createRouter.ts
@@ -1,4 +1,4 @@
-import { DeepReadonly, reactive, readonly, App } from 'vue'
+import { DeepReadonly, reactive, readonly, App, InjectionKey } from 'vue'
 import { RouterView } from '@/components'
 import { Resolved, Route, RouteMethods, Routes } from '@/types'
 import { createRouteMethods, createRouterNavigation, resolveRoutes, routeMatch, getInitialUrl, resolveRoutesRegex } from '@/utilities'
@@ -11,7 +11,7 @@ type RouterPush = (url: string, options?: { replace: boolean }) => Promise<void>
 type RouterReplace = (url: string) => Promise<void>
 
 export type Router<
-  TRoutes extends Routes
+  TRoutes extends Routes = []
 > = {
   routes: RouteMethods<TRoutes>,
   route: DeepReadonly<Resolved<Route>>,
@@ -22,6 +22,8 @@ export type Router<
   go: (delta: number) => void,
   install: (app: App) => void,
 }
+
+export const routerInjectionKey: InjectionKey<Router> = Symbol()
 
 export function createRouter<T extends Routes>(routes: T, options: RouterOptions = {}): Router<T> {
   const resolved = resolveRoutes(routes)
@@ -34,6 +36,7 @@ export function createRouter<T extends Routes>(routes: T, options: RouterOptions
 
   function install(app: App): void {
     app.component('RouterView', RouterView)
+    app.provide(routerInjectionKey, router)
   }
 
   function getInitialRoute(): Resolved<Route> {

--- a/src/utilities/resolveRoutes.ts
+++ b/src/utilities/resolveRoutes.ts
@@ -1,3 +1,4 @@
+import { markRaw } from 'vue'
 import { Resolved, Routes, isParentRoute, isNamedRoute, Route, Param } from '@/types'
 import { mergeParams, path as createPath } from '@/utilities'
 
@@ -28,8 +29,8 @@ export function resolveRoutes(routes: Routes, parentContext: ParentContext = {})
 
     if (isNamedRoute(route)) {
       value.push({
-        matched: route,
-        matches: fullMatches,
+        matched: markRaw(route),
+        matches: markRaw(fullMatches),
         name: route.name,
         path: fullPath,
         params: fullParams,

--- a/src/utilities/routeMatch.ts
+++ b/src/utilities/routeMatch.ts
@@ -4,7 +4,9 @@ import { routeParamsAreValid } from '@/utilities/paramValidation'
 import { ResolvedWithRegex } from '@/utilities/resolveRoutesRegex'
 
 export function routeMatch(routes: ResolvedWithRegex[], path: string): Resolved<Route> | undefined {
-  const { route } = routes.find(({ regexp, route }) => regexp.test(path) && routeParamsAreValid(path, route)) ?? {}
+  const { route } = routes.find(({ regexp, route }) => {
+    return regexp.test(path) && routeParamsAreValid(path, route)
+  }) ?? {}
 
   return route
 }


### PR DESCRIPTION
# Description
Adds a basic implementation for the `RouterView` component. Changed the existing boilerplate component from a sfc to a basic typescript component with a render function. 

- Removed `vue-tsc` as a dependency (everything seems to work fine without it)
- Added `@vue/test-utils`

Notes:
I don't like how in `RouterView` the types for the route component need some coercion. Seems like its getting an expanded type for some reason and typescript cannot sort it out. 