### PR TITLE
Separate out type checking from the type tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,3 +26,15 @@ jobs:
 
       - name: Run unit tests
         run: npm run test:types
+
+  types:
+    name: Types
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Setup
+        id: setup
+        uses: kitbagjs/actions-setup-project@main
+
+      - name: Run tsc
+        run: npm run types

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "vitest",
     "test:types": "vitest typecheck",
     "lint": "eslint ./src",
-    "lint:fix": "eslint ./src --fix"
+    "lint:fix": "eslint ./src --fix",
+    "types": "tsc --noEmit"
   },
   "type": "module",
   "files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src/**/*.ts", "src/**/*.d.ts", "src/**/*.vue"],
+  "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,7 @@ import dts from 'vite-plugin-dts'
 export default defineConfig({
   test: {
     typecheck: {
-      checker: 'vue-tsc',
+      ignoreSourceErrors: true,
     },
     environmentMatchGlobs: [
       ['**\/*.browser.spec.ts', 'happy-dom'],


### PR DESCRIPTION
# Description
Better devx so test:types can run without picking up source errors. 