### PR TITLE
Add type for flattening routes into an object of route & params pairs

### DIFF
--- a/src/types/flattened.spec-d.ts
+++ b/src/types/flattened.spec-d.ts
@@ -1,0 +1,52 @@
+/* eslint-disable @typescript-eslint/ban-types */
+import { expectTypeOf, test } from 'vitest'
+import { Flattened, Routes } from '.'
+import { component } from '@/utilities'
+
+test('Returns the correct route keys', () => {
+  const routes = [
+    {
+      name: 'parentA',
+      path: '/parentA',
+      children: [
+        {
+          name: 'childA',
+          path: '/childA',
+          children: [{ name: 'grandChildA', path: '/grandChildA', component }],
+        },
+      ],
+    },
+    {
+      path: '/parentB',
+      children: [
+        {
+          name: 'childB',
+          path: '/childB',
+          children: [{ name: 'grandChildB', path: '/grandChildB', component }],
+        },
+      ],
+    },
+    {
+      name: 'parentC',
+      path: '/parentC',
+      children: [
+        {
+          name: 'childC',
+          path: '/childC',
+          public: false,
+          children: [{ name: 'grandChildC', path: '/grandChildC', component }],
+        },
+      ],
+    },
+  ] as const satisfies Routes
+
+  expectTypeOf<Flattened<typeof routes>>().toMatchTypeOf<{
+    parentA: {},
+    'parentA.childA': {},
+    'parentA.childA.grandChildA': {},
+    childB: {},
+    'childB.grandChildB': {},
+    parentC: {},
+    'parentC.grandChildC': {},
+  }>()
+})

--- a/src/types/flattened.spec-d.ts
+++ b/src/types/flattened.spec-d.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import { expectTypeOf, test } from 'vitest'
 import { Flattened, Routes } from '.'
-import { component } from '@/utilities'
+import { component, path } from '@/utilities'
 
 test('Returns the correct route keys', () => {
   const routes = [
@@ -48,5 +48,35 @@ test('Returns the correct route keys', () => {
     'childB.grandChildB': {},
     parentC: {},
     'parentC.grandChildC': {},
+  }>()
+})
+
+test('returns correct param type for routes', () => {
+  const routes = [
+    {
+      path: '/:A',
+      children: [
+        {
+          path: path('/:B', {
+            B: Boolean,
+          }),
+          children: [
+            {
+              name: 'grandchild',
+              path: '/:A/:B/:?C',
+              component,
+            },
+          ],
+        },
+      ],
+    },
+  ] as const satisfies Routes
+
+  expectTypeOf<Flattened<typeof routes>>().toMatchTypeOf<{
+    grandchild: {
+      B: [boolean, string],
+      C?: string,
+      A: [string, string],
+    },
   }>()
 })

--- a/src/types/flattened.ts
+++ b/src/types/flattened.ts
@@ -1,0 +1,48 @@
+import { ExtractParamsFromPath, MarkOptionalParams, MergeParams } from '@/types/routeMethods'
+import { Public, Route, Routes } from '@/types/routes'
+import { Identity, UnionToIntersection } from '@/types/utilities'
+
+export type Flattened<
+  TRoute extends Route | Routes,
+  TPrefix extends string = '',
+  TParams extends Record<string, unknown> = Record<never, never>
+> = Identity<
+TRoute extends Route
+  ? RouteFlat<TRoute, TPrefix, TParams> & RouteChildrenFlat<TRoute, TPrefix, TParams>
+  : TRoute extends Routes
+    ? UnionToIntersection<{
+      [K in keyof TRoute]: TRoute[K] extends Route
+        ? Flattened<TRoute[K], TPrefix, TParams>
+        : Record<never, never>
+    }[number]>
+    : Record<never, never>
+>
+
+type RouteFlat<
+  TRoute extends Route,
+  TPrefix extends string,
+  TParams extends Record<string, unknown> = Record<never, never>
+> = TRoute extends Public<TRoute> & { path: infer Path, name: infer Name extends string }
+  ? Record<Prefix<Name, TPrefix>, MarkOptionalParams<MergeParams<TParams, ExtractParamsFromPath<Path>>>>
+  : Record<never, never>
+
+type RouteChildrenFlat<
+  TRoute extends Route,
+  TPrefix extends string,
+  TParams extends Record<string, unknown> = Record<never, never>
+> = TRoute extends { path: infer Path, children: infer Children extends Routes }
+  ? TRoute extends Public<TRoute> & { name: infer Name extends string }
+    ? Flattened<Children, Prefix<Name, TPrefix>, MergeParams<TParams, ExtractParamsFromPath<Path>>>
+    : Flattened<Children, Prefix<'', TPrefix>, MergeParams<TParams, ExtractParamsFromPath<Path>>>
+  : Record<never, never>
+
+type Prefix<
+  TChildName extends string,
+  TParentName extends string
+> = `${TChildName}${TParentName}` extends ''
+  ? ''
+  : TParentName extends ''
+    ? TChildName
+    : TChildName extends ''
+      ? TParentName
+      : `${TParentName}.${TChildName}`

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from './flattened'
 export * from './invalidRouteParamValueError'
 export * from './middleware'
 export * from './params'

--- a/src/types/routeMethods.ts
+++ b/src/types/routeMethods.ts
@@ -70,7 +70,7 @@ export type ExtractParamsFromPathString<
       ? { [P in ExtractParamName<Param>]: [ExtractPathParamType<Param, TParams>] }
       : Record<never, never>
 
-type MergeParams<
+export type MergeParams<
   TAlpha extends Record<string, unknown>,
   TBeta extends Record<string, unknown>
 > = {
@@ -120,7 +120,7 @@ export type ExtractParamType<TParam extends Param | undefined> = TParam extends 
     ? ReturnType<TParam>
     : string
 
-type MarkOptionalParams<TParams extends Record<string, unknown[]>> = Identity<{
+export type MarkOptionalParams<TParams extends Record<string, unknown[]>> = Identity<{
   [K in keyof GetAllOptionalParams<TParams>]?: K extends keyof TParams ? UnwrapSingleParams<TParams[K]> : never
 } & {
   [K in keyof GetAllRequiredParams<TParams>]: K extends keyof TParams ? UnwrapSingleParams<TParams[K]> : never


### PR DESCRIPTION
# Description
Introduces a new type called `Flattened` that accepts `Route | Routes`. Produces a flag record keyed by the dot notation name of the route with values of each individual route's params

WIP - Need to add tests