### PR TITLE
RFC: Add type support for route query

### DIFF
--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -27,3 +27,30 @@ export function isParamGetSet(value: Param): value is ParamGetSet {
     && 'set' in value
     && typeof value.set === 'function'
 }
+
+export type ExtractParamName<
+  TParam extends string
+> = TParam extends `?${infer Param}`
+  ? Param extends ''
+    ? never
+    : Param
+  : TParam extends ''
+    ? never
+    : TParam
+
+export type ExtractPathParamType<
+  TParam extends string,
+  TParams extends Record<string, Param | undefined>
+> = TParam extends `?${infer OptionalParam}`
+  ? OptionalParam extends keyof TParams
+    ? ExtractParamType<TParams[OptionalParam]> | undefined
+    : string | undefined
+  : TParam extends keyof TParams
+    ? ExtractParamType<TParams[TParam]>
+    : string
+
+export type ExtractParamType<TParam extends Param | undefined> = TParam extends ParamGetSet<infer Type>
+  ? Type
+  : TParam extends ParamGetter
+    ? ReturnType<TParam>
+    : string

--- a/src/types/routeMethods.ts
+++ b/src/types/routeMethods.ts
@@ -1,7 +1,6 @@
-import { Param, ParamGetSet, ParamGetter } from '@/types/params'
 import { RouteMethod, RouteMethodResponse } from '@/types/routeMethod'
 import { Public, Route, Routes } from '@/types/routes'
-import { Identity, ReplaceAll, TupleCanBeAllUndefined, UnionToIntersection } from '@/types/utilities'
+import { Identity, TupleCanBeAllUndefined, UnionToIntersection } from '@/types/utilities'
 import { Path } from '@/utilities/path'
 
 export type RouteMethods<
@@ -53,23 +52,6 @@ export type ExtractParamsFromPath<
     ? Path<TPath, object>['params']
     : never
 
-type ParamEnd = '/'
-
-type UnifyParamEnds<
-  TPath extends string
-> = ReplaceAll<ReplaceAll<TPath, '-', ParamEnd>, '_', ParamEnd>
-
-export type ExtractParamsFromPathString<
-  TPath extends string,
-  TParams extends Record<string, Param | undefined> = Record<never, never>
-> = UnifyParamEnds<TPath> extends `${infer Path}${ParamEnd}`
-  ? ExtractParamsFromPathString<Path, TParams>
-  : UnifyParamEnds<TPath> extends `${string}:${infer Param}${ParamEnd}${infer Rest}`
-    ? MergeParams<{ [P in ExtractParamName<Param>]: ExtractPathParamType<Param, TParams> }, ExtractParamsFromPathString<Rest, TParams>>
-    : UnifyParamEnds<TPath> extends `${string}:${infer Param}`
-      ? { [P in ExtractParamName<Param>]: [ExtractPathParamType<Param, TParams>] }
-      : Record<never, never>
-
 export type MergeParams<
   TAlpha extends Record<string, unknown>,
   TBeta extends Record<string, unknown>
@@ -92,33 +74,6 @@ export type MergeParams<
           : [TBeta[K]]
         : never
 }
-
-type ExtractParamName<
-  TParam extends string
-> = TParam extends `?${infer Param}`
-  ? Param extends ''
-    ? never
-    : Param
-  : TParam extends ''
-    ? never
-    : TParam
-
-type ExtractPathParamType<
-  TParam extends string,
-  TParams extends Record<string, Param | undefined>
-> = TParam extends `?${infer OptionalParam}`
-  ? OptionalParam extends keyof TParams
-    ? ExtractParamType<TParams[OptionalParam]> | undefined
-    : string | undefined
-  : TParam extends keyof TParams
-    ? ExtractParamType<TParams[TParam]>
-    : string
-
-export type ExtractParamType<TParam extends Param | undefined> = TParam extends ParamGetSet<infer Type>
-  ? Type
-  : TParam extends ParamGetter
-    ? ReturnType<TParam>
-    : string
 
 export type MarkOptionalParams<TParams extends Record<string, unknown[]>> = Identity<{
   [K in keyof GetAllOptionalParams<TParams>]?: K extends keyof TParams ? UnwrapSingleParams<TParams[K]> : never

--- a/src/types/routes.ts
+++ b/src/types/routes.ts
@@ -2,6 +2,7 @@ import { AsyncComponentLoader, Component, DefineComponent } from 'vue'
 import { RouteMiddleware } from '@/types/middleware'
 import { MaybeArray } from '@/types/utilities'
 import { Path } from '@/utilities/path'
+import { Query } from '@/utilities/query'
 
 export type RouteComponent = Component | DefineComponent | AsyncComponentLoader
 
@@ -11,7 +12,7 @@ export interface RouteMeta {
 
 export type ParentRoute<
   TPath extends string | Path = any,
-  TQuery extends string | Path = any
+  TQuery extends string | Query = any
 > = {
   name?: string,
   path: TPath,
@@ -25,7 +26,7 @@ export type ParentRoute<
 
 export type ChildRoute<
   TPath extends string | Path = any,
-  TQuery extends string | Path = any
+  TQuery extends string | Query = any
 > = {
   name: string,
   public?: boolean,

--- a/src/types/routes.ts
+++ b/src/types/routes.ts
@@ -10,10 +10,12 @@ export interface RouteMeta {
 }
 
 export type ParentRoute<
-  TRoute extends string | Path = any
+  TPath extends string | Path = any,
+  TQuery extends string | Path = any
 > = {
   name?: string,
-  path: TRoute,
+  path: TPath,
+  query?: TQuery,
   public?: boolean,
   children: Routes,
   component?: RouteComponent,
@@ -22,11 +24,13 @@ export type ParentRoute<
 }
 
 export type ChildRoute<
-  TRoute extends string | Path = any
+  TPath extends string | Path = any,
+  TQuery extends string | Path = any
 > = {
   name: string,
   public?: boolean,
-  path: TRoute,
+  path: TPath,
+  query?: TQuery,
   component: RouteComponent,
   middleware?: MaybeArray<RouteMiddleware>,
   meta?: RouteMeta,

--- a/src/utilities/params.ts
+++ b/src/utilities/params.ts
@@ -1,5 +1,46 @@
 import { Param, ParamGetSet, ParamExtras, isParamGetSet, isParamGetter, ExtractParamType } from '@/types'
 import { InvalidRouteParamValueError } from '@/types/invalidRouteParamValueError'
+import { mergeParams } from '@/utilities/mergeParams'
+import { stringHasValue } from '@/utilities/string'
+
+export function getParam<P extends Record<string, Param | undefined>>(params: P, param: string): Param {
+  return params[param] ?? String
+}
+
+export function optional<TParam extends Param>(param: TParam): ParamGetSet<ExtractParamType<TParam> | undefined> {
+  return {
+    get: (value) => {
+      if (!stringHasValue(value)) {
+        return undefined
+      }
+
+      return getParamValue(value, param)
+    },
+    set: (value) => {
+      if (!stringHasValue(value)) {
+        return ''
+      }
+
+      return setParamValue(value, param)
+    },
+  }
+}
+
+export function getParamsForString<TInput extends string, TParams extends Record<string, Param | undefined>>(string: TInput, params: TParams): Record<string, unknown[]> {
+  const paramPattern = /:\??([\w]+)(?=\W|$)/g
+  const matches = Array.from(string.matchAll(paramPattern))
+
+  const paramAssignments = matches.map(([match, paramName]) => {
+    const isOptional = match.startsWith(':?')
+    const param = getParam(params, paramName)
+
+    return {
+      [paramName]: [isOptional ? optional(param) : param],
+    }
+  })
+
+  return mergeParams(...paramAssignments)
+}
 
 const extras: ParamExtras = {
   invalid: (message?: string) => {

--- a/src/utilities/path.ts
+++ b/src/utilities/path.ts
@@ -1,8 +1,22 @@
-import { Param, ExtractParamsFromPathString, Identity, ParamGetSet, ExtractParamType } from '@/types'
-import { getParamValue, mergeParams, setParamValue } from '@/utilities'
-import { stringHasValue } from '@/utilities/string'
+import { Param, Identity, ReplaceAll, MergeParams, ExtractParamName, ExtractPathParamType } from '@/types'
+import { getParamsForString } from '@/utilities'
 
-type OptionalParam = Param | undefined
+type ParamEnd = '/'
+
+type UnifyParamEnds<
+  TPath extends string
+> = ReplaceAll<ReplaceAll<TPath, '-', ParamEnd>, '_', ParamEnd>
+
+type ExtractParamsFromPathString<
+  TPath extends string,
+  TParams extends Record<string, Param | undefined> = Record<never, never>
+> = UnifyParamEnds<TPath> extends `${infer Path}${ParamEnd}`
+  ? ExtractParamsFromPathString<Path, TParams>
+  : UnifyParamEnds<TPath> extends `${string}:${infer Param}${ParamEnd}${infer Rest}`
+    ? MergeParams<{ [P in ExtractParamName<Param>]: ExtractPathParamType<Param, TParams> }, ExtractParamsFromPathString<Rest, TParams>>
+    : UnifyParamEnds<TPath> extends `${string}:${infer Param}`
+      ? { [P in ExtractParamName<Param>]: [ExtractPathParamType<Param, TParams>] }
+      : Record<never, never>
 
 type PathParams<T extends string> = {
   [K in keyof ExtractParamsFromPathString<T>]?: Param
@@ -16,44 +30,9 @@ export type Path<
   params: Identity<ExtractParamsFromPathString<T, P>>,
 }
 
-function getParam<P extends Record<string, OptionalParam>>(params: P, param: string): Param {
-  return params[param] ?? String
-}
-
 export function path<T extends string, P extends PathParams<T>>(path: T, params: Identity<P>): Path<T, P> {
-  const paramPattern = /:\??([\w]+)(?=\W|$)/g
-  const matches = Array.from(path.matchAll(paramPattern))
-
-  const paramAssignments = matches.map(([match, paramName]) => {
-    const isOptional = match.startsWith(':?')
-    const param = getParam(params, paramName)
-
-    return {
-      [paramName]: [isOptional ? optional(param) : param],
-    }
-  })
-
   return {
     path,
-    params: mergeParams(...paramAssignments) as Path<T, P>['params'],
-  }
-}
-
-export function optional<TParam extends Param>(param: TParam): ParamGetSet<ExtractParamType<TParam> | undefined> {
-  return {
-    get: (value) => {
-      if (!stringHasValue(value)) {
-        return undefined
-      }
-
-      return getParamValue(value, param)
-    },
-    set: (value) => {
-      if (!stringHasValue(value)) {
-        return ''
-      }
-
-      return setParamValue(value, param)
-    },
+    params: getParamsForString(path, params) as Path<T, P>['params'],
   }
 }

--- a/src/utilities/query.ts
+++ b/src/utilities/query.ts
@@ -1,0 +1,32 @@
+import { ExtractParamName, ExtractPathParamType, Param } from '@/types/params'
+import { MergeParams } from '@/types/routeMethods'
+import { Identity } from '@/types/utilities'
+import { getParamsForString } from '@/utilities/params'
+
+type ExtractQueryParamsFromQueryString<
+  TQuery extends string,
+  TParams extends Record<string, Param | undefined> = Record<never, never>
+> = TQuery extends `${string}=:${infer Param}&${infer Rest}`
+  ? MergeParams<{ [P in ExtractParamName<Param>]: ExtractPathParamType<Param, TParams> }, ExtractQueryParamsFromQueryString<Rest, TParams>>
+  : TQuery extends `${string}:${infer Param}`
+    ? { [P in ExtractParamName<Param>]: [ExtractPathParamType<Param, TParams>] }
+    : Record<never, never>
+
+type QueryParams<T extends string> = {
+  [K in keyof ExtractQueryParamsFromQueryString<T>]?: Param
+}
+
+export type Query<
+  T extends string = any,
+  P extends QueryParams<T> = any
+> = {
+  query: T,
+  params: Identity<ExtractQueryParamsFromQueryString<T, P>>,
+}
+
+export function query<T extends string, P extends QueryParams<T>>(query: T, params: Identity<P>): Query<T, P> {
+  return {
+    query,
+    params: getParamsForString(query, params) as Query<T, P>['params'],
+  }
+}


### PR DESCRIPTION
# Description
Adds initial type support for query params on `Route`. This works very similarly to out path params work. `Route.query` is type `string | Query`. 

## Examples
This example has three params. `name`, `gender`, and `age`. `name` and `gender` are required, `age` is optional. All are strings.
```typescript
const route = {
  name: 'route',
  path: '/route',
  query: 'name=:name&gender=:gender&age=:?age'
} as const satisfies Route
```
Same example but using the `query` utility to make the `age` param a `number`
```typescript
const route = {
  name: 'route',
  path: '/route',
  query: query('name=:name&gender=:gender&age=:?age', {
    age: Number
  })
} as const satisfies Route
```
## Route Matching
This is not implemented. Didn't want to get to far without discussing. But the idea is that any route that has a query would require those params exist unless they are optional in order to match the route. If a parent route specifies a `query` it is added to the `query` on any child routes. Unlike the path, the order of params in the query does not matter. Also additional params can exist. 

## Route methods & `Router.push`
I'm not 100% sure how to account for required query params when routing. I briefly thought about combining all params together when asking for values. But that get's weird with multiple params with the same name because the ordering of query params. I think a better experience would be making both `params` and `queryParams` required but keep their types separate. 

So when passing a `string` to `Router.push` there's no issue. 
When using the object route syntax there's no issue (`{ route: 'parent.child', queryParams: { age: 1 } }`)
But it doesn't really fit with the route methods devx. 
