### PR TITLE
Update route method and flattened types to support query params

### DIFF
--- a/src/types/flattened.spec-d.ts
+++ b/src/types/flattened.spec-d.ts
@@ -82,7 +82,7 @@ test('returns correct param type for routes', () => {
   }>()
 })
 
-test('works with query params', () => {
+test('returns correct type when query params are used', () => {
   const routes = [
     {
       path: '/:param1',

--- a/src/types/flattened.spec-d.ts
+++ b/src/types/flattened.spec-d.ts
@@ -85,17 +85,17 @@ test('returns correct param type for routes', () => {
 test('works with query params', () => {
   const routes = [
     {
-      path: '/:A',
-      query: query('B=:B', {
-        B: Boolean,
+      path: '/:param1',
+      query: query('param2=:param2', {
+        param2: Boolean,
       }),
       children: [
         {
           name: 'child',
-          path: path('/:B/:?D', {
-            D: Boolean,
+          path: path('/:param2/:?param3', {
+            param3: Boolean,
           }),
-          query: 'A=:A&D=:?D',
+          query: 'param1=:param1&param3=:?param3',
           component,
         },
       ],
@@ -104,9 +104,9 @@ test('works with query params', () => {
 
   expectTypeOf<Flattened<typeof routes>>().toMatchTypeOf<{
     child: {
-      A: [string, string],
-      B: [string, boolean],
-      D?: [boolean | undefined, string | undefined],
+      param1: [string, string],
+      param2: [string, boolean],
+      param3?: [boolean | undefined, string | undefined],
     },
   }>()
 

--- a/src/types/flattened.spec-d.ts
+++ b/src/types/flattened.spec-d.ts
@@ -2,6 +2,7 @@
 import { expectTypeOf, test } from 'vitest'
 import { Flattened, Routes } from '.'
 import { component, path } from '@/utilities'
+import { query } from '@/utilities/query'
 
 test('Returns the correct route keys', () => {
   const routes = [
@@ -79,4 +80,34 @@ test('returns correct param type for routes', () => {
       A: [string, string],
     },
   }>()
+})
+
+test('works with query params', () => {
+  const routes = [
+    {
+      path: '/:A',
+      query: query('B=:B', {
+        B: Boolean,
+      }),
+      children: [
+        {
+          name: 'child',
+          path: path('/:B/:?D', {
+            D: Boolean,
+          }),
+          query: 'A=:A&D=:?D',
+          component,
+        },
+      ],
+    },
+  ] as const satisfies Routes
+
+  expectTypeOf<Flattened<typeof routes>>().toMatchTypeOf<{
+    child: {
+      A: [string, string],
+      B: [string, boolean],
+      D?: [boolean | undefined, string | undefined],
+    },
+  }>()
+
 })


### PR DESCRIPTION
# Description
Updates both the `Flattened` and the `RouteMethods` types (and their individual pieces) to support query params. 