### PR TITLE
Discovered bug while proving Param names are case senstitive

### DIFF
--- a/src/utilities/paramValidation.spec.ts
+++ b/src/utilities/paramValidation.spec.ts
@@ -101,6 +101,28 @@ test('given route with regex param that expects forward slashes, will NOT match'
   expect(response).toBe(false)
 })
 
+test.each([
+  ['/:sameId/:SameId/:SAMEID'],
+  [
+    path('/:sameId/:SameId/:SAMEID', {
+      sameId: String,
+      SameId: Number,
+      SAMEID: Boolean,
+    }),
+  ],
+])('given route with the same param name of different casing, treats params separately', (path) => {
+  const route: Route = {
+    name: 'different-cased-params',
+    path,
+    component,
+  }
+  const [routerRoutes] = createRouterRoutes([route])
+
+  const response = routeParamsAreValid(routerRoutes, '/ABC/123/true')
+
+  expect(response).toBe(true)
+})
+
 describe('getRouteParamValues', () => {
   test('given route with path params and query params of the same name, combines both', () => {
     const route: Route = {

--- a/src/utilities/paramsFinder.spec.ts
+++ b/src/utilities/paramsFinder.spec.ts
@@ -38,6 +38,12 @@ describe('getParamValuesFromUrl', () => {
 
     expect(response).toMatchObject(['ABC', '', 'GHI'])
   })
+
+  test('given multiple params, uses wildcards for non-selected param name', () => {
+    const response = getParamValuesFromUrl('/ABC/123/true', '/:str/:num/:bool', 'num')
+
+    expect(response).toMatchObject(['123'])
+  })
 })
 
 describe('setParamValuesOnUrl', () => {

--- a/src/utilities/paramsFinder.ts
+++ b/src/utilities/paramsFinder.ts
@@ -33,7 +33,7 @@ export function setParamValuesOnUrl(path: string, paramReplace?: ParamReplace): 
 function getParamRegexPattern(path: string, paramName: string): RegExp {
   const regexPattern = [
     replaceOptionalParamSyntaxWithCaptureGroup,
-    replaceREquiredParamSyntaxWithCaptureGroup,
+    replaceRequiredParamSyntaxWithCaptureGroup,
     replaceParamSyntaxWithCatchAlls,
   ].reduce((pattern, regexBuild) => {
     return regexBuild(pattern, paramName)
@@ -48,7 +48,7 @@ function replaceOptionalParamSyntaxWithCaptureGroup(path: string, paramName: str
   return path.replace(optionalParamRegex, '([^/]*)')
 }
 
-function replaceREquiredParamSyntaxWithCaptureGroup(path: string, paramName: string): string {
+function replaceRequiredParamSyntaxWithCaptureGroup(path: string, paramName: string): string {
   const requiredParamRegex = new RegExp(`(:${paramName})(?=\\W|$)`, 'g')
 
   return path.replace(requiredParamRegex, '([^/]+)')

--- a/src/utilities/routeRegex.spec.ts
+++ b/src/utilities/routeRegex.spec.ts
@@ -28,7 +28,7 @@ describe('generateRoutePathRegexPattern', () => {
 
     const result = generateRoutePathRegexPattern(routerRoutes)
 
-    const catchAll = '([^/]+)'
+    const catchAll = '[^/]+'
     const expected = new RegExp(`^parent/child/${catchAll}/grand-child/${catchAll}$`, 'i')
     expect(result.toString()).toBe(expected.toString())
   })
@@ -43,7 +43,7 @@ describe('generateRoutePathRegexPattern', () => {
 
     const result = generateRoutePathRegexPattern(routerRoutes)
 
-    const catchAll = '([^/]*)'
+    const catchAll = '[^/]*'
     const expected = new RegExp(`^parent/child/${catchAll}/grand-child/${catchAll}$`, 'i')
     expect(result.toString()).toBe(expected.toString())
   })

--- a/src/utilities/routeRegex.ts
+++ b/src/utilities/routeRegex.ts
@@ -14,9 +14,23 @@ export function generateRouteQueryRegexPatterns(route: RouterRoute): RegExp[] {
     .map(([key, value]) => new RegExp(`${key}=${replaceParamSyntaxWithCatchAlls(value)}`, 'i'))
 }
 
-function replaceParamSyntaxWithCatchAlls(value: string): string {
+export function replaceParamSyntaxWithCatchAlls(value: string): string {
+  return [
+    replaceOptionalParamSyntaxWithCatchAll,
+    replaceRequiredParamSyntaxWithCatchAll,
+  ].reduce((pattern, regexBuild) => {
+    return regexBuild(pattern)
+  }, value)
+}
+
+function replaceOptionalParamSyntaxWithCatchAll(value: string): string {
   const optionalParamRegex = /(:\?[\w]+)(?=\W|$)/g
+
+  return value.replace(optionalParamRegex, '[^/]*')
+}
+
+function replaceRequiredParamSyntaxWithCatchAll(value: string): string {
   const requiredParamRegex = /(:[\w]+)(?=\W|$)/g
 
-  return value.replace(optionalParamRegex, '([^/]*)').replace(requiredParamRegex, '([^/]+)')
+  return value.replace(requiredParamRegex, '[^/]+')
 }


### PR DESCRIPTION
While setting out to prove param name is case sensitive I found and fixed a bug with regex utilities when multiple params

We have 2 major places we use regex utilities
1. routeRegex.ts -> responsible for taking a `path` and giving back the pattern we use to check if a given url "matches" the expectation of this routes path (used for route matching)
2. paramsFinder.ts -> responsible for getting and setting param values to/from a url (use for url building)

The bug was in param finding, when looking for a param value it would take a path like

```
/somewhere/:id
```

and when you ask for it to find "id", you get back

```
/somewhere/(fancy-capture-group)
```

Things seemed fine with all the tests we had thrown at it until I wrote a test for multiple params with different cases. In that test I gave param finder the following path

```
/:someId/:SomeId/:SOMEID
```

and when you ask for any of those (let's use "SomeId") you get back

```
/:someId/(fancy-capture-group)/:SOMEID
```

See the issue? It wasn't doing anything with the params other than the 1 you specifically asked for. Works great when the things around your param are static and actually expected, not so much when they are param names.

The solution, reuse the logic `routeRegex` (used in route matching) which already knows how to find any param names and replace them with catch alls.

So the logic for getting `/:someId/(fancy-capture-group)/:SOMEID` is left in tact, but AFTER we do that we run it through the function that finds any param name and returns it with catch alls, resulting in

```
/[fancy-non-capture-group]/(fancy-capture-group)/[fancy-non-capture-group]
```