### PR TITLE
Router link classes

### DIFF
--- a/src/components/routerLink.browser.spec.ts
+++ b/src/components/routerLink.browser.spec.ts
@@ -119,3 +119,75 @@ test('to prop as string renders and routes correctly', () => {
 
   expect(arg1).toBe(route.path)
 })
+
+test('when current route matches descendant, parent has "match" class', async () => {
+  const route = {
+    name: 'parent-route',
+    path: '/parent-route',
+    children: [
+      {
+        name: 'child-route',
+        path: '/child-route',
+        component,
+      },
+    ],
+  } as const satisfies Route
+
+  const router = createRouter([route], {
+    initialUrl: '/parent-route/child-route',
+  })
+
+  const wrapper = mount(routerLink, {
+    props: {
+      to: route.path,
+    },
+    slots: {
+      default: route.name,
+    },
+    global: {
+      plugins: [router],
+    },
+  })
+
+  await router.initialized
+
+  const anchor = wrapper.find('a')
+  expect(anchor.classes()).toContain('router-link--match')
+  expect(anchor.classes()).not.toContain('router-link--exact-match')
+})
+
+test('when current route matches to prop, parent has "match" and "exact-match" classes', async () => {
+  const route = {
+    name: 'parent-route',
+    path: '/parent-route',
+    children: [
+      {
+        name: 'child-route',
+        path: '/child-route',
+        component,
+      },
+    ],
+  } as const satisfies Route
+
+  const router = createRouter([route], {
+    initialUrl: '/parent-route',
+  })
+
+  const wrapper = mount(routerLink, {
+    props: {
+      to: route.path,
+    },
+    slots: {
+      default: route.name,
+    },
+    global: {
+      plugins: [router],
+    },
+  })
+
+  await router.initialized
+
+  const anchor = wrapper.find('a')
+  expect(anchor.classes()).toContain('router-link--match')
+  expect(anchor.classes()).toContain('router-link--exact-match')
+})

--- a/src/components/routerLink.browser.spec.ts
+++ b/src/components/routerLink.browser.spec.ts
@@ -3,13 +3,13 @@ import { expect, test, vi } from 'vitest'
 import { h } from 'vue'
 import routerLink from '@/components/routerLink.vue'
 import { Route } from '@/types'
-import { component, createRouter } from '@/utilities'
+import { component, createMaybeRelativeUrl, createRouter } from '@/utilities'
 
 test('renders an anchor tag with the correct href and slot content', () => {
   const path = '/path/:param'
   const param = 'param'
   const content = 'hello world'
-  const href = path.replace(':param', param)
+  const href = createMaybeRelativeUrl(path.replace(':param', param))
 
   const route = {
     name: 'parent',
@@ -33,7 +33,11 @@ test('renders an anchor tag with the correct href and slot content', () => {
     },
   })
 
-  expect(wrapper.html()).toBe(`<a href="${href}">${content}</a>`)
+  const anchor = wrapper.find('a')
+  const element = anchor.element as HTMLAnchorElement
+  expect(element).toBeInstanceOf(HTMLAnchorElement)
+  expect(element.href).toBe(href.toString())
+  expect(element.innerHTML).toBe(content)
 })
 
 test.each([
@@ -83,6 +87,7 @@ test('to prop as string renders and routes correctly', () => {
     path: '/route',
     component,
   } as const satisfies Route
+  const href = createMaybeRelativeUrl(route.path)
 
   const router = createRouter([route], {
     initialUrl: route.path,
@@ -103,7 +108,10 @@ test('to prop as string renders and routes correctly', () => {
   })
 
   const anchor = wrapper.find('a')
-  expect(anchor.html()).toBe(`<a href="${route.path}">${route.name}</a>`)
+  const element = anchor.element as HTMLAnchorElement
+  expect(element).toBeInstanceOf(HTMLAnchorElement)
+  expect(element.href).toBe(href.toString())
+  expect(element.innerHTML).toBe(route.name)
 
   anchor.trigger('click')
 

--- a/src/components/routerLink.vue
+++ b/src/components/routerLink.vue
@@ -23,7 +23,7 @@
   const isMatched = computed(() => !!route.value && router.route.matched === route.value)
 
   const classes = computed(() => ({
-    'router-link--matches': inMatches.value,
+    'router-link--match': inMatches.value,
     'router-link--exact-match': isMatched.value,
   }))
 

--- a/src/components/routerLink.vue
+++ b/src/components/routerLink.vue
@@ -1,10 +1,11 @@
 <template>
-  <a :href="resolve()" @click="onClick">
+  <a :href="resolve()" :class="classes" @click="onClick">
     <slot />
   </a>
 </template>
 
 <script setup lang="ts" generic="T extends string">
+  import { computed } from 'vue'
   import { useRouter } from '@/compositions'
   import { RouteMethod } from '@/types/routeMethod'
   import { RegisteredRouteWithParams } from '@/types/routeWithParams'
@@ -15,6 +16,16 @@
   } & RouterPushOptions>()
 
   const router = useRouter()
+
+  const route = computed(() => router.find(props.to)?.matched)
+
+  const inMatches = computed(() => !!route.value && router.route.matches.includes(route.value))
+  const isMatched = computed(() => !!route.value && router.route.matched === route.value)
+
+  const classes = computed(() => ({
+    'router-link--matches': inMatches.value,
+    'router-link--exact-match': isMatched.value,
+  }))
 
   function resolve(): string {
     return router.resolve(props.to)

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -2,6 +2,7 @@ import { App } from 'vue'
 import { ResolvedRoute } from '@/types/resolved'
 import { RouteMethods, RouteMethodsImplementation } from '@/types/routeMethods'
 import { Routes } from '@/types/routes'
+import { RouterFind, RouterFindImplementation } from '@/utilities/createRouterFind'
 import { RouterPush, RouterPushImplementation } from '@/utilities/createRouterPush'
 import { RouterReject, RouterRejectionComponents } from '@/utilities/createRouterReject'
 import { RouterReplace, RouterReplaceImplementation } from '@/utilities/createRouterReplace'
@@ -19,6 +20,7 @@ export type Router<
   resolve: RouterResolve<TRoutes>,
   push: RouterPush<TRoutes>,
   replace: RouterReplace<TRoutes>,
+  find: RouterFind<TRoutes>,
   reject: RouterReject,
   refresh: () => Promise<void>,
   back: () => void,
@@ -34,6 +36,7 @@ export type RouterImplementation = {
   resolve: RouterResolveImplementation,
   push: RouterPushImplementation,
   replace: RouterReplaceImplementation,
+  find: RouterFindImplementation,
   reject: RouterReject,
   refresh: () => Promise<void>,
   back: () => void,

--- a/src/utilities/createRouter.ts
+++ b/src/utilities/createRouter.ts
@@ -4,6 +4,7 @@ import { routerInjectionKey, routerRejectionKey } from '@/compositions'
 import { Routes, Router, RouterOptions, RouterImplementation } from '@/types'
 import { RouterPushError, RouterRejectionError, RouterReplaceError } from '@/types/errors'
 import { createRouteMethods, createRouterNavigation, resolveRoutes } from '@/utilities'
+import { createRouterFind } from '@/utilities/createRouterFind'
 import { createRouterPush } from '@/utilities/createRouterPush'
 import { createRouterReject } from '@/utilities/createRouterReject'
 import { createRouterReplace } from '@/utilities/createRouterReplace'
@@ -66,6 +67,7 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
   const push = createRouterPush({ navigation, resolve })
   const replace = createRouterReplace({ push })
   const methods = createRouteMethods({ resolved, push })
+  const find = createRouterFind({ resolved, resolve })
   const { reject, rejection, getRejectionRoute, clearRejection } = createRouterReject(options)
   const notFoundRoute = getRejectionRoute('NotFound')
   const { route, updateRoute } = createRouterRoute(notFoundRoute)
@@ -86,6 +88,7 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
     push,
     replace,
     reject,
+    find,
     refresh: navigation.refresh,
     forward: navigation.forward,
     back: navigation.back,

--- a/src/utilities/createRouterFind.ts
+++ b/src/utilities/createRouterFind.ts
@@ -1,0 +1,25 @@
+import { ResolvedRoute, RouteMethod, RouteMethodResponseImplementation, Routes } from '@/types'
+import { RouteWithParams, RouteWithParamsImplementation } from '@/types/routeWithParams'
+import { RouterResolveImplementation } from '@/utilities/createRouterResolve'
+import { routeMatch } from '@/utilities/routeMatch'
+
+export type RouterFind<
+  TRoutes extends Routes
+> = <
+  TRoutePath extends string
+>(source: string | RouteWithParams<TRoutes, TRoutePath> | ReturnType<RouteMethod>) => ResolvedRoute | undefined
+
+export type RouterFindImplementation = (source: string | RouteWithParamsImplementation | RouteMethodResponseImplementation) => ResolvedRoute | undefined
+
+type CreateRouterFindContext = {
+  resolved: ResolvedRoute[],
+  resolve: RouterResolveImplementation,
+}
+
+export function createRouterFind({ resolved, resolve }: CreateRouterFindContext): RouterFindImplementation {
+  return (source) => {
+    const url = resolve(source)
+
+    return routeMatch(resolved, url)
+  }
+}


### PR DESCRIPTION
added `router.find` method

takes `source`, same type as `router.push` and `RouterLink.to`

first calls `resolve` to convert source into url, then passes that url into existing `routeMatch` logic

returns `ResolvedRoute | undefined`

