### PR TITLE
Simplify `Resolved<T>` type to `ResolvedRoute`

### DIFF
--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -1,11 +1,11 @@
-import { Resolved } from '@/types/resolved'
+import { ResolvedRoute } from '@/types/resolved'
 import { MaybePromise } from '@/types/utilities'
 import { RegisteredRouterPush } from '@/utilities/createRouterPush'
 import { RouterReject } from '@/utilities/createRouterReject'
 import { RegisteredRouterReplace } from '@/utilities/createRouterReplace'
 
 type MiddlewareContext = {
-  from: Resolved | null,
+  from: ResolvedRoute | null,
   // state: RegisteredRouterState,
   reject: RouterReject,
   push: RegisteredRouterPush,
@@ -14,4 +14,4 @@ type MiddlewareContext = {
   // router: RegisteredRouter,
 }
 
-export type RouteMiddleware = (route: Resolved, context: MiddlewareContext) => MaybePromise<void>
+export type RouteMiddleware = (route: ResolvedRoute, context: MiddlewareContext) => MaybePromise<void>

--- a/src/types/middleware.ts
+++ b/src/types/middleware.ts
@@ -1,12 +1,11 @@
 import { Resolved } from '@/types/resolved'
-import { Route } from '@/types/routes'
 import { MaybePromise } from '@/types/utilities'
 import { RegisteredRouterPush } from '@/utilities/createRouterPush'
 import { RouterReject } from '@/utilities/createRouterReject'
 import { RegisteredRouterReplace } from '@/utilities/createRouterReplace'
 
 type MiddlewareContext = {
-  from: Resolved<Route> | null,
+  from: Resolved | null,
   // state: RegisteredRouterState,
   reject: RouterReject,
   push: RegisteredRouterPush,
@@ -15,4 +14,4 @@ type MiddlewareContext = {
   // router: RegisteredRouter,
 }
 
-export type RouteMiddleware = (route: Resolved<Route>, context: MiddlewareContext) => MaybePromise<void>
+export type RouteMiddleware = (route: Resolved, context: MiddlewareContext) => MaybePromise<void>

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -1,8 +1,8 @@
 import { Param } from '@/types/params'
 import { Route } from '@/types/routes'
 
-export type Resolved<T extends Route> = {
-  matched: T,
+export type Resolved = {
+  matched: Route,
   matches: Route[],
   name: string,
   path: string,

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -1,9 +1,6 @@
 import { Param } from '@/types/params'
 import { Route } from '@/types/routes'
 
-export const isRejectionSymbol = Symbol()
-export const routeDepthSymbol = Symbol()
-
 export type Resolved<T extends Route> = {
   matched: T,
   matches: Route[],
@@ -11,6 +8,6 @@ export type Resolved<T extends Route> = {
   path: string,
   query: string,
   params: Record<string, Param[]>,
-  [routeDepthSymbol]: number,
-  [isRejectionSymbol]?: true,
+  depth: number,
+  isRejection: boolean,
 }

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -1,7 +1,7 @@
 import { Param } from '@/types/params'
 import { Route } from '@/types/routes'
 
-export type Resolved = {
+export type ResolvedRoute = {
   matched: Route,
   matches: Route[],
   name: string,

--- a/src/types/routeMatchRule.ts
+++ b/src/types/routeMatchRule.ts
@@ -1,3 +1,3 @@
-import { Resolved } from '@/types/resolved'
+import { ResolvedRoute } from '@/types/resolved'
 
-export type RouteMatchRule = (route: Resolved, url: string) => boolean
+export type RouteMatchRule = (route: ResolvedRoute, url: string) => boolean

--- a/src/types/routeMatchRule.ts
+++ b/src/types/routeMatchRule.ts
@@ -1,4 +1,3 @@
 import { Resolved } from '@/types/resolved'
-import { Route } from '@/types/routes'
 
-export type RouteMatchRule = (route: Resolved<Route>, url: string) => boolean
+export type RouteMatchRule = (route: Resolved, url: string) => boolean

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -1,7 +1,7 @@
 import { App } from 'vue'
 import { Resolved } from '@/types/resolved'
 import { RouteMethods, RouteMethodsImplementation } from '@/types/routeMethods'
-import { Route, Routes } from '@/types/routes'
+import { Routes } from '@/types/routes'
 import { RouterPush, RouterPushImplementation } from '@/utilities/createRouterPush'
 import { RouterReject, RouterRejectionComponents } from '@/utilities/createRouterReject'
 import { RouterReplace, RouterReplaceImplementation } from '@/utilities/createRouterReplace'
@@ -15,7 +15,7 @@ export type Router<
   TRoutes extends Routes = []
 > = {
   routes: RouteMethods<TRoutes>,
-  route: Resolved<Route>,
+  route: Resolved,
   resolve: RouterResolve<TRoutes>,
   push: RouterPush<TRoutes>,
   replace: RouterReplace<TRoutes>,
@@ -30,7 +30,7 @@ export type Router<
 
 export type RouterImplementation = {
   routes: RouteMethodsImplementation,
-  route: Resolved<Route>,
+  route: Resolved,
   resolve: RouterResolveImplementation,
   push: RouterPushImplementation,
   replace: RouterReplaceImplementation,

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -1,5 +1,5 @@
 import { App } from 'vue'
-import { Resolved } from '@/types/resolved'
+import { ResolvedRoute } from '@/types/resolved'
 import { RouteMethods, RouteMethodsImplementation } from '@/types/routeMethods'
 import { Routes } from '@/types/routes'
 import { RouterPush, RouterPushImplementation } from '@/utilities/createRouterPush'
@@ -15,7 +15,7 @@ export type Router<
   TRoutes extends Routes = []
 > = {
   routes: RouteMethods<TRoutes>,
-  route: Resolved,
+  route: ResolvedRoute,
   resolve: RouterResolve<TRoutes>,
   push: RouterPush<TRoutes>,
   replace: RouterReplace<TRoutes>,
@@ -30,7 +30,7 @@ export type Router<
 
 export type RouterImplementation = {
   routes: RouteMethodsImplementation,
-  route: Resolved,
+  route: ResolvedRoute,
   resolve: RouterResolveImplementation,
   push: RouterPushImplementation,
   replace: RouterReplaceImplementation,

--- a/src/utilities/createResolvedRoute.ts
+++ b/src/utilities/createResolvedRoute.ts
@@ -1,5 +1,5 @@
 import { markRaw } from 'vue'
-import { Route, Param, Resolved, routeDepthSymbol, isRejectionSymbol } from '@/types'
+import { Route, Param, Resolved } from '@/types'
 
 type ResolvedRouteProperties<T extends Route> = {
   matched: T,
@@ -9,7 +9,7 @@ type ResolvedRouteProperties<T extends Route> = {
   query: string,
   params: Record<string, Param[]>,
   depth: number,
-  isRejection?: true,
+  isRejection: boolean,
 }
 
 export function createResolvedRoute<T extends Route>(route: ResolvedRouteProperties<T>): Resolved<T> {
@@ -20,15 +20,7 @@ export function createResolvedRoute<T extends Route>(route: ResolvedRoutePropert
     path: route.path,
     query: route.query,
     params: route.params,
-    [routeDepthSymbol]: route.depth,
-    [isRejectionSymbol]: route.isRejection,
+    depth: route.depth,
+    isRejection: route.isRejection,
   }
-}
-
-export function getRouteIsRejection(route: Resolved<Route>): boolean {
-  return Boolean(route[isRejectionSymbol])
-}
-
-export function getRouteDepth(route: Resolved<Route>): number {
-  return route[routeDepthSymbol]
 }

--- a/src/utilities/createResolvedRoute.ts
+++ b/src/utilities/createResolvedRoute.ts
@@ -1,8 +1,8 @@
 import { markRaw } from 'vue'
 import { Route, Param, Resolved } from '@/types'
 
-type ResolvedRouteProperties<T extends Route> = {
-  matched: T,
+type ResolvedRouteProperties = {
+  matched: Route,
   matches: Route[],
   name: string,
   path: string,
@@ -12,7 +12,7 @@ type ResolvedRouteProperties<T extends Route> = {
   isRejection: boolean,
 }
 
-export function createResolvedRoute<T extends Route>(route: ResolvedRouteProperties<T>): Resolved<T> {
+export function createResolvedRoute(route: ResolvedRouteProperties): Resolved {
   return {
     matched: markRaw(route.matched),
     matches: markRaw(route.matches),

--- a/src/utilities/createResolvedRoute.ts
+++ b/src/utilities/createResolvedRoute.ts
@@ -1,5 +1,5 @@
 import { markRaw } from 'vue'
-import { Route, Param, Resolved } from '@/types'
+import { Route, Param, ResolvedRoute } from '@/types'
 
 type ResolvedRouteProperties = {
   matched: Route,
@@ -12,7 +12,7 @@ type ResolvedRouteProperties = {
   isRejection: boolean,
 }
 
-export function createResolvedRoute(route: ResolvedRouteProperties): Resolved {
+export function createResolvedRoute(route: ResolvedRouteProperties): ResolvedRoute {
   return {
     matched: markRaw(route.matched),
     matches: markRaw(route.matches),

--- a/src/utilities/createRouteMethods.ts
+++ b/src/utilities/createRouteMethods.ts
@@ -1,11 +1,11 @@
-import { Resolved, Route, RouteMethodImplementation, RouteMethodsImplementation, isDisabledRoute } from '@/types'
+import { Resolved, RouteMethodImplementation, RouteMethodsImplementation, isDisabledRoute } from '@/types'
 import { RouteMethodPush, RouteMethodReplace } from '@/types/routeMethod'
 import { RouterPushImplementation } from '@/utilities/createRouterPush'
 import { normalizeRouteParams } from '@/utilities/normalizeRouteParams'
 import { assembleUrl } from '@/utilities/urlAssembly'
 
 type RouteMethodsContext = {
-  resolved: Resolved<Route>[],
+  resolved: Resolved[],
   push: RouterPushImplementation,
 }
 
@@ -39,7 +39,7 @@ export function createRouteMethods({ resolved, push }: RouteMethodsContext): Rou
 }
 
 type CreateRouteMethodArgs = {
-  route: Resolved<Route>,
+  route: Resolved,
   push: RouterPushImplementation,
 }
 

--- a/src/utilities/createRouteMethods.ts
+++ b/src/utilities/createRouteMethods.ts
@@ -1,11 +1,11 @@
-import { Resolved, RouteMethodImplementation, RouteMethodsImplementation, isDisabledRoute } from '@/types'
+import { ResolvedRoute, RouteMethodImplementation, RouteMethodsImplementation, isDisabledRoute } from '@/types'
 import { RouteMethodPush, RouteMethodReplace } from '@/types/routeMethod'
 import { RouterPushImplementation } from '@/utilities/createRouterPush'
 import { normalizeRouteParams } from '@/utilities/normalizeRouteParams'
 import { assembleUrl } from '@/utilities/urlAssembly'
 
 type RouteMethodsContext = {
-  resolved: Resolved[],
+  resolved: ResolvedRoute[],
   push: RouterPushImplementation,
 }
 
@@ -39,7 +39,7 @@ export function createRouteMethods({ resolved, push }: RouteMethodsContext): Rou
 }
 
 type CreateRouteMethodArgs = {
-  route: Resolved,
+  route: ResolvedRoute,
   push: RouterPushImplementation,
 }
 

--- a/src/utilities/createRouter.ts
+++ b/src/utilities/createRouter.ts
@@ -4,7 +4,6 @@ import { routerInjectionKey, routerRejectionKey } from '@/compositions'
 import { Routes, Router, RouterOptions, RouterImplementation } from '@/types'
 import { RouterPushError, RouterRejectionError, RouterReplaceError } from '@/types/errors'
 import { createRouteMethods, createRouterNavigation, resolveRoutes } from '@/utilities'
-import { getRouteIsRejection } from '@/utilities/createResolvedRoute'
 import { createRouterPush } from '@/utilities/createRouterPush'
 import { createRouterReject } from '@/utilities/createRouterReject'
 import { createRouterReplace } from '@/utilities/createRouterReplace'
@@ -28,7 +27,7 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
     try {
       await executeMiddleware({
         to: matched,
-        from: getRouteIsRejection(route) ? null : route,
+        from: route.isRejection ? null : route,
       })
     } catch (error) {
       if (error instanceof RouterRejectionError) {

--- a/src/utilities/createRouterReject.ts
+++ b/src/utilities/createRouterReject.ts
@@ -1,6 +1,6 @@
 import { Ref, markRaw, ref } from 'vue'
 import { NotFound } from '@/components'
-import { RegisteredRejectionType, Resolved, RouteComponent } from '@/types'
+import { RegisteredRejectionType, ResolvedRoute, RouteComponent } from '@/types'
 import { createResolvedRoute } from '@/utilities/createResolvedRoute'
 
 export const builtInRejections = ['NotFound'] as const
@@ -20,7 +20,7 @@ export type RouterRejectionComponents = RegisteredRejectionType extends never
 
 export type RouterReject = (type: RouterRejectionType) => void
 
-type GetRejectionRoute = (type: RouterRejectionType) => Resolved
+type GetRejectionRoute = (type: RouterRejectionType) => ResolvedRoute
 type ClearRejection = () => void
 export type RouterRejection = Ref<null | { type: RouterRejectionType, component: RouteComponent }>
 

--- a/src/utilities/createRouterReject.ts
+++ b/src/utilities/createRouterReject.ts
@@ -1,6 +1,6 @@
 import { Ref, markRaw, ref } from 'vue'
 import { NotFound } from '@/components'
-import { RegisteredRejectionType, Resolved, Route, RouteComponent } from '@/types'
+import { RegisteredRejectionType, Resolved, RouteComponent } from '@/types'
 import { createResolvedRoute } from '@/utilities/createResolvedRoute'
 
 export const builtInRejections = ['NotFound'] as const
@@ -20,7 +20,7 @@ export type RouterRejectionComponents = RegisteredRejectionType extends never
 
 export type RouterReject = (type: RouterRejectionType) => void
 
-type GetRejectionRoute = (type: RouterRejectionType) => Resolved<Route>
+type GetRejectionRoute = (type: RouterRejectionType) => Resolved
 type ClearRejection = () => void
 export type RouterRejection = Ref<null | { type: RouterRejectionType, component: RouteComponent }>
 

--- a/src/utilities/createRouterResolve.ts
+++ b/src/utilities/createRouterResolve.ts
@@ -1,4 +1,4 @@
-import { Resolved, RouteMethod, RouteMethodResponseImplementation, Routes, isRouteMethodResponse } from '@/types'
+import { ResolvedRoute, RouteMethod, RouteMethodResponseImplementation, Routes, isRouteMethodResponse } from '@/types'
 import { RouteWithParams, RouteWithParamsImplementation } from '@/types/routeWithParams'
 import { isRecord } from '@/utilities/guards'
 import { normalizeRouteParams } from '@/utilities/normalizeRouteParams'
@@ -6,7 +6,7 @@ import { getRoutePath } from '@/utilities/routes'
 import { assembleUrl } from '@/utilities/urlAssembly'
 
 type RouterResolveContext = {
-  resolved: Resolved[],
+  resolved: ResolvedRoute[],
 }
 
 export type RouterResolve<

--- a/src/utilities/createRouterResolve.ts
+++ b/src/utilities/createRouterResolve.ts
@@ -1,4 +1,4 @@
-import { Resolved, Route, RouteMethod, RouteMethodResponseImplementation, Routes, isRouteMethodResponse } from '@/types'
+import { Resolved, RouteMethod, RouteMethodResponseImplementation, Routes, isRouteMethodResponse } from '@/types'
 import { RouteWithParams, RouteWithParamsImplementation } from '@/types/routeWithParams'
 import { isRecord } from '@/utilities/guards'
 import { normalizeRouteParams } from '@/utilities/normalizeRouteParams'
@@ -6,7 +6,7 @@ import { getRoutePath } from '@/utilities/routes'
 import { assembleUrl } from '@/utilities/urlAssembly'
 
 type RouterResolveContext = {
-  resolved: Resolved<Route>[],
+  resolved: Resolved[],
 }
 
 export type RouterResolve<

--- a/src/utilities/createRouterRoute.ts
+++ b/src/utilities/createRouterRoute.ts
@@ -1,15 +1,15 @@
 import { reactive } from 'vue'
-import { Resolved, Route } from '@/types'
+import { Resolved } from '@/types'
 
-type RouterRouteUpdate = (matched: Resolved<Route>) => void
+type RouterRouteUpdate = (matched: Resolved) => void
 
 type RouterRoute = {
-  route: Resolved<Route>,
+  route: Resolved,
   updateRoute: RouterRouteUpdate,
 }
 
-export function createRouterRoute(fallbackRoute: Resolved<Route>): RouterRoute {
-  const route = reactive<Resolved<Route>>(fallbackRoute)
+export function createRouterRoute(fallbackRoute: Resolved): RouterRoute {
+  const route = reactive<Resolved>(fallbackRoute)
 
   const updateRoute: RouterRouteUpdate = (newRoute) => {
     Object.assign(route, newRoute)

--- a/src/utilities/createRouterRoute.ts
+++ b/src/utilities/createRouterRoute.ts
@@ -1,15 +1,15 @@
 import { reactive } from 'vue'
-import { Resolved } from '@/types'
+import { ResolvedRoute } from '@/types'
 
-type RouterRouteUpdate = (matched: Resolved) => void
+type RouterRouteUpdate = (matched: ResolvedRoute) => void
 
 type RouterRoute = {
-  route: Resolved,
+  route: ResolvedRoute,
   updateRoute: RouterRouteUpdate,
 }
 
-export function createRouterRoute(fallbackRoute: Resolved): RouterRoute {
-  const route = reactive<Resolved>(fallbackRoute)
+export function createRouterRoute(fallbackRoute: ResolvedRoute): RouterRoute {
+  const route = reactive<ResolvedRoute>(fallbackRoute)
 
   const updateRoute: RouterRouteUpdate = (newRoute) => {
     Object.assign(route, newRoute)

--- a/src/utilities/middleware.ts
+++ b/src/utilities/middleware.ts
@@ -1,4 +1,4 @@
-import { Resolved, Route } from '@/types'
+import { Resolved } from '@/types'
 import { RouterPushError, RouterRejectionError, RouterReplaceError } from '@/types/errors'
 import { RouterPushImplementation } from '@/utilities/createRouterPush'
 import { RouterReject } from '@/utilities/createRouterReject'
@@ -6,8 +6,8 @@ import { RouterReplaceImplementation } from '@/utilities/createRouterReplace'
 import { getRouteMiddleware } from '@/utilities/routes'
 
 type ExecuteMiddlewareContext = {
-  to: Resolved<Route>,
-  from: Resolved<Route> | null,
+  to: Resolved,
+  from: Resolved | null,
 }
 
 export async function executeMiddleware({ to, from }: ExecuteMiddlewareContext): Promise<void> {

--- a/src/utilities/middleware.ts
+++ b/src/utilities/middleware.ts
@@ -1,4 +1,4 @@
-import { Resolved } from '@/types'
+import { ResolvedRoute } from '@/types'
 import { RouterPushError, RouterRejectionError, RouterReplaceError } from '@/types/errors'
 import { RouterPushImplementation } from '@/utilities/createRouterPush'
 import { RouterReject } from '@/utilities/createRouterReject'
@@ -6,8 +6,8 @@ import { RouterReplaceImplementation } from '@/utilities/createRouterReplace'
 import { getRouteMiddleware } from '@/utilities/routes'
 
 type ExecuteMiddlewareContext = {
-  to: Resolved,
-  from: Resolved | null,
+  to: ResolvedRoute,
+  from: ResolvedRoute | null,
 }
 
 export async function executeMiddleware({ to, from }: ExecuteMiddlewareContext): Promise<void> {

--- a/src/utilities/resolveRoutes.spec.ts
+++ b/src/utilities/resolveRoutes.spec.ts
@@ -1,7 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { Route, Routes } from '@/types'
 import { resolveRoutes, path, query } from '@/utilities'
-import { getRouteDepth } from '@/utilities/createResolvedRoute'
 import { component } from '@/utilities/testHelpers'
 
 describe('resolveRoutes', () => {
@@ -165,16 +164,16 @@ describe('resolveRoutes', () => {
     const response = resolveRoutes(routes)
 
     const resolvedAccountsRoute = response.find(route => route.name === 'accounts')
-    expect(getRouteDepth(resolvedAccountsRoute!)).toBe(1)
+    expect(resolvedAccountsRoute!.depth).toBe(1)
 
     const resolvedNewAccountRoute = response.find(route => route.name === 'new-account')
-    expect(getRouteDepth(resolvedNewAccountRoute!)).toBe(2)
+    expect(resolvedNewAccountRoute!.depth).toBe(2)
 
     const resolvedAccountRoute = response.find(route => route.name === 'account')
-    expect(getRouteDepth(resolvedAccountRoute!)).toBe(2)
+    expect(resolvedAccountRoute!.depth).toBe(2)
 
     const resolvedEditAccountRoute = response.find(route => route.name === 'edit-account')
-    expect(getRouteDepth(resolvedEditAccountRoute!)).toBe(3)
+    expect(resolvedEditAccountRoute!.depth).toBe(3)
   })
 
   describe('matches', () => {

--- a/src/utilities/resolveRoutes.ts
+++ b/src/utilities/resolveRoutes.ts
@@ -9,10 +9,10 @@ type ParentContext = {
   parentDepth?: number,
 }
 
-export function resolveRoutes(routes: Routes, parentContext: ParentContext = {}): Resolved<Route>[] {
+export function resolveRoutes(routes: Routes, parentContext: ParentContext = {}): Resolved[] {
   const { parentPath = [], parentQuery = [], parentMatches = [], parentDepth = 0 } = { ...parentContext }
 
-  return routes.reduce<Resolved<Route>[]>((value, route) => {
+  return routes.reduce<Resolved[]>((value, route) => {
     const path = typeof route.path === 'string' ? createPath(route.path, {}) : route.path
     const query = typeof route.query === 'string' ? createQuery(route.query, {}) : route.query ?? { query: '', params: {} }
 

--- a/src/utilities/resolveRoutes.ts
+++ b/src/utilities/resolveRoutes.ts
@@ -40,6 +40,7 @@ export function resolveRoutes(routes: Routes, parentContext: ParentContext = {})
         query: fullQuery.map(({ query }) => query.toString()).join('&'),
         params: mergeParams(reduceParams(fullPath), reduceParams(fullQuery)),
         depth: parentDepth + 1,
+        isRejection: false,
       })
 
       value.push(resolved)

--- a/src/utilities/resolveRoutes.ts
+++ b/src/utilities/resolveRoutes.ts
@@ -1,4 +1,4 @@
-import { Resolved, Routes, isParentRoute, isNamedRoute, Route, Param } from '@/types'
+import { ResolvedRoute, Routes, isParentRoute, isNamedRoute, Route, Param } from '@/types'
 import { mergeParams, path as createPath, query as createQuery, Query, Path } from '@/utilities'
 import { createResolvedRoute } from '@/utilities/createResolvedRoute'
 
@@ -9,10 +9,10 @@ type ParentContext = {
   parentDepth?: number,
 }
 
-export function resolveRoutes(routes: Routes, parentContext: ParentContext = {}): Resolved[] {
+export function resolveRoutes(routes: Routes, parentContext: ParentContext = {}): ResolvedRoute[] {
   const { parentPath = [], parentQuery = [], parentMatches = [], parentDepth = 0 } = { ...parentContext }
 
-  return routes.reduce<Resolved[]>((value, route) => {
+  return routes.reduce<ResolvedRoute[]>((value, route) => {
     const path = typeof route.path === 'string' ? createPath(route.path, {}) : route.path
     const query = typeof route.query === 'string' ? createQuery(route.query, {}) : route.query ?? { query: '', params: {} }
 

--- a/src/utilities/routeMatch.browser.spec.ts
+++ b/src/utilities/routeMatch.browser.spec.ts
@@ -139,7 +139,7 @@ test('given route with simple string query param WITHOUT value present, returns 
 
 test('given route with equal matches, returns route with highest score', () => {
   vi.spyOn(utilities, 'getRouteScoreSortMethod').mockImplementation(() => {
-    return (route: Resolved<Route>) => {
+    return (route: Resolved) => {
       return route.name === 'second-route' ? -1 : +1
     }
   })

--- a/src/utilities/routeMatch.browser.spec.ts
+++ b/src/utilities/routeMatch.browser.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, vi } from 'vitest'
-import { ResolvedRoute, Route, Routes } from '@/types'
+import { ResolvedRoute, Routes } from '@/types'
 import { resolveRoutes } from '@/utilities/resolveRoutes'
 import { routeMatch } from '@/utilities/routeMatch'
 import * as utilities from '@/utilities/routeMatchScore'

--- a/src/utilities/routeMatch.browser.spec.ts
+++ b/src/utilities/routeMatch.browser.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test, vi } from 'vitest'
-import { Resolved, Route, Routes } from '@/types'
+import { ResolvedRoute, Route, Routes } from '@/types'
 import { resolveRoutes } from '@/utilities/resolveRoutes'
 import { routeMatch } from '@/utilities/routeMatch'
 import * as utilities from '@/utilities/routeMatchScore'
@@ -139,7 +139,7 @@ test('given route with simple string query param WITHOUT value present, returns 
 
 test('given route with equal matches, returns route with highest score', () => {
   vi.spyOn(utilities, 'getRouteScoreSortMethod').mockImplementation(() => {
-    return (route: Resolved) => {
+    return (route: ResolvedRoute) => {
       return route.name === 'second-route' ? -1 : +1
     }
   })

--- a/src/utilities/routeMatch.ts
+++ b/src/utilities/routeMatch.ts
@@ -1,10 +1,9 @@
-import { Route } from '@/types'
 import { Resolved } from '@/types/resolved'
 import { routeParamsAreValid } from '@/utilities/paramValidation'
 import { routePathMatches, routeQueryMatches } from '@/utilities/routeMatchRegexRules'
 import { getRouteScoreSortMethod } from '@/utilities/routeMatchScore'
 
-export function routeMatch(routes: Resolved<Route>[], url: string): Resolved<Route> | undefined {
+export function routeMatch(routes: Resolved[], url: string): Resolved | undefined {
   const rules = [routePathMatches, routeQueryMatches, routeParamsAreValid]
   const sortByRouteScore = getRouteScoreSortMethod(url)
 

--- a/src/utilities/routeMatch.ts
+++ b/src/utilities/routeMatch.ts
@@ -1,9 +1,9 @@
-import { Resolved } from '@/types/resolved'
+import { ResolvedRoute } from '@/types/resolved'
 import { routeParamsAreValid } from '@/utilities/paramValidation'
 import { routePathMatches, routeQueryMatches } from '@/utilities/routeMatchRegexRules'
 import { getRouteScoreSortMethod } from '@/utilities/routeMatchScore'
 
-export function routeMatch(routes: Resolved[], url: string): Resolved | undefined {
+export function routeMatch(routes: ResolvedRoute[], url: string): ResolvedRoute | undefined {
   const rules = [routePathMatches, routeQueryMatches, routeParamsAreValid]
   const sortByRouteScore = getRouteScoreSortMethod(url)
 

--- a/src/utilities/routeMatchScore.ts
+++ b/src/utilities/routeMatchScore.ts
@@ -1,7 +1,7 @@
-import { Resolved, Route } from '@/types'
+import { Resolved } from '@/types'
 import { createMaybeRelativeUrl } from '@/utilities'
 
-type RouteSortMethod = (aRoute: Resolved<Route>, bRoute: Resolved<Route>) => number
+type RouteSortMethod = (aRoute: Resolved, bRoute: Resolved) => number
 
 export function getRouteScoreSortMethod(url: string): RouteSortMethod {
   const { searchParams: actualQuery } = createMaybeRelativeUrl(url)
@@ -30,7 +30,7 @@ export function getRouteScoreSortMethod(url: string): RouteSortMethod {
   }
 }
 
-export function countExpectedQueryKeys(route: Resolved<Route>, actualQuery: URLSearchParams): number {
+export function countExpectedQueryKeys(route: Resolved, actualQuery: URLSearchParams): number {
   const expectedQuery = new URLSearchParams(route.query)
   const expectedQueryKeys = Array.from(expectedQuery.keys())
 

--- a/src/utilities/routeMatchScore.ts
+++ b/src/utilities/routeMatchScore.ts
@@ -1,6 +1,5 @@
 import { Resolved, Route } from '@/types'
 import { createMaybeRelativeUrl } from '@/utilities'
-import { getRouteDepth } from '@/utilities/createResolvedRoute'
 
 type RouteSortMethod = (aRoute: Resolved<Route>, bRoute: Resolved<Route>) => number
 
@@ -20,10 +19,10 @@ export function getRouteScoreSortMethod(url: string): RouteSortMethod {
       return sortAfter
     }
 
-    if (getRouteDepth(aRoute) > getRouteDepth(bRoute)) {
+    if (aRoute.depth > bRoute.depth) {
       return sortBefore
     }
-    if (getRouteDepth(aRoute) < getRouteDepth(bRoute)) {
+    if (aRoute.depth < bRoute.depth) {
       return sortAfter
     }
 

--- a/src/utilities/routeMatchScore.ts
+++ b/src/utilities/routeMatchScore.ts
@@ -1,7 +1,7 @@
-import { Resolved } from '@/types'
+import { ResolvedRoute } from '@/types'
 import { createMaybeRelativeUrl } from '@/utilities'
 
-type RouteSortMethod = (aRoute: Resolved, bRoute: Resolved) => number
+type RouteSortMethod = (aRoute: ResolvedRoute, bRoute: ResolvedRoute) => number
 
 export function getRouteScoreSortMethod(url: string): RouteSortMethod {
   const { searchParams: actualQuery } = createMaybeRelativeUrl(url)
@@ -30,7 +30,7 @@ export function getRouteScoreSortMethod(url: string): RouteSortMethod {
   }
 }
 
-export function countExpectedQueryKeys(route: Resolved, actualQuery: URLSearchParams): number {
+export function countExpectedQueryKeys(route: ResolvedRoute, actualQuery: URLSearchParams): number {
   const expectedQuery = new URLSearchParams(route.query)
   const expectedQueryKeys = Array.from(expectedQuery.keys())
 

--- a/src/utilities/routeRegex.ts
+++ b/src/utilities/routeRegex.ts
@@ -1,12 +1,12 @@
-import { Resolved } from '@/types'
+import { ResolvedRoute } from '@/types'
 
-export function generateRoutePathRegexPattern(route: Resolved): RegExp {
+export function generateRoutePathRegexPattern(route: ResolvedRoute): RegExp {
   const routeRegex = replaceParamSyntaxWithCatchAlls(route.path)
 
   return new RegExp(`^${routeRegex}$`, 'i')
 }
 
-export function generateRouteQueryRegexPatterns(route: Resolved): RegExp[] {
+export function generateRouteQueryRegexPatterns(route: ResolvedRoute): RegExp[] {
   const queryParams = new URLSearchParams(route.query)
 
   return Array

--- a/src/utilities/routeRegex.ts
+++ b/src/utilities/routeRegex.ts
@@ -1,12 +1,12 @@
-import { Resolved, Route } from '@/types'
+import { Resolved } from '@/types'
 
-export function generateRoutePathRegexPattern(route: Resolved<Route>): RegExp {
+export function generateRoutePathRegexPattern(route: Resolved): RegExp {
   const routeRegex = replaceParamSyntaxWithCatchAlls(route.path)
 
   return new RegExp(`^${routeRegex}$`, 'i')
 }
 
-export function generateRouteQueryRegexPatterns(route: Resolved<Route>): RegExp[] {
+export function generateRouteQueryRegexPatterns(route: Resolved): RegExp[] {
   const queryParams = new URLSearchParams(route.query)
 
   return Array

--- a/src/utilities/routes.ts
+++ b/src/utilities/routes.ts
@@ -1,14 +1,14 @@
-import { MaybeDeepReadonly, Resolved, RouteMiddleware, isNamedRoute } from '@/types'
+import { MaybeDeepReadonly, ResolvedRoute, RouteMiddleware, isNamedRoute } from '@/types'
 import { asArray } from '@/utilities/array'
 
-export function getRoutePath(route: Resolved): string {
+export function getRoutePath(route: ResolvedRoute): string {
   return route.matches
     .filter(route => isNamedRoute(route))
     .map(route => route.name)
     .join('.')
 }
 
-export function getRouteMiddleware(route: MaybeDeepReadonly<Resolved>): Readonly<RouteMiddleware[]> {
+export function getRouteMiddleware(route: MaybeDeepReadonly<ResolvedRoute>): Readonly<RouteMiddleware[]> {
   return route.matches.flatMap(route => {
     if (!route.middleware) {
       return []

--- a/src/utilities/routes.ts
+++ b/src/utilities/routes.ts
@@ -1,14 +1,14 @@
-import { MaybeDeepReadonly, Resolved, Route, RouteMiddleware, isNamedRoute } from '@/types'
+import { MaybeDeepReadonly, Resolved, RouteMiddleware, isNamedRoute } from '@/types'
 import { asArray } from '@/utilities/array'
 
-export function getRoutePath(route: Resolved<Route>): string {
+export function getRoutePath(route: Resolved): string {
   return route.matches
     .filter(route => isNamedRoute(route))
     .map(route => route.name)
     .join('.')
 }
 
-export function getRouteMiddleware(route: MaybeDeepReadonly<Resolved<Route>>): Readonly<RouteMiddleware[]> {
+export function getRouteMiddleware(route: MaybeDeepReadonly<Resolved>): Readonly<RouteMiddleware[]> {
   return route.matches.flatMap(route => {
     if (!route.middleware) {
       return []

--- a/src/utilities/urlAssembly.ts
+++ b/src/utilities/urlAssembly.ts
@@ -1,7 +1,7 @@
-import { Param, Resolved, Route } from '@/types'
+import { Param, Resolved } from '@/types'
 import { setParamValuesOnUrl } from '@/utilities/paramsFinder'
 
-export function assembleUrl(route: Resolved<Route>, values: Record<string, unknown[]> = {}): string {
+export function assembleUrl(route: Resolved, values: Record<string, unknown[]> = {}): string {
   const params = Object.entries<Param[]>(route.params)
   const pathWithQuery = route.query.length ? `${route.path}?${route.query}` : route.path
 

--- a/src/utilities/urlAssembly.ts
+++ b/src/utilities/urlAssembly.ts
@@ -1,7 +1,7 @@
-import { Param, Resolved } from '@/types'
+import { Param, ResolvedRoute } from '@/types'
 import { setParamValuesOnUrl } from '@/utilities/paramsFinder'
 
-export function assembleUrl(route: Resolved, values: Record<string, unknown[]> = {}): string {
+export function assembleUrl(route: ResolvedRoute, values: Record<string, unknown[]> = {}): string {
   const params = Object.entries<Param[]>(route.params)
   const pathWithQuery = route.query.length ? `${route.path}?${route.query}` : route.path
 


### PR DESCRIPTION
# Description
Cleans up `Resolved` type to be simpler based on decision to make it an internal only type. Will follow this with a PR to remove Resolved from things like router.route and middleware types

- Removes generic `Route` since there's no reason to type guard this type
- Removes symbol properties in favor of strings
- Renames to `ResolvedRoute`