### PR TITLE
More complete types for `RouterPush` and abstact implementation into `createRouterPush`

### DIFF
--- a/src/types/flattened.ts
+++ b/src/types/flattened.ts
@@ -28,7 +28,6 @@ type RouteFlat<
   ? Record<Prefix<Name, TPrefix>, MarkOptionalParams<MergeParams<RoutePathParams<TRoute, TPathParams>, RouteQueryParams<TRoute, TQueryParams>>>>
   : Record<never, never>
 
-
 type RouteChildrenFlat<
   TRoute extends Route,
   TPrefix extends string,

--- a/src/types/routeMethods.ts
+++ b/src/types/routeMethods.ts
@@ -48,15 +48,15 @@ export type ExtractRouteMethodParams<T extends RouteMethod> =
 export type RoutePathParams<
   TRoute extends Route,
   TPathParams extends Record<string, unknown>
-> = TRoute extends { path: infer Path }
-  ? MergeParams<TPathParams, ExtractParamsFromPath<Path>>
+> = TRoute extends { path: infer TPath extends string | Path }
+  ? MergeParams<TPathParams, ExtractParamsFromPath<TPath>>
   : MergeParams<TPathParams, {}>
 
 export type RouteQueryParams<
   TRoute extends Route,
   TQueryParams extends Record<string, unknown>
-> = TRoute extends { query: infer Query }
-  ? MergeParams<TQueryParams, ExtractParamsFromQuery<Query>>
+> = TRoute extends { query: infer TQuery extends string | Query }
+  ? MergeParams<TQueryParams, ExtractParamsFromQuery<TQuery>>
   : MergeParams<TQueryParams, {}>
 
 type ExtractParamsFromPath<

--- a/src/types/routes.ts
+++ b/src/types/routes.ts
@@ -38,8 +38,9 @@ export type ChildRoute<
 }
 
 export type Route<
-  TRoute extends string | Path = any
-> = ParentRoute<TRoute> | ChildRoute<TRoute>
+  TPath extends string | Path = any,
+  TQuery extends string | Query = any
+> = ParentRoute<TPath, TQuery> | ChildRoute<TPath, TQuery>
 
 export type Routes = Readonly<Route[]>
 

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -52,3 +52,5 @@ export type ReplaceAll<
 export type OnlyRequiredProperties<T extends Record<string, unknown>> = {
   [K in keyof T as Extract<T[K], undefined> extends never ? K : never]: T[K]
 }
+
+export type AllPropertiesAreOptional<T extends Record<string, unknown>> = IsEmptyObject<OnlyRequiredProperties<T>>

--- a/src/utilities/createRouteMethods.spec.ts
+++ b/src/utilities/createRouteMethods.spec.ts
@@ -7,7 +7,7 @@ test.each([
   [undefined],
   [true],
 ])('given route is named and is public, makes parent callable', (isPublic) => {
-  const routerPush = vi.fn()
+  const push = vi.fn()
 
   const routes = [
     {
@@ -19,7 +19,7 @@ test.each([
   ] as const satisfies Routes
   const resolved = resolveRoutes(routes)
 
-  const response = createRouteMethods<typeof routes>(resolved, routerPush)
+  const response = createRouteMethods<typeof routes>({ resolved, push })
 
   if (isPublic !== false) {
     // @ts-expect-error
@@ -32,7 +32,7 @@ test.each([
 })
 
 test('given route is NOT public, returns empty object', () => {
-  const routerPush = vi.fn()
+  const push = vi.fn()
 
   const routes = [
     {
@@ -44,7 +44,7 @@ test('given route is NOT public, returns empty object', () => {
   ] as const satisfies Routes
   const resolved = resolveRoutes(routes)
 
-  const response = createRouteMethods<typeof routes>(resolved, routerPush)
+  const response = createRouteMethods<typeof routes>({ resolved, push })
 
   expect(response).toMatchObject({})
 })
@@ -54,7 +54,7 @@ test.each([
   [true],
   [false],
 ])('given parent route with named children, has property for child name', (isPublic) => {
-  const routerPush = vi.fn()
+  const push = vi.fn()
 
   const routes = [
     {
@@ -72,7 +72,7 @@ test.each([
   ] as const satisfies Routes
   const resolved = resolveRoutes(routes)
 
-  const response = createRouteMethods<typeof routes>(resolved, routerPush)
+  const response = createRouteMethods<typeof routes>({ resolved, push })
 
   if (isPublic !== false) {
     // @ts-expect-error
@@ -84,7 +84,7 @@ test.each([
 })
 
 test('given parent route with named children and grandchildren, has path to grandchild all callable', () => {
-  const routerPush = vi.fn()
+  const push = vi.fn()
 
   const routes = [
     {
@@ -107,7 +107,7 @@ test('given parent route with named children and grandchildren, has path to gran
   ] as const satisfies Routes
   const resolved = resolveRoutes(routes)
 
-  const response = createRouteMethods<typeof routes>(resolved, routerPush)
+  const response = createRouteMethods<typeof routes>({ resolved, push })
 
   expect(response.parent).toBeTypeOf('function')
   expect(response.parent.child).toBeTypeOf('function')
@@ -116,7 +116,7 @@ test('given parent route with named children and grandchildren, has path to gran
 
 describe('routeMethod', () => {
   test('push and replace call router.push with correct parameters', () => {
-    const routerPush = vi.fn()
+    const push = vi.fn()
 
     const routes = [
       {
@@ -126,23 +126,23 @@ describe('routeMethod', () => {
       },
     ] as const satisfies Routes
     const resolved = resolveRoutes(routes)
-    const { route } = createRouteMethods<typeof routes>(resolved, routerPush)
+    const { route } = createRouteMethods<typeof routes>({ resolved, push })
 
     route().push()
-    expect(routerPush).toHaveBeenLastCalledWith('/route/', {})
+    expect(push).toHaveBeenLastCalledWith('/route/', {})
 
     route().replace()
-    expect(routerPush).toHaveBeenLastCalledWith('/route/', { replace: true })
+    expect(push).toHaveBeenLastCalledWith('/route/', { replace: true })
 
     route({ param: 'foo' }).push()
-    expect(routerPush).toHaveBeenLastCalledWith('/route/foo', {})
+    expect(push).toHaveBeenLastCalledWith('/route/foo', {})
 
     route({ param: 'foo' }).push({ params: { param: 'bar' } })
-    expect(routerPush).toHaveBeenLastCalledWith('/route/bar', {})
+    expect(push).toHaveBeenLastCalledWith('/route/bar', {})
   })
 
   test('returns correct url', () => {
-    const routerPush = vi.fn()
+    const push = vi.fn()
 
     const routes = [
       {
@@ -152,7 +152,7 @@ describe('routeMethod', () => {
       },
     ] as const satisfies Routes
     const resolved = resolveRoutes(routes)
-    const { route } = createRouteMethods<typeof routes>(resolved, routerPush)
+    const { route } = createRouteMethods<typeof routes>({ resolved, push })
 
     expect(route().url).toBe('/route/')
     expect(route({ param: 'param' }).url).toBe('/route/param')

--- a/src/utilities/createRouter.spec.ts
+++ b/src/utilities/createRouter.spec.ts
@@ -52,7 +52,7 @@ test('updates the route when navigating', async () => {
 
   expect(route.matched).toMatchObject(second)
 
-  await push({ name: third.name, params: { id: '123' } })
+  await push({ route: third.name, params: { id: '123' } })
 
   expect(route.matched).toMatchObject(third)
 })

--- a/src/utilities/createRouter.ts
+++ b/src/utilities/createRouter.ts
@@ -44,8 +44,8 @@ export function createRouter<T extends Routes>(routes: T, options: RouterOptions
     Object.assign(route, newRoute)
   }
 
-  async function replace(url: string, options: RouterReplaceOptions = {}): Promise<void> {
-    await navigation.update(url, { ...options, replace: true })
+  function replace(url: string, options: RouterReplaceOptions = {}): Promise<void> {
+    return push(url, { ...options, replace: true })
   }
 
   const push = createRouterPush<T>({ navigation, resolved })

--- a/src/utilities/createRouterPush.ts
+++ b/src/utilities/createRouterPush.ts
@@ -1,0 +1,39 @@
+import { Resolved, Route, RouterPush, RouterPushOptions, Routes } from '@/types'
+import { flattenParentMatches } from '@/utilities/flattenParentMatches'
+import { RouterNavigation } from '@/utilities/routerNavigation'
+import { component } from '@/utilities/testHelpers'
+import { assembleUrl } from '@/utilities/urlAssembly'
+
+type DummyRoutes = [{ name: string, path: '/', component: typeof component }]
+
+type RouterPushContext = {
+  navigation: RouterNavigation,
+  resolved: Resolved<Route>[],
+}
+
+export function createRouterPush<const TRoutes extends Routes>({ navigation, resolved }: RouterPushContext): RouterPush<TRoutes> {
+
+  const push: RouterPush<DummyRoutes> = (urlOrRouteConfig, options?: RouterPushOptions) => {
+    if (typeof urlOrRouteConfig === 'object') {
+      const { route, params, ...options } = urlOrRouteConfig
+      const match = resolved.find((resolvedRoute) => flattenParentMatches(resolvedRoute) === route)
+
+      if (!match) {
+        throw `No route found: "${String(route)}"`
+      }
+
+      const url = assembleUrl(match, params)
+
+      return push(url, options)
+    }
+
+    if (typeof urlOrRouteConfig === 'string') {
+      return navigation.update(urlOrRouteConfig, options)
+    }
+
+    const exhaustive: never = urlOrRouteConfig
+    throw new Error(`Unhandled router push overload: ${JSON.stringify(exhaustive)}`)
+  }
+
+  return push as any
+}

--- a/src/utilities/createRouterPush.ts
+++ b/src/utilities/createRouterPush.ts
@@ -1,10 +1,9 @@
-import { Resolved, Route, RouterPush, RouterPushOptions, Routes } from '@/types'
+import { Resolved, Route, RouteComponent, RouterPush, RouterPushOptions, Routes } from '@/types'
 import { flattenParentMatches } from '@/utilities/flattenParentMatches'
 import { RouterNavigation } from '@/utilities/routerNavigation'
-import { component } from '@/utilities/testHelpers'
 import { assembleUrl } from '@/utilities/urlAssembly'
 
-type DummyRoutes = [{ name: string, path: '/', component: typeof component }]
+type AnyRoutes = [{ name: string, path: string, component: RouteComponent }]
 
 type RouterPushContext = {
   navigation: RouterNavigation,
@@ -13,7 +12,7 @@ type RouterPushContext = {
 
 export function createRouterPush<const TRoutes extends Routes>({ navigation, resolved }: RouterPushContext): RouterPush<TRoutes> {
 
-  const push: RouterPush<DummyRoutes> = (urlOrRouteConfig, options?: RouterPushOptions) => {
+  const push: RouterPush<AnyRoutes> = (urlOrRouteConfig, options?: RouterPushOptions) => {
     if (typeof urlOrRouteConfig === 'object') {
       const { route, params, ...options } = urlOrRouteConfig
       const match = resolved.find((resolvedRoute) => flattenParentMatches(resolvedRoute) === route)

--- a/src/utilities/routerNavigation.ts
+++ b/src/utilities/routerNavigation.ts
@@ -15,7 +15,7 @@ type NavigationGo = (delta: number) => void
 type NavigationUpdate = (url: string, options?: RouterNavigationUpdateOptions) => Promise<void>
 type NavigationCleanup = () => void
 
-type RouterNavigation = {
+export type RouterNavigation = {
   forward: NavigationForward,
   back: NavigationBack,
   go: NavigationGo,


### PR DESCRIPTION
# Description
Updates the types for `RouterPush` to be a little more accurate. Was hoping to remove the need for an `as any` but still had that same issue in `createRouterPush`. But at least now its consistent with `createRouteMethods`. 