### PR TITLE
Implement route methods and organize router and route method types

### DIFF
--- a/src/compositions/useRoute.ts
+++ b/src/compositions/useRoute.ts
@@ -1,4 +1,5 @@
-import { ExtractRouteMethodParams, RouteMethod } from '@/types/routeMethods'
+import { RouteMethod } from '@/types/routeMethod'
+import { ExtractRouteMethodParams } from '@/types/routeMethods'
 import { Identity } from '@/types/utilities'
 
 type Route<T extends RouteMethod> = {

--- a/src/compositions/useRouteParam.ts
+++ b/src/compositions/useRouteParam.ts
@@ -1,5 +1,6 @@
 import { Ref } from 'vue'
-import { ExtractRouteMethodParams, RouteMethod } from '@/types/routeMethods'
+import { RouteMethod } from '@/types/routeMethod'
+import { ExtractRouteMethodParams } from '@/types/routeMethods'
 
 export function useRouteParam<
   TRoute extends RouteMethod,

--- a/src/compositions/useRouteParamRaw.ts
+++ b/src/compositions/useRouteParamRaw.ts
@@ -1,5 +1,6 @@
 import { Ref } from 'vue'
-import { ExtractRouteMethodParams, RouteMethod } from '@/types/routeMethods'
+import { RouteMethod } from '@/types/routeMethod'
+import { ExtractRouteMethodParams } from '@/types/routeMethods'
 
 type ParamRawValue<T> = Extract<T, undefined> extends never ? string : string | undefined
 

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -1,6 +1,6 @@
 import { EffectScope } from 'vue'
+import { Router } from '@/types/router'
 import { MaybePromise } from '@/types/utilities'
-import { Router } from '@/utilities'
 
 type Route = {
   name: string,
@@ -24,7 +24,7 @@ type MiddlewareExtras = {
   state: RouteState,
   reject: RouteReject,
   scope: EffectScope,
-  router: Omit<Router<[]>, 'routes'> & { routes: Record<string, any> },
+  router: Omit<Router, 'routes'> & { routes: Record<string, any> },
 }
 
 export type RouteMiddleware = (route: Route, extras: MiddlewareExtras) => MaybePromise<void>

--- a/src/types/routeMethod.ts
+++ b/src/types/routeMethod.ts
@@ -1,0 +1,18 @@
+import { IsEmptyObject } from '@/types/utilities'
+
+export type RouteMethod<
+  TParams extends Record<string, unknown> = any
+> = IsEmptyObject<TParams> extends false
+  ? (params: TParams, options?: RouteMethodOptions) => RouteMethodResponse
+  : (options?: RouteMethodOptions) => RouteMethodResponse
+
+export type RouteMethodOptions = {
+  replace: boolean,
+  skipRouting: boolean,
+}
+
+export type RouteMethodResponse = {
+  url: string,
+  // push: RouteMethodPush,
+  // replace: RouteMethodReplace,
+}

--- a/src/types/routeMethod.ts
+++ b/src/types/routeMethod.ts
@@ -1,18 +1,30 @@
+import { RouterPushOptions, RouterReplaceOptions } from '@/types/router'
 import { IsEmptyObject } from '@/types/utilities'
 
 export type RouteMethod<
-  TParams extends Record<string, unknown> = any
+  TParams extends Record<string, unknown> = Record<string, unknown>
 > = IsEmptyObject<TParams> extends false
-  ? (params: TParams, options?: RouteMethodOptions) => RouteMethodResponse
-  : (options?: RouteMethodOptions) => RouteMethodResponse
+  ? (params: TParams) => RouteMethodResponse<TParams>
+  : () => RouteMethodResponse<TParams>
 
-export type RouteMethodOptions = {
-  replace: boolean,
-  skipRouting: boolean,
+export type RouteMethodOptions<
+  TParams extends Record<string, unknown>
+> = {
+  params?: Partial<TParams>,
 }
 
-export type RouteMethodResponse = {
+export type RouteMethodPush<
+  TParams extends Record<string, unknown> = Record<string, unknown>
+> = (options?: RouteMethodOptions<TParams> & RouterPushOptions) => Promise<void>
+
+export type RouteMethodReplace<
+  TParams extends Record<string, unknown> = Record<string, unknown>
+> = (options?: RouteMethodOptions<TParams> & RouterReplaceOptions) => Promise<void>
+
+export type RouteMethodResponse<
+  TParams extends Record<string, unknown> = Record<string, unknown>
+> = {
   url: string,
-  // push: RouteMethodPush,
-  // replace: RouteMethodReplace,
+  push: RouteMethodPush<TParams>,
+  replace: RouteMethodReplace<TParams>,
 }

--- a/src/types/routeMethod.ts
+++ b/src/types/routeMethod.ts
@@ -1,11 +1,14 @@
 import { RouterPushOptions, RouterReplaceOptions } from '@/types/router'
-import { IsEmptyObject } from '@/types/utilities'
+import { IsEmptyObject, OnlyRequiredProperties } from '@/types/utilities'
 
 export type RouteMethod<
   TParams extends Record<string, unknown> = Record<string, unknown>
-> = IsEmptyObject<TParams> extends false
-  ? (params: TParams) => RouteMethodResponse<TParams>
-  : () => RouteMethodResponse<TParams>
+> = IsEmptyObject<TParams> extends true
+  ? () => RouteMethodResponse<TParams>
+  : IsEmptyObject<OnlyRequiredProperties<TParams>> extends true
+    ? (params?: TParams) => RouteMethodResponse<TParams>
+    : (params: TParams) => RouteMethodResponse<TParams>
+
 
 export type RouteMethodOptions<
   TParams extends Record<string, unknown>

--- a/src/types/routeMethods.spec-d.ts
+++ b/src/types/routeMethods.spec-d.ts
@@ -1,6 +1,6 @@
 import { test, expectTypeOf } from 'vitest'
 import { ParamGetSet } from '@/types/params'
-import { RouteMethodOptions } from '@/types/routeMethods'
+import { RouteMethodOptions } from '@/types/routeMethod'
 import { Routes } from '@/types/routes'
 import { createRouter, path } from '@/utilities'
 import { component } from '@/utilities/testHelpers'

--- a/src/types/routeMethods.spec-d.ts
+++ b/src/types/routeMethods.spec-d.ts
@@ -1,6 +1,5 @@
 import { test, expectTypeOf } from 'vitest'
 import { ParamGetSet } from '@/types/params'
-import { RouteMethodOptions } from '@/types/routeMethod'
 import { Routes } from '@/types/routes'
 import { createRouter, path } from '@/utilities'
 import { component } from '@/utilities/testHelpers'
@@ -21,7 +20,7 @@ test('requires no arguments when there are no parameters', () => {
 
   const router = createRouter(routes)
 
-  expectTypeOf(router.routes.foo).parameter(0).toEqualTypeOf<RouteMethodOptions | undefined>()
+  expectTypeOf(router.routes.foo).parameters.toEqualTypeOf<[]>()
 })
 
 test('does not match single colons as params', () => {
@@ -35,7 +34,7 @@ test('does not match single colons as params', () => {
 
   const router = createRouter(routes)
 
-  expectTypeOf(router.routes.foo).parameter(0).toEqualTypeOf<RouteMethodOptions | undefined>()
+  expectTypeOf(router.routes.foo).parameters.toEqualTypeOf<[]>()
 })
 
 test('does not match :? as params', () => {
@@ -51,7 +50,7 @@ test('does not match :? as params', () => {
 
   router.routes.foo()
 
-  expectTypeOf(router.routes.foo).parameter(0).toEqualTypeOf<RouteMethodOptions | undefined>()
+  expectTypeOf(router.routes.foo).parameters.toEqualTypeOf<[]>()
 })
 
 test('matches individual params', () => {
@@ -438,5 +437,4 @@ test('route method returns correct type when called', async () => {
   const router = createRouter(routes)
 
   expectTypeOf(router.routes.foo()).toMatchTypeOf<{ url: string }>()
-  expectTypeOf(await router.routes.foo()).toEqualTypeOf<{ url: string }>()
 })

--- a/src/types/routeMethods.spec-d.ts
+++ b/src/types/routeMethods.spec-d.ts
@@ -82,7 +82,7 @@ test('matches individual optional params', () => {
 
   expectTypeOf(router.routes.foo).parameter(0).toEqualTypeOf<{
     foo?: string,
-  }>()
+  } | undefined>()
 })
 
 test('matches multiple params with the same name', () => {
@@ -114,7 +114,7 @@ test('matches multiple params with the same name as optional', () => {
 
   expectTypeOf(router.routes.foo).parameter(0).toEqualTypeOf<{
     foo?: [string | undefined, string | undefined, string | undefined],
-  }>()
+  } | undefined>()
 })
 
 test('matches typed params using a Param', () => {
@@ -253,7 +253,7 @@ test('matches multiple params with the same name as optional across children', (
 
   expectTypeOf(router.routes.foo.bar).parameter(0).toEqualTypeOf<{
     foo?: [string | undefined, string | undefined],
-  }>()
+  } | undefined>()
 })
 
 test('multiple root routes produces multiple routes', () => {

--- a/src/types/routeMethods.ts
+++ b/src/types/routeMethods.ts
@@ -1,22 +1,8 @@
 import { Param, ParamGetSet, ParamGetter } from '@/types/params'
+import { RouteMethod, RouteMethodResponse } from '@/types/routeMethod'
 import { Public, Route, Routes } from '@/types/routes'
-import { Identity, IsEmptyObject, ReplaceAll, Thenable, TupleCanBeAllUndefined, UnionToIntersection } from '@/types/utilities'
+import { Identity, ReplaceAll, TupleCanBeAllUndefined, UnionToIntersection } from '@/types/utilities'
 import { Path } from '@/utilities/path'
-
-export type RouteMethod<
-  TParams extends Record<string, unknown> = any
-> = IsEmptyObject<TParams> extends false
-  ? (params: TParams, options?: RouteMethodOptions) => RouteMethodResponse
-  : (options?: RouteMethodOptions) => RouteMethodResponse
-
-export type RouteMethodOptions = {
-  replace: boolean,
-  skipRouting: boolean,
-}
-
-export type RouteMethodResponse = Thenable<{
-  url: string,
-}>
 
 export type RouteMethods<
   TRoutes extends Routes,

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -1,0 +1,34 @@
+import { App, DeepReadonly } from 'vue'
+import { Resolved } from '@/types/resolved'
+import { RouteMethods } from '@/types/routeMethods'
+import { Route, Routes } from '@/types/routes'
+
+export type RouterOptions = {
+  initialUrl?: string,
+}
+
+export type RouterPushOptions = RouterReplaceOptions & {
+  replace?: boolean,
+}
+
+export type RouterPush = (url: string, options?: RouterPushOptions) => Promise<void>
+
+export type RouterReplaceOptions = {
+  // not implemented
+  query?: never,
+}
+
+export type RouterReplace = (url: string) => Promise<void>
+
+export type Router<
+  TRoutes extends Routes = []
+> = {
+  routes: RouteMethods<TRoutes>,
+  route: DeepReadonly<Resolved<Route>>,
+  push: RouterPush,
+  replace: RouterReplace,
+  back: () => void,
+  forward: () => void,
+  go: (delta: number) => void,
+  install: (app: App) => void,
+}

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -7,16 +7,15 @@ export type RouterOptions = {
   initialUrl?: string,
 }
 
-export type RouterPushOptions = RouterReplaceOptions & {
+export type RouterPushOptions = {
+  // not implemented
+  query?: never,
   replace?: boolean,
 }
 
 export type RouterPush = (url: string, options?: RouterPushOptions) => Promise<void>
 
-export type RouterReplaceOptions = {
-  // not implemented
-  query?: never,
-}
+export type RouterReplaceOptions = Omit<RouterPushOptions, 'replace'>
 
 export type RouterReplace = (url: string) => Promise<void>
 

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -17,7 +17,7 @@ export type RouterPush = (url: string, options?: RouterPushOptions) => Promise<v
 
 export type RouterReplaceOptions = Omit<RouterPushOptions, 'replace'>
 
-export type RouterReplace = (url: string) => Promise<void>
+export type RouterReplace = (url: string, options?: RouterReplaceOptions) => Promise<void>
 
 export type Router<
   TRoutes extends Routes = []

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -49,9 +49,6 @@ export type ReplaceAll<
   ? `${Head}${Replacement}${ReplaceAll<Tail, Search, Replacement>}`
   : Input
 
-export type Thenable<T> = T & PromiseLike<T>
-export type Then<T extends Thenable<unknown>> = T extends PromiseLike<infer R> ? R : never
-
 export type OnlyRequiredProperties<T extends Record<string, unknown>> = {
   [K in keyof T as Extract<T[K], undefined> extends never ? K : never]: T[K]
 }

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -51,3 +51,7 @@ export type ReplaceAll<
 
 export type Thenable<T> = T & PromiseLike<T>
 export type Then<T extends Thenable<unknown>> = T extends PromiseLike<infer R> ? R : never
+
+export type OnlyRequiredProperties<T extends Record<string, unknown>> = {
+  [K in keyof T as Extract<T[K], undefined> extends never ? K : never]: T[K]
+}

--- a/src/utilities/createRouteMethods.spec.ts
+++ b/src/utilities/createRouteMethods.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from 'vitest'
+import { expect, test, vi } from 'vitest'
 import { Routes } from '@/types'
 import { createRouteMethods, resolveRoutes } from '@/utilities'
 import { component } from '@/utilities/testHelpers'
@@ -17,7 +17,7 @@ test.each([
   ] as const satisfies Routes
   const resolved = resolveRoutes(routes)
 
-  const response = createRouteMethods<typeof routes>(resolved)
+  const response = createRouteMethods<typeof routes>(resolved, vi.fn())
 
   if (isPublic !== false) {
     // @ts-expect-error
@@ -40,7 +40,7 @@ test('given route is NOT public, returns empty object', () => {
   ] as const satisfies Routes
   const resolved = resolveRoutes(routes)
 
-  const response = createRouteMethods<typeof routes>(resolved)
+  const response = createRouteMethods<typeof routes>(resolved, vi.fn())
 
   expect(response).toMatchObject({})
 })
@@ -66,7 +66,7 @@ test.each([
   ] as const satisfies Routes
   const resolved = resolveRoutes(routes)
 
-  const response = createRouteMethods<typeof routes>(resolved)
+  const response = createRouteMethods<typeof routes>(resolved, vi.fn())
 
   if (isPublic !== false) {
     // @ts-expect-error
@@ -99,7 +99,7 @@ test('given parent route with named children and grandchildren, has path to gran
   ] as const satisfies Routes
   const resolved = resolveRoutes(routes)
 
-  const response = createRouteMethods<typeof routes>(resolved)
+  const response = createRouteMethods<typeof routes>(resolved, vi.fn())
 
   expect(response.parent).toBeTypeOf('function')
   expect(response.parent.child).toBeTypeOf('function')

--- a/src/utilities/createRouteMethods.spec.ts
+++ b/src/utilities/createRouteMethods.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, vi } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { Routes } from '@/types'
 import { createRouteMethods, resolveRoutes } from '@/utilities'
 import { component } from '@/utilities/testHelpers'
@@ -104,4 +104,57 @@ test('given parent route with named children and grandchildren, has path to gran
   expect(response.parent).toBeTypeOf('function')
   expect(response.parent.child).toBeTypeOf('function')
   expect(response.parent.child.grandchild).toBeTypeOf('function')
+})
+
+describe('routeMethod', () => {
+  test('push and replace call router.push with correct parameters', () => {
+    const routerPush = vi.fn()
+
+    const routes = [
+      {
+        name: 'route',
+        path: '/route/:?param',
+        component,
+      },
+    ] as const satisfies Routes
+    const resolved = resolveRoutes(routes)
+    const { route } = createRouteMethods<typeof routes>(resolved, routerPush)
+
+    route().push()
+
+    expect(routerPush).toHaveBeenCalledWith('/route/', {})
+
+    routerPush.mockClear()
+
+    route().replace()
+
+    expect(routerPush).toHaveBeenCalledWith('/route/', { replace: true })
+
+    routerPush.mockClear()
+
+    route({ param: 'foo' }).push()
+    expect(routerPush).toHaveBeenCalledWith('/route/foo', {})
+
+    routerPush.mockClear()
+
+    route({ param: 'foo' }).push({ params: { param: 'bar' } })
+    expect(routerPush).toHaveBeenCalledWith('/route/bar', {})
+  })
+
+  test('returns correct url', () => {
+    const routerPush = vi.fn()
+
+    const routes = [
+      {
+        name: 'route',
+        path: '/route/:?param',
+        component,
+      },
+    ] as const satisfies Routes
+    const resolved = resolveRoutes(routes)
+    const { route } = createRouteMethods<typeof routes>(resolved, routerPush)
+
+    expect(route().url).toBe('/route/')
+    expect(route({ param: 'param' }).url).toBe('/route/param')
+  })
 })

--- a/src/utilities/createRouteMethods.spec.ts
+++ b/src/utilities/createRouteMethods.spec.ts
@@ -121,24 +121,16 @@ describe('routeMethod', () => {
     const { route } = createRouteMethods<typeof routes>(resolved, routerPush)
 
     route().push()
-
-    expect(routerPush).toHaveBeenCalledWith('/route/', {})
-
-    routerPush.mockClear()
+    expect(routerPush).toHaveBeenLastCalledWith('/route/', {})
 
     route().replace()
-
-    expect(routerPush).toHaveBeenCalledWith('/route/', { replace: true })
-
-    routerPush.mockClear()
+    expect(routerPush).toHaveBeenLastCalledWith('/route/', { replace: true })
 
     route({ param: 'foo' }).push()
-    expect(routerPush).toHaveBeenCalledWith('/route/foo', {})
-
-    routerPush.mockClear()
+    expect(routerPush).toHaveBeenLastCalledWith('/route/foo', {})
 
     route({ param: 'foo' }).push({ params: { param: 'bar' } })
-    expect(routerPush).toHaveBeenCalledWith('/route/bar', {})
+    expect(routerPush).toHaveBeenLastCalledWith('/route/bar', {})
   })
 
   test('returns correct url', () => {

--- a/src/utilities/createRouteMethods.ts
+++ b/src/utilities/createRouteMethods.ts
@@ -1,4 +1,5 @@
-import { Resolved, Route, RouteMethod, RouteMethodResponse, RouteMethods, Routes, Then, isPublicRoute } from '@/types'
+import { Resolved, Route, RouteMethods, Routes, isPublicRoute } from '@/types'
+import { RouteMethod } from '@/types/routeMethod'
 import { assembleUrl } from '@/utilities/urlAssembly'
 
 export function createRouteMethods<T extends Routes>(routes: Resolved<Route>[]): RouteMethods<T> {
@@ -33,11 +34,9 @@ export function createRouteMethods<T extends Routes>(routes: Resolved<Route>[]):
 function createCallableNode(route: Resolved<Route>): RouteMethod {
   const node: RouteMethod = (values) => {
     const url = assembleUrl(route, values)
-    const { then } = new Promise<Then<RouteMethodResponse>>(resolve => resolve({ url }))
 
     return {
       url,
-      then,
     }
   }
 

--- a/src/utilities/createRouteMethods.ts
+++ b/src/utilities/createRouteMethods.ts
@@ -40,15 +40,18 @@ type CreateRouteMethodArgs = {
 }
 
 function createRouteMethod({ route, routerPush }: CreateRouteMethodArgs): RouteMethod {
-  const node: RouteMethod = (params) => {
+  const node: RouteMethod = (params = {}) => {
     const normalizedParams = normalizeRouteParams(params)
     const url = assembleUrl(route, normalizedParams)
 
     const push: RouteMethodPush = ({ params, ...options } = {}) => {
       if (params) {
         const normalizedParamOverrides = normalizeRouteParams(params)
-        const merged = mergeRouteParams(normalizedParams, normalizedParamOverrides)
-        const url = assembleUrl(route, merged)
+
+        const url = assembleUrl(route, {
+          ...normalizeRouteParams,
+          ...normalizedParamOverrides,
+        })
 
         return routerPush(url, options)
       }
@@ -76,23 +79,11 @@ function createRouteMethod({ route, routerPush }: CreateRouteMethodArgs): RouteM
 function normalizeRouteParams(params: Record<string, unknown>): Record<string, unknown[]> {
   const normalizedParams: Record<string, unknown[]> = {}
 
-  for (const key in Object.keys(params)) {
+  for (const key of Object.keys(params)) {
     const value = params[key]
 
     normalizedParams[key] = Array.isArray(value) ? value : [value]
   }
 
   return normalizedParams
-}
-
-function mergeRouteParams(paramsA: Record<string, unknown[]>, paramsB: Record<string, unknown[]>): Record<string, unknown[] | undefined> {
-  const merged: Record<string, unknown[] | undefined> = { ...paramsA }
-
-  for (const [key, params] of Object.entries(paramsB)) {
-    const existing = merged[key] ?? []
-
-    merged[key] = [...existing, ...params]
-  }
-
-  return merged
 }

--- a/src/utilities/createRouteMethods.ts
+++ b/src/utilities/createRouteMethods.ts
@@ -1,8 +1,9 @@
 import { Resolved, Route, RouteMethods, Routes, isPublicRoute } from '@/types'
-import { RouteMethod } from '@/types/routeMethod'
+import { RouteMethod, RouteMethodPush, RouteMethodReplace } from '@/types/routeMethod'
+import { RouterPush } from '@/types/router'
 import { assembleUrl } from '@/utilities/urlAssembly'
 
-export function createRouteMethods<T extends Routes>(routes: Resolved<Route>[]): RouteMethods<T> {
+export function createRouteMethods<T extends Routes>(routes: Resolved<Route>[], routerPush: RouterPush): RouteMethods<T> {
   const methods = routes.reduce<Record<string, any>>((methods, route) => {
     let level = methods
 
@@ -14,7 +15,9 @@ export function createRouteMethods<T extends Routes>(routes: Resolved<Route>[]):
       const isLeaf = match === route.matched
 
       if (isLeaf && isPublicRoute(route.matched)) {
-        level[route.name] = Object.assign(createCallableNode(route), level[route.name])
+        const method = createRouteMethod({ route, routerPush })
+
+        level[route.name] = Object.assign(method, level[route.name])
         return
       }
 
@@ -31,14 +34,65 @@ export function createRouteMethods<T extends Routes>(routes: Resolved<Route>[]):
   return methods as any
 }
 
-function createCallableNode(route: Resolved<Route>): RouteMethod {
-  const node: RouteMethod = (values) => {
-    const url = assembleUrl(route, values)
+type CreateRouteMethodArgs = {
+  route: Resolved<Route>,
+  routerPush: RouterPush,
+}
+
+function createRouteMethod({ route, routerPush }: CreateRouteMethodArgs): RouteMethod {
+  const node: RouteMethod = (params) => {
+    const normalizedParams = normalizeRouteParams(params)
+    const url = assembleUrl(route, normalizedParams)
+
+    const push: RouteMethodPush = ({ params, ...options } = {}) => {
+      if (params) {
+        const normalizedParamOverrides = normalizeRouteParams(params)
+        const merged = mergeRouteParams(normalizedParams, normalizedParamOverrides)
+        const url = assembleUrl(route, merged)
+
+        return routerPush(url, options)
+      }
+
+      return routerPush(url, options)
+    }
+
+    const replace: RouteMethodReplace = (options) => {
+      return routerPush(url, {
+        ...options,
+        replace: true,
+      })
+    }
 
     return {
       url,
+      push,
+      replace,
     }
   }
 
   return node
+}
+
+function normalizeRouteParams(params: Record<string, unknown>): Record<string, unknown[]> {
+  const normalizedParams: Record<string, unknown[]> = {}
+
+  for (const key in Object.keys(params)) {
+    const value = params[key]
+
+    normalizedParams[key] = Array.isArray(value) ? value : [value]
+  }
+
+  return normalizedParams
+}
+
+function mergeRouteParams(paramsA: Record<string, unknown[]>, paramsB: Record<string, unknown[]>): Record<string, unknown[] | undefined> {
+  const merged: Record<string, unknown[] | undefined> = { ...paramsA }
+
+  for (const [key, params] of Object.entries(paramsB)) {
+    const existing = merged[key] ?? []
+
+    merged[key] = [...existing, ...params]
+  }
+
+  return merged
 }

--- a/src/utilities/createRouter.ts
+++ b/src/utilities/createRouter.ts
@@ -1,27 +1,9 @@
-import { DeepReadonly, reactive, readonly, App, InjectionKey } from 'vue'
+import { reactive, readonly, App, InjectionKey } from 'vue'
 import { RouterView } from '@/components'
-import { Resolved, Route, RouteMethods, Routes } from '@/types'
+import { Resolved, Route, Routes } from '@/types'
+import { Router, RouterOptions, RouterPush, RouterReplace } from '@/types/router'
 import { createRouteMethods, createRouterNavigation, resolveRoutes, routeMatch, getInitialUrl, resolveRoutesRegex } from '@/utilities'
 
-type RouterOptions = {
-  initialUrl?: string,
-}
-
-type RouterPush = (url: string, options?: { replace: boolean }) => Promise<void>
-type RouterReplace = (url: string) => Promise<void>
-
-export type Router<
-  TRoutes extends Routes = []
-> = {
-  routes: RouteMethods<TRoutes>,
-  route: DeepReadonly<Resolved<Route>>,
-  push: RouterPush,
-  replace: RouterReplace,
-  back: () => void,
-  forward: () => void,
-  go: (delta: number) => void,
-  install: (app: App) => void,
-}
 
 export const routerInjectionKey: InjectionKey<Router> = Symbol()
 
@@ -71,7 +53,7 @@ export function createRouter<T extends Routes>(routes: T, options: RouterOptions
   }
 
   const router = {
-    routes: createRouteMethods<T>(resolved),
+    routes: createRouteMethods<T>(resolved, push),
     route: readonly(route),
     push,
     replace,

--- a/src/utilities/urlAssembly.ts
+++ b/src/utilities/urlAssembly.ts
@@ -1,7 +1,7 @@
 import { Param, Resolved, Route } from '@/types'
 import { setParamValuesOnUrl } from '@/utilities/paramsFinder'
 
-export function assembleUrl(route: Resolved<Route>, values: Record<string, unknown[]>): string {
+export function assembleUrl(route: Resolved<Route>, values: Record<string, unknown[] | undefined>): string {
   const params = Object.entries<Param[]>(route.params)
 
   return params.reduce((url, [name, params]) => {


### PR DESCRIPTION
# Description
- Moved `Router` and associated types into `@/types/router`
- Moved `RouteMethod` and associated types into `@/types/routeMethod`
- Updated `RouteMethod` type to match what we discussed at standup
- Updated `createRouteMethods` to implement the route methods to match the expected type
- Wrote unit tests