### PR TITLE
add support for BEFORE navigation update

### DIFF
--- a/src/utilities/createRouter.ts
+++ b/src/utilities/createRouter.ts
@@ -56,7 +56,14 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
     }
   }
 
-  const onLocationUpdate = async (url: string): Promise<void> => {
+  const onBeforeLocationUpdate = async (url: string): Promise<void> => {
+    const to = getResolvedRouteForUrl(routerRoutes, url)
+
+    // execute before hooks
+    return Promise.resolve()
+  }
+
+  const onAfterLocationUpdate = async (url: string): Promise<void> => {
     const to = getResolvedRouteForUrl(routerRoutes, url)
     const from = isRejectionRoute(route) ? null : route
 
@@ -83,7 +90,8 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
   }
 
   const navigation = createRouterNavigation({
-    onLocationUpdate,
+    onBeforeLocationUpdate,
+    onAfterLocationUpdate,
   })
 
   const push = createRouterPush({ navigation, resolve })
@@ -94,7 +102,7 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
   const notFoundRoute = getRejectionRoute('NotFound')
   const { route, updateRoute } = createCurrentRoute(notFoundRoute)
 
-  const initialized = onLocationUpdate(getInitialUrl(options.initialUrl))
+  const initialized = onAfterLocationUpdate(getInitialUrl(options.initialUrl))
 
   function install(app: App): void {
     app.component('RouterView', RouterView)

--- a/src/utilities/createRouter.ts
+++ b/src/utilities/createRouter.ts
@@ -56,8 +56,9 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
     }
   }
 
-  const onBeforeLocationUpdate = async (url: string): Promise<void> => {
-    const to = getResolvedRouteForUrl(routerRoutes, url)
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars, require-await
+  const onBeforeLocationUpdate = async (_url: string): Promise<void> => {
+    // const to = getResolvedRouteForUrl(routerRoutes, url)
 
     // execute before hooks
     return Promise.resolve()

--- a/src/utilities/createRouterPush.spec.ts
+++ b/src/utilities/createRouterPush.spec.ts
@@ -5,14 +5,14 @@ import { createRouterRoutes } from '@/utilities/createRouterRoutes'
 import { createRouterNavigation } from '@/utilities/routerNavigation'
 import { routes } from '@/utilities/testHelpers'
 
-test('push calls onLocationUpdated', () => {
-  const onLocationUpdate = vi.fn()
-  const navigation = createRouterNavigation({ onLocationUpdate })
+test('push calls onAfterLocationUpdate', () => {
+  const onAfterLocationUpdate = vi.fn()
+  const navigation = createRouterNavigation({ onAfterLocationUpdate })
   const routerRoutes = createRouterRoutes(routes)
   const resolve = createRouterResolve(routerRoutes)
   const push = createRouterPush({ navigation, resolve })
 
   push({ route: 'parentA', params: { paramA: '' } })
 
-  expect(onLocationUpdate).toHaveBeenCalledOnce()
+  expect(onAfterLocationUpdate).toHaveBeenCalledOnce()
 })

--- a/src/utilities/routerNavigation.browser.spec.ts
+++ b/src/utilities/routerNavigation.browser.spec.ts
@@ -6,9 +6,9 @@ import * as utilities from '@/utilities/updateBrowserUrl'
 test('when go is called, forwards call to window history', () => {
   vi.spyOn(window.history, 'go')
 
-  const onLocationUpdate = vi.fn()
+  const onAfterLocationUpdate = vi.fn()
   const delta = random.number({ min: 0, max: 100 })
-  const history = createRouterNavigation({ onLocationUpdate })
+  const history = createRouterNavigation({ onAfterLocationUpdate })
 
   history.go(delta)
 
@@ -18,8 +18,8 @@ test('when go is called, forwards call to window history', () => {
 test('when back is called, forwards call to window history', () => {
   vi.spyOn(window.history, 'back')
 
-  const onLocationUpdate = vi.fn()
-  const history = createRouterNavigation({ onLocationUpdate })
+  const onAfterLocationUpdate = vi.fn()
+  const history = createRouterNavigation({ onAfterLocationUpdate })
 
   history.back()
 
@@ -29,8 +29,8 @@ test('when back is called, forwards call to window history', () => {
 test('when forward is called, forwards call to window history', () => {
   vi.spyOn(window.history, 'forward')
 
-  const onLocationUpdate = vi.fn()
-  const history = createRouterNavigation({ onLocationUpdate })
+  const onAfterLocationUpdate = vi.fn()
+  const history = createRouterNavigation({ onAfterLocationUpdate })
 
   history.forward()
 
@@ -40,35 +40,35 @@ test('when forward is called, forwards call to window history', () => {
 test('when update is called, calls updateBrowserUrl', () => {
   vi.spyOn(utilities, 'updateBrowserUrl')
 
-  const onLocationUpdate = vi.fn()
+  const onAfterLocationUpdate = vi.fn()
   const url = random.number().toString()
-  const history = createRouterNavigation({ onLocationUpdate })
+  const history = createRouterNavigation({ onAfterLocationUpdate })
 
   history.update(url)
 
   expect(utilities.updateBrowserUrl).toHaveBeenCalledWith(url, undefined)
 })
 
-test('when update is called and same origin calls onLocationUpdate', async () => {
+test('when update is called and same origin calls onAfterLocationUpdate', async () => {
   vi.spyOn(utilities, 'isSameOrigin').mockReturnValue(true)
 
-  const onLocationUpdate = vi.fn()
+  const onAfterLocationUpdate = vi.fn()
   const url = random.number().toString()
-  const history = createRouterNavigation({ onLocationUpdate })
+  const history = createRouterNavigation({ onAfterLocationUpdate })
 
   await history.update(url)
 
-  expect(onLocationUpdate).toHaveBeenCalledWith(url)
+  expect(onAfterLocationUpdate).toHaveBeenCalledWith(url)
 })
 
-test('when update is called and not same origin does not call onLocationUpdate ', () => {
-  const onLocationUpdate = vi.fn()
+test('when update is called and not same origin does not call onAfterLocationUpdate ', () => {
+  const onAfterLocationUpdate = vi.fn()
   vi.spyOn(utilities, 'isSameOrigin').mockReturnValue(true)
 
   const url = random.number().toString()
-  const history = createRouterNavigation({ onLocationUpdate })
+  const history = createRouterNavigation({ onAfterLocationUpdate })
 
   history.update(url)
 
-  expect(onLocationUpdate).not.toHaveBeenCalled()
+  expect(onAfterLocationUpdate).not.toHaveBeenCalled()
 })

--- a/src/utilities/routerNavigation.spec.ts
+++ b/src/utilities/routerNavigation.spec.ts
@@ -3,20 +3,20 @@ import { createRouterNavigation } from '@/utilities/routerNavigation'
 import { random } from '@/utilities/testHelpers'
 
 test('Browser like navigation is not supported', () => {
-  const onLocationUpdate = vi.fn()
-  const navigation = createRouterNavigation({ onLocationUpdate })
+  const onAfterLocationUpdate = vi.fn()
+  const navigation = createRouterNavigation({ onAfterLocationUpdate })
 
   expect(() => navigation.back()).toThrowError()
   expect(() => navigation.forward()).toThrowError()
   expect(() => navigation.go(1)).toThrowError()
 })
 
-test('when update is called and same origin calls onLocationUpdate', () => {
-  const onLocationUpdate = vi.fn()
+test('when update is called and same origin calls onAfterLocationUpdate', () => {
+  const onAfterLocationUpdate = vi.fn()
   const url = random.number().toString()
-  const history = createRouterNavigation({ onLocationUpdate })
+  const history = createRouterNavigation({ onAfterLocationUpdate })
 
   history.update(url)
 
-  expect(onLocationUpdate).toHaveBeenCalledWith(url)
+  expect(onAfterLocationUpdate).toHaveBeenCalledWith(url)
 })

--- a/src/utilities/routerNavigation.ts
+++ b/src/utilities/routerNavigation.ts
@@ -49,8 +49,14 @@ function createBrowserNavigation({ onBeforeLocationUpdate, onAfterLocationUpdate
   }
 
   const refresh: NavigationRefresh = async () => {
+    const url = window.location.toString()
+
+    if (onBeforeLocationUpdate) {
+      await onBeforeLocationUpdate(url)
+    }
+
     if (onAfterLocationUpdate) {
-      await onAfterLocationUpdate(window.location.toString())
+      await onAfterLocationUpdate(url)
     }
   }
 

--- a/src/utilities/routerNavigation.ts
+++ b/src/utilities/routerNavigation.ts
@@ -2,7 +2,8 @@ import { isBrowser } from '@/utilities/isBrowser'
 import { updateBrowserUrl } from '@/utilities/updateBrowserUrl'
 
 type RouterNavigationOptions = {
-  onLocationUpdate: (url: string) => Promise<void>,
+  onBeforeLocationUpdate?: (url: string) => Promise<void>,
+  onAfterLocationUpdate?: (url: string) => Promise<void>,
 }
 
 type RouterNavigationUpdateOptions = {
@@ -33,16 +34,24 @@ export function createRouterNavigation(options: RouterNavigationOptions): Router
   return createNodeNavigation(options)
 }
 
-function createBrowserNavigation({ onLocationUpdate }: RouterNavigationOptions): RouterNavigation {
+function createBrowserNavigation({ onBeforeLocationUpdate, onAfterLocationUpdate }: RouterNavigationOptions): RouterNavigation {
 
   const update: NavigationUpdate = async (url, options) => {
+    if (onBeforeLocationUpdate) {
+      await onBeforeLocationUpdate(url)
+    }
+
     await updateBrowserUrl(url, options)
 
-    return await onLocationUpdate(url)
+    if (onAfterLocationUpdate) {
+      return await onAfterLocationUpdate(url)
+    }
   }
 
   const refresh: NavigationRefresh = async () => {
-    await onLocationUpdate(window.location.toString())
+    if (onAfterLocationUpdate) {
+      await onAfterLocationUpdate(window.location.toString())
+    }
   }
 
   const cleanup: NavigationCleanup = () => {
@@ -61,13 +70,20 @@ function createBrowserNavigation({ onLocationUpdate }: RouterNavigationOptions):
   }
 }
 
-function createNodeNavigation({ onLocationUpdate }: RouterNavigationOptions): RouterNavigation {
+function createNodeNavigation({ onBeforeLocationUpdate, onAfterLocationUpdate }: RouterNavigationOptions): RouterNavigation {
+
   const notSupported = (): any => {
     throw new Error('Browser like navigation is not supported outside of a browser context')
   }
 
   const update: NavigationUpdate = async (url) => {
-    return await onLocationUpdate(url)
+    if (onBeforeLocationUpdate) {
+      await onBeforeLocationUpdate(url)
+    }
+
+    if (onAfterLocationUpdate) {
+      return await onAfterLocationUpdate(url)
+    }
   }
 
   const cleanup: NavigationCleanup = () => {}


### PR DESCRIPTION
now when you create `Navigation` you pass `onBeforeLocationUpdate` and `onAfterLocationUpdate`
<img width="1101" alt="image" src="https://github.com/kitbagjs/router/assets/6098901/34d3c68c-f6da-44a9-8293-b96974a68824">

which should enable us to have our hooks actually run before browser knows about the route, making them abortable