### PR TITLE
RFC: Implementation types for internal utilities

### DIFF
--- a/src/types/routeMethod.ts
+++ b/src/types/routeMethod.ts
@@ -11,6 +11,7 @@ export type RouteMethod<
     ? (params?: TParams) => RouteMethodResponse<TParams>
     : (params: TParams) => RouteMethodResponse<TParams>
 
+export type RouteMethodImplementation = (params?: Record<string, unknown>) => RouteMethodResponseImplementation
 
 export type RouteMethodOptions<
   TParams extends Record<string, unknown>
@@ -32,6 +33,12 @@ export type RouteMethodResponse<
   url: string,
   push: RouteMethodPush<TParams>,
   replace: RouteMethodReplace<TParams>,
+}
+
+export type RouteMethodResponseImplementation = {
+  url: string,
+  push: (options?: { params?: Record<string, unknown> } & RouterPushOptions) => Promise<void>,
+  replace: (options?: { params?: Record<string, unknown> } & RouterReplaceOptions) => Promise<void>,
 }
 
 export function isRouteMethodResponse(value: unknown): value is RouteMethodResponse {

--- a/src/types/routeMethods.ts
+++ b/src/types/routeMethods.ts
@@ -1,4 +1,4 @@
-import { RouteMethod, RouteMethodResponse } from '@/types/routeMethod'
+import { RouteMethod, RouteMethodImplementation, RouteMethodResponse } from '@/types/routeMethod'
 import { Public, Route, Routes } from '@/types/routes'
 import { Identity, TupleCanBeAllUndefined, UnionToIntersection } from '@/types/utilities'
 import { Path } from '@/utilities/path'
@@ -9,6 +9,10 @@ export type RouteMethods<
   TPathParams extends Record<string, unknown[]> = Record<never, never>,
   TQueryParams extends Record<string, unknown[]> = Record<never, never>
 > = UnionToIntersection<RouteMethodsTuple<TRoutes, TPathParams, TQueryParams>[number]>
+
+export type RouteMethodsImplementation = {
+  [key: string]: RouteMethodImplementation & Record<string, RouteMethodsImplementation>,
+}
 
 type RouteMethodsTuple<
   TRoutes extends Routes,

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -1,8 +1,8 @@
 import { App, DeepReadonly } from 'vue'
 import { Resolved } from '@/types/resolved'
-import { RouteMethods } from '@/types/routeMethods'
+import { RouteMethods, RouteMethodsImplementation } from '@/types/routeMethods'
 import { Route, Routes } from '@/types/routes'
-import { RouterPush, RouterPushOptions } from '@/utilities/createRouterPush'
+import { RouterPush, RouterPushImplementation, RouterPushOptions } from '@/utilities/createRouterPush'
 import { RouterResolve } from '@/utilities/createRouterResolve'
 
 export type RouterOptions = {
@@ -21,6 +21,18 @@ export type Router<
   route: DeepReadonly<Resolved<Route>>,
   resolve: RouterResolve,
   push: RouterPush<TRoutes>,
+  replace: RouterReplace,
+  back: () => void,
+  forward: () => void,
+  go: (delta: number) => void,
+  install: (app: App) => void,
+}
+
+export type RouterImplementation = {
+  routes: RouteMethodsImplementation,
+  route: DeepReadonly<Resolved<Route>>,
+  resolve: RouterResolve,
+  push: RouterPushImplementation,
   replace: RouterReplace,
   back: () => void,
   forward: () => void,

--- a/src/utilities/createRouteMethods.spec.ts
+++ b/src/utilities/createRouteMethods.spec.ts
@@ -19,7 +19,7 @@ test.each([
   ] as const satisfies Routes
   const resolved = resolveRoutes(routes)
 
-  const response = createRouteMethods<typeof routes>({ resolved, push })
+  const response = createRouteMethods({ resolved, push })
 
   if (isPublic !== false) {
     expect(response.parent).toBeTypeOf('function')
@@ -42,7 +42,7 @@ test('given route is NOT public, returns empty object', () => {
   ] as const satisfies Routes
   const resolved = resolveRoutes(routes)
 
-  const response = createRouteMethods<typeof routes>({ resolved, push })
+  const response = createRouteMethods({ resolved, push })
 
   expect(response).toMatchObject({})
 })
@@ -70,7 +70,7 @@ test.each([
   ] as const satisfies Routes
   const resolved = resolveRoutes(routes)
 
-  const response = createRouteMethods<typeof routes>({ resolved, push })
+  const response = createRouteMethods({ resolved, push })
 
   if (isPublic !== false) {
     expect(response.parent.child).toBeTypeOf('function')
@@ -103,7 +103,7 @@ test('given parent route with named children and grandchildren, has path to gran
   ] as const satisfies Routes
   const resolved = resolveRoutes(routes)
 
-  const response = createRouteMethods<typeof routes>({ resolved, push })
+  const response = createRouteMethods({ resolved, push })
 
   expect(response.parent).toBeTypeOf('function')
   expect(response.parent.child).toBeTypeOf('function')
@@ -122,7 +122,7 @@ describe('routeMethod', () => {
       },
     ] as const satisfies Routes
     const resolved = resolveRoutes(routes)
-    const { route } = createRouteMethods<typeof routes>({ resolved, push })
+    const { route } = createRouteMethods({ resolved, push })
 
     route().push()
     expect(push).toHaveBeenLastCalledWith('/route/', {})
@@ -148,7 +148,7 @@ describe('routeMethod', () => {
       },
     ] as const satisfies Routes
     const resolved = resolveRoutes(routes)
-    const { route } = createRouteMethods<typeof routes>({ resolved, push })
+    const { route } = createRouteMethods({ resolved, push })
 
     expect(route().url).toBe('/route/')
     expect(route({ param: 'param' }).url).toBe('/route/param')

--- a/src/utilities/createRouteMethods.ts
+++ b/src/utilities/createRouteMethods.ts
@@ -1,15 +1,15 @@
-import { Resolved, Route, RouteMethods, Routes, isPublicRoute } from '@/types'
-import { RouteMethod, RouteMethodPush, RouteMethodReplace } from '@/types/routeMethod'
-import { RouterPush } from '@/utilities/createRouterPush'
+import { Resolved, Route, RouteMethodImplementation, RouteMethodsImplementation, isPublicRoute } from '@/types'
+import { RouteMethodPush, RouteMethodReplace } from '@/types/routeMethod'
+import { RouterPushImplementation } from '@/utilities/createRouterPush'
 import { normalizeRouteParams } from '@/utilities/normalizeRouteParams'
 import { assembleUrl } from '@/utilities/urlAssembly'
 
-type RouteMethodsContext<T extends Routes> = {
+type RouteMethodsContext = {
   resolved: Resolved<Route>[],
-  push: RouterPush<T>,
+  push: RouterPushImplementation,
 }
 
-export function createRouteMethods<T extends Routes>({ resolved, push }: RouteMethodsContext<T>): RouteMethods<T> {
+export function createRouteMethods({ resolved, push }: RouteMethodsContext): RouteMethodsImplementation {
   const methods = resolved.reduce<Record<string, any>>((methods, route) => {
     let level = methods
 
@@ -21,7 +21,7 @@ export function createRouteMethods<T extends Routes>({ resolved, push }: RouteMe
       const isLeaf = match === route.matched
 
       if (isLeaf && isPublicRoute(route.matched)) {
-        const method = createRouteMethod<T>({ route, push })
+        const method = createRouteMethod({ route, push })
 
         level[route.name] = Object.assign(method, level[route.name])
         return
@@ -40,13 +40,13 @@ export function createRouteMethods<T extends Routes>({ resolved, push }: RouteMe
   return methods as any
 }
 
-type CreateRouteMethodArgs<T extends Routes> = {
+type CreateRouteMethodArgs = {
   route: Resolved<Route>,
-  push: RouterPush<T>,
+  push: RouterPushImplementation,
 }
 
-function createRouteMethod<T extends Routes>({ route, push: routerPush }: CreateRouteMethodArgs<T>): RouteMethod {
-  const node: RouteMethod = (params = {}) => {
+function createRouteMethod({ route, push: routerPush }: CreateRouteMethodArgs): RouteMethodImplementation {
+  return (params = {}) => {
     const normalizedParams = normalizeRouteParams(params)
     const url = assembleUrl(route, normalizedParams)
 
@@ -78,6 +78,4 @@ function createRouteMethod<T extends Routes>({ route, push: routerPush }: Create
       replace,
     }
   }
-
-  return node
 }

--- a/src/utilities/createRouteMethods.ts
+++ b/src/utilities/createRouteMethods.ts
@@ -10,7 +10,7 @@ type RouteMethodsContext = {
 }
 
 export function createRouteMethods({ resolved, push }: RouteMethodsContext): RouteMethodsImplementation {
-  const methods = resolved.reduce<Record<string, any>>((methods, route) => {
+  return resolved.reduce<Record<string, any>>((methods, route) => {
     let level = methods
 
     route.matches.forEach(match => {
@@ -36,8 +36,6 @@ export function createRouteMethods({ resolved, push }: RouteMethodsContext): Rou
 
     return methods
   }, {})
-
-  return methods as any
 }
 
 type CreateRouteMethodArgs = {

--- a/src/utilities/createRouter.ts
+++ b/src/utilities/createRouter.ts
@@ -1,6 +1,6 @@
 import { reactive, readonly, App, InjectionKey } from 'vue'
 import { RouterLink, RouterView } from '@/components'
-import { Resolved, Route, Routes, Router, RouterOptions, RegisteredRouter, RouterReplaceOptions } from '@/types'
+import { Resolved, Route, Routes, Router, RouterOptions, RegisteredRouter, RouterReplaceOptions, RouterImplementation } from '@/types'
 import { createRouteMethods, createRouterNavigation, resolveRoutes, routeMatch, getInitialUrl } from '@/utilities'
 import { createRouterPush } from '@/utilities/createRouterPush'
 import { createRouterResolve } from '@/utilities/createRouterResolve'
@@ -49,10 +49,11 @@ export function createRouter<T extends Routes>(routes: T, options: RouterOptions
   }
 
   const resolve = createRouterResolve({ resolved })
-  const push = createRouterPush<T>({ navigation, resolve })
+  const push = createRouterPush({ navigation, resolve })
+  const methods = createRouteMethods({ resolved, push })
 
-  const router = {
-    routes: createRouteMethods<T>({ resolved, push }),
+  const router: RouterImplementation = {
+    routes: methods,
     route: readonly(route),
     resolve,
     push,
@@ -63,5 +64,5 @@ export function createRouter<T extends Routes>(routes: T, options: RouterOptions
     install,
   }
 
-  return router
+  return router as any
 }

--- a/src/utilities/createRouterPush.spec.ts
+++ b/src/utilities/createRouterPush.spec.ts
@@ -10,7 +10,7 @@ test('push calls onLocationUpdated', () => {
   const navigation = createRouterNavigation({ onLocationUpdate })
   const resolved = resolveRoutes(routes)
   const resolve = createRouterResolve({ resolved })
-  const push = createRouterPush<typeof routes>({ navigation, resolve })
+  const push = createRouterPush({ navigation, resolve })
 
   push({ route: 'parentA', params: { paramA: '' } })
 

--- a/src/utilities/createRouterPush.ts
+++ b/src/utilities/createRouterPush.ts
@@ -1,4 +1,4 @@
-import { RouteMethod, RouteMethods, Routes } from '@/types'
+import { RouteMethod, RouteMethodResponseImplementation, RouteMethods, Routes } from '@/types'
 import { ExtractRoutePathParameters, RoutePaths } from '@/types/routePaths'
 import { RouterResolve } from '@/utilities/createRouterResolve'
 import { RouterNavigation } from '@/utilities/routerNavigation'
@@ -22,14 +22,15 @@ export type RouterPush<
   TRoutePath extends string
 >(source: string | RouteWithParams<TRoutes, TRoutePath> | ReturnType<RouteMethod>, options?: RouterPushOptions) => Promise<void>
 
+type RouteWithParamsImplementation = { route: string, params?: Record<string, unknown> }
+export type RouterPushImplementation = (source: string | RouteWithParamsImplementation | RouteMethodResponseImplementation, options?: RouterPushOptions) => Promise<void>
+
 type RouterPushContext = {
   navigation: RouterNavigation,
   resolve: RouterResolve,
 }
 
-export function createRouterPush<
-  TRoutes extends Routes
->({ navigation, resolve }: RouterPushContext): RouterPush<TRoutes> {
+export function createRouterPush({ navigation, resolve }: RouterPushContext): RouterPushImplementation {
   return (source, options) => {
     const url = resolve(source as any)
 

--- a/src/utilities/createRouterPush.ts
+++ b/src/utilities/createRouterPush.ts
@@ -32,7 +32,7 @@ type RouterPushContext = {
 
 export function createRouterPush({ navigation, resolve }: RouterPushContext): RouterPushImplementation {
   return (source, options) => {
-    const url = resolve(source as any)
+    const url = resolve(source)
 
     return navigation.update(url, options)
   }


### PR DESCRIPTION
# Description
Adding more general implementation types for internal utilities so that we don't have to pass so many generics around. I think this will make development and testing simpler. 

I'm not attached to this idea. But it felt kinda nice when making these changes. 

The idea is that internal utilities like `createRouteMethods`, and `createRouterPush` return wider `Implementation` types that don't use generics. I think this means there will be less typescript depth but not totally sure. Either way several methods got simpler. 