### PR TITLE
Add support for running route hooks in before location update hook

### DIFF
--- a/src/errors/navigationAbortError.ts
+++ b/src/errors/navigationAbortError.ts
@@ -1,0 +1,1 @@
+export class NavigationAbortError extends Error {}

--- a/src/errors/navigationDoneError.ts
+++ b/src/errors/navigationDoneError.ts
@@ -1,1 +1,0 @@
-export class NavigationDoneError extends Error {}

--- a/src/errors/navigationDoneError.ts
+++ b/src/errors/navigationDoneError.ts
@@ -1,0 +1,1 @@
+export class NavigationDoneError extends Error {}

--- a/src/utilities/createRouter.ts
+++ b/src/utilities/createRouter.ts
@@ -62,10 +62,11 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
 
     if (!to) {
       reject('NotFound')
+
       return false
     }
 
-    const success = await executeRouteHooks({
+    return await executeRouteHooks({
       hooks: [
         ...hooks.before,
         ...getRouteHooks(to, from, 'before'),
@@ -74,8 +75,6 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
       from,
       onRouteHookError,
     })
-
-    return success
   }
 
   const onAfterLocationUpdate: AfterLocationUpdate = async (url) => {
@@ -83,10 +82,14 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
     // const from = isRejectionRoute(route) ? null : route
 
     if (!to) {
-      return reject('NotFound')
+      reject('NotFound')
+      return
     }
 
-    // const success = await executeRouteHooks({
+    updateRoute(to)
+    clearRejection()
+
+    // await executeRouteHooks({
     //   hooks: [
     //     ...hooks.after,
     //     ...getRouteHooks(to, from, 'after'),
@@ -95,13 +98,6 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
     //   from,
     //   onRouteHookError,
     // })
-
-    // if (!success) {
-    //   return
-    // }
-
-    updateRoute(to)
-    clearRejection()
   }
 
   const navigation = createRouterNavigation({

--- a/src/utilities/createRouter.ts
+++ b/src/utilities/createRouter.ts
@@ -56,14 +56,13 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
     }
   }
 
-  const onBeforeLocationUpdate: BeforeLocationUpdate = async (url, { done }) => {
+  const onBeforeLocationUpdate: BeforeLocationUpdate = async (url) => {
     const to = getResolvedRouteForUrl(routerRoutes, url)
     const from = isRejectionRoute(route) ? null : route
 
     if (!to) {
       reject('NotFound')
-      done()
-      return
+      return false
     }
 
     const success = await executeRouteHooks({
@@ -76,9 +75,7 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
       onRouteHookError,
     })
 
-    if (!success) {
-      done()
-    }
+    return success
   }
 
   const onAfterLocationUpdate: AfterLocationUpdate = async (url) => {


### PR DESCRIPTION
# Description
Updates navigation to provide context methods for the `onBeforeLocationUpdate` hook to allow for control over what happens next. Currently providing `done` and `abort` methods. `done` instructions navigation to finish updating the location but then to stop prior to running `onAfterLocationUpdate`. `abort` prevents the location from being updated at all. 

I haven't yet added support for `abort` in hooks with a timing of `before`. That will be in a future PR. 