### PR TITLE
Refactor of how hooks are run to account for different timing and outcomes

### DIFF
--- a/src/compositions/hooks.ts
+++ b/src/compositions/hooks.ts
@@ -1,0 +1,48 @@
+import { inject, onUnmounted } from 'vue'
+import { useRouterDepth } from '@/compositions/useRouterDepth'
+import { RouterNotInstalledError } from '@/errors/routerNotInstalledError'
+import { RouteHookStore } from '@/models/RouteHookStore'
+import { AddAfterRouteHook, AddBeforeRouteHook, AfterRouteHook, AfterRouteHookLifecycle, BeforeRouteHook, BeforeRouteHookLifecycle } from '@/types/hooks'
+import { routeHookStoreKey } from '@/utilities/createRouterHooks'
+
+function useRouteHookStore(): RouteHookStore {
+  const hooks = inject(routeHookStoreKey)
+
+  if (!hooks) {
+    throw new RouterNotInstalledError()
+  }
+
+  return hooks
+}
+
+function beforeComponentHookFactory(lifecycle: BeforeRouteHookLifecycle) {
+  return (hook: BeforeRouteHook) => {
+    const depth = useRouterDepth()
+    const store = useRouteHookStore()
+
+    const remove = store.addBeforeRouteHook({ lifecycle, hook, depth, timing: 'component' })
+
+    onUnmounted(remove)
+
+    return remove
+  }
+}
+
+function afterComponentHookFactory(lifecycle: AfterRouteHookLifecycle) {
+  return (hook: AfterRouteHook) => {
+    const depth = useRouterDepth()
+    const store = useRouteHookStore()
+
+    const remove = store.addAfterRouteHook({ lifecycle, hook, depth, timing: 'component' })
+
+    onUnmounted(remove)
+
+    return remove
+  }
+}
+
+export const useOnBeforeRouteLeave: AddBeforeRouteHook = beforeComponentHookFactory('onBeforeRouteUpdate')
+export const useOnBeforeRouteUpdate: AddBeforeRouteHook = beforeComponentHookFactory('onBeforeRouteLeave')
+export const useOnAfterRouteEnter: AddAfterRouteHook = afterComponentHookFactory('onAfterRouteEnter')
+export const useOnAfterRouteLeave: AddAfterRouteHook = afterComponentHookFactory('onAfterRouteUpdate')
+export const useOnAfterRouteUpdate: AddAfterRouteHook = afterComponentHookFactory('onAfterRouteLeave')

--- a/src/models/RouteHookStore.ts
+++ b/src/models/RouteHookStore.ts
@@ -1,0 +1,59 @@
+import { RouteHooks } from '@/models/RouteHooks'
+import { AfterRouteHook, BeforeRouteHook, RouteHookRemove } from '@/types/hooks'
+import { getRouteHookCondition } from '@/utilities/hooks'
+
+type RouteHookTiming = 'global' | 'component'
+
+type BeforeRouteHookRegistration = {
+  timing: RouteHookTiming,
+  lifecycle: 'onBeforeRouteEnter' | 'onBeforeRouteUpdate' | 'onBeforeRouteLeave',
+  hook: BeforeRouteHook,
+  depth: number,
+}
+
+type AfterRouteHookRegistration = {
+  timing: RouteHookTiming,
+  lifecycle: 'onAfterRouteEnter' | 'onAfterRouteUpdate' | 'onAfterRouteLeave',
+  hook: AfterRouteHook,
+  depth: number,
+}
+
+export class RouteHookStore {
+  public global = new RouteHooks()
+  public component = new RouteHooks()
+
+  public addBeforeRouteHook({ lifecycle, timing, depth, hook }: BeforeRouteHookRegistration): RouteHookRemove {
+    const condition = getRouteHookCondition(lifecycle)
+    const store = this[timing][lifecycle]
+
+    const wrapped: BeforeRouteHook = (to, context) => {
+      if (!condition(to, context.from, depth)) {
+        return
+      }
+
+      return hook(to, context)
+    }
+
+    store.add(wrapped)
+
+    return () => store.delete(wrapped)
+  }
+
+  public addAfterRouteHook({ lifecycle, timing, depth, hook }: AfterRouteHookRegistration): RouteHookRemove {
+    const condition = getRouteHookCondition(lifecycle)
+    const store = this[timing][lifecycle]
+
+    const wrapped: AfterRouteHook = (to, context) => {
+      if (!condition(to, context.from, depth)) {
+        return
+      }
+
+      return hook(to, context)
+    }
+
+    store.add(wrapped)
+
+    return () => store.delete(wrapped)
+  }
+
+}

--- a/src/models/RouteHooks.ts
+++ b/src/models/RouteHooks.ts
@@ -1,0 +1,10 @@
+import { AfterRouteHook, BeforeRouteHook } from '@/types/hooks'
+
+export class RouteHooks {
+  public onBeforeRouteEnter = new Set<BeforeRouteHook>()
+  public onBeforeRouteUpdate = new Set<BeforeRouteHook>()
+  public onBeforeRouteLeave = new Set<BeforeRouteHook>()
+  public onAfterRouteEnter = new Set<AfterRouteHook>()
+  public onAfterRouteUpdate = new Set<AfterRouteHook>()
+  public onAfterRouteLeave = new Set<AfterRouteHook>()
+}

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,8 +1,9 @@
 import { ResolvedRoute } from '@/types/resolved'
-import { RegisteredRouterPush } from '@/types/routerPush'
-import { MaybePromise } from '@/types/utilities'
-import { RouterReject } from '@/utilities/createRouterReject'
+import { RouterReject } from '@/types/router'
+import { RegisteredRouterPush, RouterPushImplementation } from '@/types/routerPush'
 import { RegisteredRouterReplace } from '@/types/routerReplace'
+import { MaybePromise } from '@/types/utilities'
+import { RouterRejectionType } from '@/utilities/createRouterReject'
 
 export type AddRouteHook = (hook: RouteHook) => RouteHookRemove
 export type RouteHookAbort = () => void
@@ -30,3 +31,26 @@ export type RouteHookRemove = () => void
 export type RouteHookTiming = 'before' | 'after'
 export type RouteHookLifeCycle = 'onBeforeRouteEnter' | 'onBeforeRouteLeave' | 'onBeforeRouteUpdate'
 export type RouteHookCondition = (to: ResolvedRoute, from: ResolvedRoute | null, depth: number) => boolean
+
+
+type RouteHookSuccessResponse = {
+  status: 'SUCCESS',
+}
+
+type RouteHookAbortResponse = {
+  status: 'ABORT',
+}
+
+type RouteHookPushResponse = {
+  status: 'PUSH',
+  to: Parameters<RouterPushImplementation>,
+}
+
+type RouteHookRejectResponse = {
+  status: 'REJECT',
+  type: RouterRejectionType,
+}
+
+export type BeforeRouteHookResponse = RouteHookSuccessResponse | RouteHookPushResponse | RouteHookRejectResponse | RouteHookAbortResponse
+export type AfterRouteHookResponse = RouteHookSuccessResponse | RouteHookPushResponse | RouteHookRejectResponse
+export type RouteHookResponse = BeforeRouteHookResponse | AfterRouteHookResponse

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -26,12 +26,11 @@ type AfterRouteHookContext = RouteHookContext
 
 export type BeforeRouteHook = (to: ResolvedRoute, context: BeforeRouteHookContext) => MaybePromise<void>
 export type AfterRouteHook = (to: ResolvedRoute, context: AfterRouteHookContext) => MaybePromise<void>
-export type RouteHook = (to: ResolvedRoute, context: RouteHookContext) => MaybePromise<void>
+export type RouteHook = BeforeRouteHook | AfterRouteHook
 export type RouteHookRemove = () => void
 export type RouteHookTiming = 'before' | 'after'
 export type RouteHookLifeCycle = 'onBeforeRouteEnter' | 'onBeforeRouteLeave' | 'onBeforeRouteUpdate'
 export type RouteHookCondition = (to: ResolvedRoute, from: ResolvedRoute | null, depth: number) => boolean
-
 
 type RouteHookSuccessResponse = {
   status: 'SUCCESS',

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -5,7 +5,8 @@ import { RegisteredRouterReplace } from '@/types/routerReplace'
 import { MaybePromise } from '@/types/utilities'
 import { RouterRejectionType } from '@/utilities/createRouterReject'
 
-export type AddRouteHook = (hook: RouteHook) => RouteHookRemove
+export type AddBeforeRouteHook = (hook: BeforeRouteHook) => RouteHookRemove
+export type AddAfterRouteHook = (hook: AfterRouteHook) => RouteHookRemove
 export type RouteHookAbort = () => void
 
 type RouteHookContext = {
@@ -28,9 +29,10 @@ export type BeforeRouteHook = (to: ResolvedRoute, context: BeforeRouteHookContex
 export type AfterRouteHook = (to: ResolvedRoute, context: AfterRouteHookContext) => MaybePromise<void>
 export type RouteHook = BeforeRouteHook | AfterRouteHook
 export type RouteHookRemove = () => void
-export type RouteHookTiming = 'before' | 'after'
-export type RouteHookLifeCycle = 'onBeforeRouteEnter' | 'onBeforeRouteLeave' | 'onBeforeRouteUpdate'
-export type RouteHookCondition = (to: ResolvedRoute, from: ResolvedRoute | null, depth: number) => boolean
+
+export type BeforeRouteHookLifecycle = 'onBeforeRouteEnter' | 'onBeforeRouteUpdate' |'onBeforeRouteLeave'
+export type AfterRouteHookLifecycle = 'onAfterRouteEnter' | 'onAfterRouteUpdate' | 'onAfterRouteLeave'
+export type RouteHookLifecycle = BeforeRouteHookLifecycle | AfterRouteHookLifecycle
 
 type RouteHookSuccessResponse = {
   status: 'SUCCESS',

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -1,5 +1,5 @@
 import { App, DeepReadonly } from 'vue'
-import { AddRouteHook } from '@/types/hooks'
+import { AddAfterRouteHook, AddBeforeRouteHook } from '@/types/hooks'
 import { ResolvedRoute } from '@/types/resolved'
 import { RouteMethods, RouteMethodsImplementation } from '@/types/routeMethods'
 import { RouterPush, RouterPushImplementation } from '@/types/routerPush'
@@ -32,9 +32,12 @@ export type Router<
   forward: () => void,
   go: (delta: number) => void,
   install: (app: App) => void,
-  onBeforeRouteEnter: AddRouteHook,
-  onBeforeRouteLeave: AddRouteHook,
-  onBeforeRouteUpdate: AddRouteHook,
+  onBeforeRouteEnter: AddBeforeRouteHook,
+  onBeforeRouteLeave: AddBeforeRouteHook,
+  onBeforeRouteUpdate: AddBeforeRouteHook,
+  onAfterRouteEnter: AddAfterRouteHook,
+  onAfterRouteLeave: AddAfterRouteHook,
+  onAfterRouteUpdate: AddAfterRouteHook,
   initialized: Promise<void>,
 }
 
@@ -51,8 +54,11 @@ export type RouterImplementation = {
   forward: () => void,
   go: (delta: number) => void,
   install: (app: App) => void,
-  onBeforeRouteEnter: AddRouteHook,
-  onBeforeRouteLeave: AddRouteHook,
-  onBeforeRouteUpdate: AddRouteHook,
+  onBeforeRouteEnter: AddBeforeRouteHook,
+  onBeforeRouteLeave: AddBeforeRouteHook,
+  onBeforeRouteUpdate: AddBeforeRouteHook,
+  onAfterRouteEnter: AddAfterRouteHook,
+  onAfterRouteLeave: AddAfterRouteHook,
+  onAfterRouteUpdate: AddAfterRouteHook,
   initialized: Promise<void>,
 }

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -3,12 +3,14 @@ import { AddRouteHook } from '@/types/hooks'
 import { ResolvedRoute } from '@/types/resolved'
 import { RouteMethods, RouteMethodsImplementation } from '@/types/routeMethods'
 import { RouterPush, RouterPushImplementation } from '@/types/routerPush'
+import { RouterReplace, RouterReplaceImplementation } from '@/types/routerReplace'
 import { Routes } from '@/types/routes'
 import { RouterFind, RouterFindImplementation } from '@/utilities/createRouterFind'
 import { RouterHistoryMode } from '@/utilities/createRouterHistory'
-import { RouterReject, RouterRejectionComponents } from '@/utilities/createRouterReject'
+import { RouterRejectionComponents, RouterRejectionType } from '@/utilities/createRouterReject'
 import { RouterResolve, RouterResolveImplementation } from '@/utilities/createRouterResolve'
-import { RouterReplace, RouterReplaceImplementation } from '@/types/routerReplace'
+
+export type RouterReject = (type: RouterRejectionType) => void
 
 export type RouterOptions = {
   initialUrl?: string,

--- a/src/types/routes.ts
+++ b/src/types/routes.ts
@@ -1,5 +1,5 @@
 import { AsyncComponentLoader, Component, DefineComponent } from 'vue'
-import { BeforeRouteHook } from '@/types/hooks'
+import { AfterRouteHook, BeforeRouteHook } from '@/types/hooks'
 import { MaybeArray } from '@/types/utilities'
 import { Path } from '@/utilities/path'
 import { Query } from '@/utilities/query'
@@ -10,28 +10,31 @@ export interface RouteMeta {
 
 }
 
-export type ParentRoute = {
+type RouteWithHooks = {
+  onBeforeRouteEnter?: MaybeArray<BeforeRouteHook>,
+  onBeforeRouteUpdate?: MaybeArray<BeforeRouteHook>,
+  onBeforeRouteLeave?: MaybeArray<BeforeRouteHook>,
+  onAfterRouteEnter?: MaybeArray<AfterRouteHook>,
+  onAfterRouteUpdate?: MaybeArray<AfterRouteHook>,
+  onAfterRouteLeave?: MaybeArray<AfterRouteHook>,
+}
+
+export type ParentRoute = RouteWithHooks & {
   name?: string,
   path: string | Path,
   query?: string | Query,
   disabled?: boolean,
   children: Routes,
   component?: RouteComponent,
-  onBeforeRouteEnter?: MaybeArray<BeforeRouteHook>,
-  onBeforeRouteUpdate?: MaybeArray<BeforeRouteHook>,
-  onBeforeRouteLeave?: MaybeArray<BeforeRouteHook>,
   meta?: RouteMeta,
 }
 
-export type ChildRoute = {
+export type ChildRoute = RouteWithHooks & {
   name: string,
   disabled?: boolean,
   path: string | Path,
   query?: string | Query,
   component: RouteComponent,
-  onBeforeRouteEnter?: MaybeArray<BeforeRouteHook>,
-  onBeforeRouteUpdate?: MaybeArray<BeforeRouteHook>,
-  onBeforeRouteLeave?: MaybeArray<BeforeRouteHook>,
   meta?: RouteMeta,
 }
 

--- a/src/types/routes.ts
+++ b/src/types/routes.ts
@@ -1,5 +1,5 @@
 import { AsyncComponentLoader, Component, DefineComponent } from 'vue'
-import { RouteHook } from '@/types/hooks'
+import { BeforeRouteHook } from '@/types/hooks'
 import { MaybeArray } from '@/types/utilities'
 import { Path } from '@/utilities/path'
 import { Query } from '@/utilities/query'
@@ -17,9 +17,9 @@ export type ParentRoute = {
   disabled?: boolean,
   children: Routes,
   component?: RouteComponent,
-  onBeforeRouteEnter?: MaybeArray<RouteHook>,
-  onBeforeRouteUpdate?: MaybeArray<RouteHook>,
-  onBeforeRouteLeave?: MaybeArray<RouteHook>,
+  onBeforeRouteEnter?: MaybeArray<BeforeRouteHook>,
+  onBeforeRouteUpdate?: MaybeArray<BeforeRouteHook>,
+  onBeforeRouteLeave?: MaybeArray<BeforeRouteHook>,
   meta?: RouteMeta,
 }
 
@@ -29,9 +29,9 @@ export type ChildRoute = {
   path: string | Path,
   query?: string | Query,
   component: RouteComponent,
-  onBeforeRouteEnter?: MaybeArray<RouteHook>,
-  onBeforeRouteUpdate?: MaybeArray<RouteHook>,
-  onBeforeRouteLeave?: MaybeArray<RouteHook>,
+  onBeforeRouteEnter?: MaybeArray<BeforeRouteHook>,
+  onBeforeRouteUpdate?: MaybeArray<BeforeRouteHook>,
+  onBeforeRouteLeave?: MaybeArray<BeforeRouteHook>,
   meta?: RouteMeta,
 }
 

--- a/src/utilities/createRouter.ts
+++ b/src/utilities/createRouter.ts
@@ -51,6 +51,17 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
         onRouteHookError,
       })
 
+      // abort
+      // do nothing
+
+      // reject
+      // update history
+      // update route
+      // run after hooks with to being the rejection? 
+
+      // push
+      // update history
+
       history.update(url, { replace })
 
       if (isRejectionRoute(to)) {

--- a/src/utilities/createRouter.ts
+++ b/src/utilities/createRouter.ts
@@ -68,8 +68,7 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
         break
 
       default:
-        const exhaustive: never = beforeResponse
-        throw new Error(`Switch is not exhaustive for before hook response status: ${JSON.stringify(exhaustive)}`)
+        throw new Error(`Switch is not exhaustive for before hook response status: ${JSON.stringify(beforeResponse satisfies never)}`)
     }
 
     const afterResponse = await runAfterRouteHooks({ to, from, hooks })

--- a/src/utilities/createRouter.ts
+++ b/src/utilities/createRouter.ts
@@ -1,7 +1,7 @@
 import { App, readonly } from 'vue'
 import { RouterLink, RouterView } from '@/components'
 import { routerInjectionKey, routerRejectionKey } from '@/compositions'
-import { Routes, Router, RouterOptions, RouterImplementation, RouterReject, RouteHookResponse } from '@/types'
+import { Routes, Router, RouterOptions, RouterImplementation, RouterReject } from '@/types'
 import { RouterPushImplementation } from '@/types/routerPush'
 import { RouterReplaceImplementation } from '@/types/routerReplace'
 import { createCurrentRoute } from '@/utilities/createCurrentRoute'
@@ -14,7 +14,6 @@ import { createRouterResolve } from '@/utilities/createRouterResolve'
 import { createRouterRoutes } from '@/utilities/createRouterRoutes'
 import { getInitialUrl } from '@/utilities/getInitialUrl'
 import { getResolvedRouteForUrl } from '@/utilities/getResolvedRouteForUrl'
-import { getRouteHooks } from '@/utilities/getRouteHooks'
 import { runAfterRouteHooks, runBeforeRouteHooks } from '@/utilities/hooks'
 
 type RouterUpdateOptions = {

--- a/src/utilities/createRouter.ts
+++ b/src/utilities/createRouter.ts
@@ -8,7 +8,7 @@ import { createCurrentRoute } from '@/utilities/createCurrentRoute'
 import { createRouteMethods } from '@/utilities/createRouteMethods'
 import { createRouterFind } from '@/utilities/createRouterFind'
 import { createRouterHistory } from '@/utilities/createRouterHistory'
-import { addRouteHookInjectionKey, createRouterHooks } from '@/utilities/createRouterHooks'
+import { routeHookStoreKey, createRouterHooks } from '@/utilities/createRouterHooks'
 import { createRouterReject } from '@/utilities/createRouterReject'
 import { createRouterResolve } from '@/utilities/createRouterResolve'
 import { createRouterRoutes } from '@/utilities/createRouterRoutes'
@@ -24,13 +24,14 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
   const routerRoutes = createRouterRoutes(routes)
   const resolve = createRouterResolve(routerRoutes)
   const history = createRouterHistory({ mode: options.historyMode })
-
   const {
-    onBeforeRouteEnter,
-    onBeforeRouteLeave,
-    onBeforeRouteUpdate,
-    addRouteHook,
     hooks,
+    onBeforeRouteEnter,
+    onAfterRouteUpdate,
+    onBeforeRouteLeave,
+    onAfterRouteEnter,
+    onBeforeRouteUpdate,
+    onAfterRouteLeave,
   } = createRouterHooks()
 
   async function update(url: string, { replace }: RouterUpdateOptions = {}): Promise<void> {
@@ -119,7 +120,7 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
     app.component('RouterLink', RouterLink)
     app.provide(routerInjectionKey, router as any)
     app.provide(routerRejectionKey, rejection)
-    app.provide(addRouteHookInjectionKey, addRouteHook)
+    app.provide(routeHookStoreKey, hooks)
   }
 
   const router: RouterImplementation = {
@@ -135,10 +136,13 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
     back: history.back,
     go: history.go,
     install,
-    onBeforeRouteEnter,
-    onBeforeRouteLeave,
-    onBeforeRouteUpdate,
     initialized,
+    onBeforeRouteEnter,
+    onAfterRouteUpdate,
+    onBeforeRouteLeave,
+    onAfterRouteEnter,
+    onBeforeRouteUpdate,
+    onAfterRouteLeave,
   }
 
   return router as any

--- a/src/utilities/createRouterHooks.ts
+++ b/src/utilities/createRouterHooks.ts
@@ -1,71 +1,53 @@
 import { InjectionKey } from 'vue'
-import { AddRouteHook, ResolvedRoute, RouteHook, RouteHookRemove, RouteHookTiming } from '@/types'
-import { asArray } from '@/utilities/array'
+import { RouteHookStore } from '@/models/RouteHookStore'
+import { AddAfterRouteHook, AddBeforeRouteHook } from '@/types'
 
-type AddRouteHookForLifeCycle = (type: RouteHookTiming, hook: RouteHook) => RouteHookRemove
-export type RouteHooks = Record<RouteHookTiming, Set<RouteHook>>
-
-export const addRouteHookInjectionKey: InjectionKey<AddRouteHookForLifeCycle> = Symbol()
+export const routeHookStoreKey: InjectionKey<RouteHookStore> = Symbol()
 
 export type RouterHooks = {
-  onBeforeRouteEnter: AddRouteHook,
-  onBeforeRouteUpdate: AddRouteHook,
-  onBeforeRouteLeave: AddRouteHook,
-  addRouteHook: AddRouteHookForLifeCycle,
-  hooks: RouteHooks,
-}
-
-type GlobalHookCondition = (to: ResolvedRoute, from: ResolvedRoute | null) => boolean
-
-const isGlobalEnter: GlobalHookCondition = (to, from) => {
-  return to.matches[1] !== from?.matches[1]
-}
-
-const isGlobalUpdate: GlobalHookCondition = (to, from) => {
-  return to.matches.some((route, depth) => route === from?.matches[depth])
-}
-
-const isGlobalLeave: GlobalHookCondition = (to, from) => {
-  return to.matches[1] !== from?.matches[1]
+  onBeforeRouteEnter: AddBeforeRouteHook,
+  onBeforeRouteUpdate: AddBeforeRouteHook,
+  onBeforeRouteLeave: AddBeforeRouteHook,
+  onAfterRouteEnter: AddAfterRouteHook,
+  onAfterRouteUpdate: AddAfterRouteHook,
+  onAfterRouteLeave: AddAfterRouteHook,
+  hooks: RouteHookStore,
 }
 
 export function createRouterHooks(): RouterHooks {
-  const hooks: RouteHooks = {
-    before: new Set(),
-    after: new Set(),
+  const hooks = new RouteHookStore()
+
+  const onBeforeRouteEnter: AddBeforeRouteHook = (hook) => {
+    return hooks.addBeforeRouteHook({ lifecycle: 'onBeforeRouteEnter', hook, timing: 'global', depth: 0 })
   }
 
-  const factory = (type: RouteHookTiming, condition: GlobalHookCondition): AddRouteHook => {
-    return (hookOrHooks) => {
-      const remove = asArray(hookOrHooks).map(hook => {
-        const wrapper: RouteHook = (to, context) => {
-          if (!condition(to, context.from)) {
-            return
-          }
-
-          hook(to, context)
-        }
-
-        hooks[type].add(wrapper)
-
-        return () => hooks[type].delete(wrapper)
-      })
-
-      return () => remove.forEach(fn => fn())
-    }
+  const onBeforeRouteUpdate: AddBeforeRouteHook = (hook) => {
+    return hooks.addBeforeRouteHook({ lifecycle: 'onBeforeRouteUpdate', hook, timing: 'global', depth: 0 })
   }
 
-  const addRouteHook: AddRouteHookForLifeCycle = (type, hook) => {
-    hooks[type].add(hook)
+  const onBeforeRouteLeave: AddBeforeRouteHook = (hook) => {
+    return hooks.addBeforeRouteHook({ lifecycle: 'onBeforeRouteLeave', hook, timing: 'global', depth: 0 })
+  }
 
-    return () => hooks[type].delete(hook)
+  const onAfterRouteEnter: AddAfterRouteHook = (hook) => {
+    return hooks.addAfterRouteHook({ lifecycle: 'onAfterRouteEnter', hook, timing: 'global', depth: 0 })
+  }
+
+  const onAfterRouteUpdate: AddAfterRouteHook = (hook) => {
+    return hooks.addAfterRouteHook({ lifecycle: 'onAfterRouteUpdate', hook, timing: 'global', depth: 0 })
+  }
+
+  const onAfterRouteLeave: AddAfterRouteHook = (hook) => {
+    return hooks.addAfterRouteHook({ lifecycle: 'onAfterRouteLeave', hook, timing: 'global', depth: 0 })
   }
 
   return {
-    onBeforeRouteEnter: factory('before', isGlobalEnter),
-    onBeforeRouteUpdate: factory('before', isGlobalUpdate),
-    onBeforeRouteLeave: factory('before', isGlobalLeave),
-    addRouteHook,
+    onBeforeRouteEnter,
+    onBeforeRouteUpdate,
+    onBeforeRouteLeave,
+    onAfterRouteEnter,
+    onAfterRouteUpdate,
+    onAfterRouteLeave,
     hooks,
   }
 }

--- a/src/utilities/createRouterHooks.ts
+++ b/src/utilities/createRouterHooks.ts
@@ -3,7 +3,7 @@ import { AddRouteHook, ResolvedRoute, RouteHook, RouteHookRemove, RouteHookTimin
 import { asArray } from '@/utilities/array'
 
 type AddRouteHookForLifeCycle = (type: RouteHookTiming, hook: RouteHook) => RouteHookRemove
-type RouteHooks = Record<RouteHookTiming, Set<RouteHook>>
+export type RouteHooks = Record<RouteHookTiming, Set<RouteHook>>
 
 export const addRouteHookInjectionKey: InjectionKey<AddRouteHookForLifeCycle> = Symbol()
 

--- a/src/utilities/createRouterReject.ts
+++ b/src/utilities/createRouterReject.ts
@@ -19,11 +19,11 @@ export type RouterRejectionComponents = RegisteredRejectionType extends never
   ? { rejections?: BuiltInRejectionComponents }
   : { rejections: BuiltInRejectionComponents & Record<RegisteredRejectionType, RouteComponent> }
 
-export type RouterReject = (type: RouterRejectionType) => void
+export type RouterSetReject = (type: RouterRejectionType | null) => void
 
 type GetRejectionRoute = (type: RouterRejectionType) => ResolvedRoute
 type IsRejectionRoute = (route: ResolvedRoute) => boolean
-type ClearRejection = () => void
+
 export type RouterRejection = Ref<null | { type: RouterRejectionType, component: RouteComponent }>
 
 type CreateRouterRejectContext = {
@@ -35,11 +35,10 @@ const isRejectionRouteSymbol = Symbol()
 type RouterRejectionRoute = ResolvedRoute & { [isRejectionRouteSymbol]?: true }
 
 export type CreateRouterReject = {
-  reject: RouterReject,
+  setRejection: RouterSetReject,
   rejection: RouterRejection,
   getRejectionRoute: GetRejectionRoute,
   isRejectionRoute: IsRejectionRoute,
-  clearRejection: ClearRejection,
 }
 
 export function createRouterReject({
@@ -80,11 +79,12 @@ export function createRouterReject({
     return route[isRejectionRouteSymbol] === true
   }
 
-  const clearRejection: ClearRejection = () => {
-    rejection.value = null
-  }
+  const setRejection: RouterSetReject = (type) => {
+    if (!type) {
+      rejection.value = null
+      return
+    }
 
-  const reject: RouterReject = (type) => {
     const component = getRejectionComponent(type)
 
     rejection.value = { type, component }
@@ -93,10 +93,9 @@ export function createRouterReject({
   const rejection: RouterRejection = ref(null)
 
   return {
-    reject,
+    setRejection,
     rejection,
     getRejectionRoute,
     isRejectionRoute,
-    clearRejection,
   }
 }

--- a/src/utilities/getRouteHooks.spec.ts
+++ b/src/utilities/getRouteHooks.spec.ts
@@ -2,7 +2,7 @@ import { expect, test, vi } from 'vitest'
 import { ResolvedRoute } from '@/types/resolved'
 import { Route } from '@/types/routes'
 import { createResolvedRouteQuery } from '@/utilities/createResolvedRouteQuery'
-import { getBeforeRouteHooks } from '@/utilities/getRouteHooks'
+import { getBeforeRouteHooksFromRoutes } from '@/utilities/getRouteHooks'
 import { component } from '@/utilities/testHelpers'
 
 function mockRoute(name: string): Route {
@@ -36,13 +36,9 @@ test('given two ResolvedRoutes returns before timing hooks in correct order', ()
   const to = mockResolvedRoute(grandchildB, [parent, childA, grandchildA])
   const from = mockResolvedRoute(grandchildA, [parent, childB, grandchildB])
 
-  const hooks = getBeforeRouteHooks(to, from)
+  const hooks = getBeforeRouteHooksFromRoutes(to, from)
 
-  expect(hooks).toMatchObject([
-    childB.onBeforeRouteLeave,
-    grandchildB.onBeforeRouteLeave,
-    parent.onBeforeRouteUpdate,
-    childA.onBeforeRouteEnter,
-    grandchildA.onBeforeRouteEnter,
-  ])
+  expect(Array.from(hooks.onBeforeRouteEnter)).toMatchObject([childA.onBeforeRouteEnter, grandchildA.onBeforeRouteEnter])
+  expect(Array.from(hooks.onBeforeRouteUpdate)).toMatchObject([parent.onBeforeRouteUpdate])
+  expect(Array.from(hooks.onBeforeRouteLeave)).toMatchObject([childB.onBeforeRouteLeave, grandchildB.onBeforeRouteLeave])
 })

--- a/src/utilities/getRouteHooks.spec.ts
+++ b/src/utilities/getRouteHooks.spec.ts
@@ -2,7 +2,7 @@ import { expect, test, vi } from 'vitest'
 import { ResolvedRoute } from '@/types/resolved'
 import { Route } from '@/types/routes'
 import { createResolvedRouteQuery } from '@/utilities/createResolvedRouteQuery'
-import { getRouteHooks } from '@/utilities/getRouteHooks'
+import { getBeforeRouteHooks } from '@/utilities/getRouteHooks'
 import { component } from '@/utilities/testHelpers'
 
 function mockRoute(name: string): Route {
@@ -36,7 +36,7 @@ test('given two ResolvedRoutes returns before timing hooks in correct order', ()
   const to = mockResolvedRoute(grandchildB, [parent, childA, grandchildA])
   const from = mockResolvedRoute(grandchildA, [parent, childB, grandchildB])
 
-  const hooks = getRouteHooks(to, from, 'before')
+  const hooks = getBeforeRouteHooks(to, from)
 
   expect(hooks).toMatchObject([
     childB.onBeforeRouteLeave,

--- a/src/utilities/getRouteHooks.ts
+++ b/src/utilities/getRouteHooks.ts
@@ -8,7 +8,8 @@ export function getRouteHooks(to: ResolvedRoute, from: ResolvedRoute | null, typ
     case 'before':
       return getRouteBeforeHooks(to, from)
     case 'after':
-      throw 'not implemented'
+      // todo
+      return []
     default:
       const exhaustive: never = type
       throw new Error(`Missing RouteHookTiming condition in getRouteHooks: ${exhaustive}`)

--- a/src/utilities/getRouteHooks.ts
+++ b/src/utilities/getRouteHooks.ts
@@ -1,22 +1,9 @@
-import { RouteHook, RouteHookTiming } from '@/types'
+import { AfterRouteHook, BeforeRouteHook } from '@/types'
 import { ResolvedRoute } from '@/types/resolved'
 import { asArray } from '@/utilities/array'
 import { isRouteEnter, isRouteLeave, isRouteUpdate } from '@/utilities/hooks'
 
-export function getRouteHooks(to: ResolvedRoute, from: ResolvedRoute | null, type: RouteHookTiming): RouteHook[] {
-  switch (type) {
-    case 'before':
-      return getRouteBeforeHooks(to, from)
-    case 'after':
-      // todo
-      return []
-    default:
-      const exhaustive: never = type
-      throw new Error(`Missing RouteHookTiming condition in getRouteHooks: ${exhaustive}`)
-  }
-}
-
-function getRouteBeforeHooks(to: ResolvedRoute, from: ResolvedRoute | null): RouteHook[] {
+export function getBeforeRouteHooks(to: ResolvedRoute, from: ResolvedRoute): BeforeRouteHook[] {
   const toHooks = to.matches.flatMap((route, depth) => {
     const hooks = []
 
@@ -31,7 +18,7 @@ function getRouteBeforeHooks(to: ResolvedRoute, from: ResolvedRoute | null): Rou
     return hooks
   })
 
-  const fromHooks = from?.matches.flatMap((route, depth) => {
+  const fromHooks = from.matches.flatMap((route, depth) => {
     const hooks = []
 
     if (route.onBeforeRouteLeave && isRouteLeave(to, from, depth)) {
@@ -39,7 +26,11 @@ function getRouteBeforeHooks(to: ResolvedRoute, from: ResolvedRoute | null): Rou
     }
 
     return hooks
-  }) ?? []
+  })
 
   return [...fromHooks, ...toHooks]
+}
+
+export function getAfterRouteHooks(to: ResolvedRoute, from: ResolvedRoute): AfterRouteHook[] {
+  return []
 }

--- a/src/utilities/getRouteHooks.ts
+++ b/src/utilities/getRouteHooks.ts
@@ -1,36 +1,48 @@
-import { AfterRouteHook, BeforeRouteHook } from '@/types'
+import { RouteHooks } from '@/models/RouteHooks'
 import { ResolvedRoute } from '@/types/resolved'
 import { asArray } from '@/utilities/array'
 import { isRouteEnter, isRouteLeave, isRouteUpdate } from '@/utilities/hooks'
 
-export function getBeforeRouteHooks(to: ResolvedRoute, from: ResolvedRoute): BeforeRouteHook[] {
-  const toHooks = to.matches.flatMap((route, depth) => {
-    const hooks = []
+export function getBeforeRouteHooksFromRoutes(to: ResolvedRoute, from: ResolvedRoute): RouteHooks {
+  const hooks = new RouteHooks()
 
+  to.matches.forEach((route, depth) => {
     if (route.onBeforeRouteEnter && isRouteEnter(to, from, depth)) {
-      hooks.push(...asArray(route.onBeforeRouteEnter))
+      asArray(route.onBeforeRouteEnter).forEach(hook => hooks.onBeforeRouteEnter.add(hook))
     }
 
     if (route.onBeforeRouteUpdate && isRouteUpdate(to, from, depth)) {
-      hooks.push(...asArray(route.onBeforeRouteUpdate))
+      asArray(route.onBeforeRouteUpdate).forEach(hook => hooks.onBeforeRouteUpdate.add(hook))
     }
-
-    return hooks
   })
 
-  const fromHooks = from.matches.flatMap((route, depth) => {
-    const hooks = []
-
+  from.matches.forEach((route, depth) => {
     if (route.onBeforeRouteLeave && isRouteLeave(to, from, depth)) {
-      hooks.push(...asArray(route.onBeforeRouteLeave))
+      asArray(route.onBeforeRouteLeave).forEach(hook => hooks.onBeforeRouteLeave.add(hook))
     }
-
-    return hooks
   })
 
-  return [...fromHooks, ...toHooks]
+  return hooks
 }
 
-export function getAfterRouteHooks(to: ResolvedRoute, from: ResolvedRoute): AfterRouteHook[] {
-  return []
+export function getAfterRouteHooksFromRoutes(to: ResolvedRoute, from: ResolvedRoute): RouteHooks {
+  const hooks = new RouteHooks()
+
+  to.matches.forEach((route, depth) => {
+    if (route.onAfterRouteEnter && isRouteEnter(to, from, depth)) {
+      asArray(route.onAfterRouteEnter).forEach(hook => hooks.onAfterRouteEnter.add(hook))
+    }
+
+    if (route.onAfterRouteUpdate && isRouteUpdate(to, from, depth)) {
+      asArray(route.onAfterRouteUpdate).forEach(hook => hooks.onAfterRouteUpdate.add(hook))
+    }
+  })
+
+  from.matches.forEach((route, depth) => {
+    if (route.onAfterRouteLeave && isRouteLeave(to, from, depth)) {
+      asArray(route.onAfterRouteLeave).forEach(hook => hooks.onAfterRouteLeave.add(hook))
+    }
+  })
+
+  return hooks
 }

--- a/src/utilities/hooks.ts
+++ b/src/utilities/hooks.ts
@@ -10,7 +10,7 @@ import { RouterPushImplementation } from '@/types/routerPush'
 import { RouterReplaceImplementation } from '@/types/routerReplace'
 import { asArray } from '@/utilities/array'
 import { RouteHooks, addRouteHookInjectionKey } from '@/utilities/createRouterHooks'
-import { getRouteHooks } from '@/utilities/getRouteHooks'
+import { getAfterRouteHooks, getBeforeRouteHooks } from '@/utilities/getRouteHooks'
 
 type BeforeContext = {
   to: ResolvedRoute,
@@ -21,7 +21,7 @@ type BeforeContext = {
 export async function runBeforeRouteHooks({ to, from, hooks }: BeforeContext): Promise<BeforeRouteHookResponse> {
   const allHooks: BeforeRouteHook[] = [
     ...hooks.before,
-    ...getRouteHooks(to, from, 'before'),
+    ...getBeforeRouteHooks(to, from),
   ]
 
   try {
@@ -74,7 +74,7 @@ type AfterContext = {
 export async function runAfterRouteHooks({ to, from, hooks }: AfterContext): Promise<AfterRouteHookResponse> {
   const allHooks: AfterRouteHook[] = [
     ...hooks.after,
-    ...getRouteHooks(to, from, 'after'),
+    ...getAfterRouteHooks(to, from),
   ]
 
   try {


### PR DESCRIPTION
# Description
Prior to this there was a single utility for executing route hooks that would return a boolean based on if something like a `push`, `replace`, or `reject` happened. This wasn't enough information for the `update` method in `createRouter` to know what to do. 

I've added stronger types for `BeforeRouteHook` and `AfterRouteHook` and defined types for `BeforeRouteHookResponse` and `AfterRouteHookResponse`. Each response has a status like `abort`, `push`, `reject`, or `success`. The `abort` status is new altogether and is only included for before hooks.