### PR TITLE
Abstract resolving a url from a route source into router.resolve

### DIFF
--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -3,6 +3,7 @@ import { Resolved } from '@/types/resolved'
 import { RouteMethods } from '@/types/routeMethods'
 import { Route, Routes } from '@/types/routes'
 import { RouterPush, RouterPushOptions } from '@/utilities/createRouterPush'
+import { RouterResolve } from '@/utilities/createRouterResolve'
 
 export type RouterOptions = {
   initialUrl?: string,
@@ -18,6 +19,7 @@ export type Router<
 > = {
   routes: RouteMethods<TRoutes>,
   route: DeepReadonly<Resolved<Route>>,
+  resolve: RouterResolve,
   push: RouterPush<TRoutes>,
   replace: RouterReplace,
   back: () => void,

--- a/src/utilities/createRouter.ts
+++ b/src/utilities/createRouter.ts
@@ -3,6 +3,7 @@ import { RouterLink, RouterView } from '@/components'
 import { Resolved, Route, Routes, Router, RouterOptions, RegisteredRouter, RouterReplaceOptions } from '@/types'
 import { createRouteMethods, createRouterNavigation, resolveRoutes, routeMatch, getInitialUrl } from '@/utilities'
 import { createRouterPush } from '@/utilities/createRouterPush'
+import { createRouterResolve } from '@/utilities/createRouterResolve'
 
 export const routerInjectionKey: InjectionKey<RegisteredRouter> = Symbol()
 
@@ -47,11 +48,13 @@ export function createRouter<T extends Routes>(routes: T, options: RouterOptions
     return push(url, { ...options, replace: true })
   }
 
-  const push = createRouterPush<T>({ navigation, resolved })
+  const resolve = createRouterResolve({ resolved })
+  const push = createRouterPush<T>({ navigation, resolve })
 
   const router = {
     routes: createRouteMethods<T>({ resolved, push }),
     route: readonly(route),
+    resolve,
     push,
     replace,
     forward: navigation.forward,

--- a/src/utilities/createRouterPush.spec.ts
+++ b/src/utilities/createRouterPush.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test, vi } from 'vitest'
 import { createRouterPush } from '@/utilities/createRouterPush'
+import { createRouterResolve } from '@/utilities/createRouterResolve'
 import { resolveRoutes } from '@/utilities/resolveRoutes'
 import { createRouterNavigation } from '@/utilities/routerNavigation'
 import { routes } from '@/utilities/testHelpers'
@@ -8,7 +9,8 @@ test('push calls onLocationUpdated', () => {
   const onLocationUpdate = vi.fn()
   const navigation = createRouterNavigation({ onLocationUpdate })
   const resolved = resolveRoutes(routes)
-  const push = createRouterPush<typeof routes>({ navigation, resolved })
+  const resolve = createRouterResolve({ resolved })
+  const push = createRouterPush<typeof routes>({ navigation, resolve })
 
   push({ route: 'parentA', params: { paramA: '' } })
 

--- a/src/utilities/createRouterResolve.browser.spec.ts
+++ b/src/utilities/createRouterResolve.browser.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from 'vitest'
+import { Route } from '@/types'
+import { createRouter } from '@/utilities/createRouter'
+import { component } from '@/utilities/testHelpers'
+
+test('when given a string returns that string', () => {
+  const route = {
+    name: 'route',
+    path: '/route/:param',
+    component,
+  } as const satisfies Route
+
+  const { resolve } = createRouter([route], {
+    initialUrl: '/route/bar',
+  })
+
+  expect(resolve('/route/bar')).toBe('/route/bar')
+})
+
+test('when given a route method returns the url', () => {
+  const route = {
+    name: 'route',
+    path: '/route/:param',
+    component,
+  } as const satisfies Route
+
+  const { resolve, routes } = createRouter([route], {
+    initialUrl: '/route/bar',
+  })
+
+  expect(resolve(routes.route({ param: 'bar' }))).toBe('/route/bar')
+})
+
+test('when given a route with params returns the url', () => {
+  const route = {
+    name: 'route',
+    path: '/route/:param',
+    component,
+  } as const satisfies Route
+
+  const { resolve } = createRouter([route], {
+    initialUrl: '/route/bar',
+  })
+
+  expect(resolve({ route: 'route', params: { param: 'bar' } })).toBe('/route/bar')
+})
+
+test('throws an error if route with params cannot be matched', () => {
+  const route = {
+    name: 'route',
+    path: '/route/:param',
+    component,
+  } as const satisfies Route
+
+  const { resolve } = createRouter([route], {
+    initialUrl: '/route/bar',
+  })
+
+  expect(() => resolve({ route: 'foo' })).toThrowError()
+})

--- a/src/utilities/createRouterResolve.ts
+++ b/src/utilities/createRouterResolve.ts
@@ -1,0 +1,39 @@
+import { Resolved, Route, RouteMethod, isRouteMethodResponse } from '@/types'
+import { flattenParentMatches } from '@/utilities/flattenParentMatches'
+import { isRecord } from '@/utilities/guards'
+import { normalizeRouteParams } from '@/utilities/normalizeRouteParams'
+import { assembleUrl } from '@/utilities/urlAssembly'
+
+type RouterResolveContext = {
+  resolved: Resolved<Route>[],
+}
+
+export type RouterResolve = (source: string | ReturnType<RouteMethod> | { route: string, params?: Record<string, unknown> }) => string
+
+export function createRouterResolve({ resolved }: RouterResolveContext): RouterResolve {
+  return (source) => {
+    if (typeof source === 'string') {
+      return source
+    }
+
+    if (isRouteMethodResponse(source)) {
+      return source.url
+    }
+
+    if (isRecord(source)) {
+      const match = resolved.find((resolvedRoute) => flattenParentMatches(resolvedRoute) === source.route)
+
+      if (!match) {
+        throw `No route found: "${String(source)}"`
+      }
+
+      const normalized = normalizeRouteParams(source.params ?? {})
+      const url = assembleUrl(match, normalized)
+
+      return url
+    }
+
+    const exhaustive: never = source
+    throw new Error(`Unhandled router push overload: ${JSON.stringify(exhaustive)}`)
+  }
+}


### PR DESCRIPTION
# Description
Moves the logic for determining the url from a route source out of createRouterPush and into createRouterResolve. Also adds `resolve` to the `Router` type so it can be used in other applications like in `RouterLink`