### PR TITLE
setup basic readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,97 @@
-# Router
+# @kitbag/router
 
-Type safe router for Vue.js
+A simple and versatile mapping utility for Typescript.
+
+[![Npm Version](https://img.shields.io/npm/v/@kitbag/router.svg)](https://www.npmjs.org/package/kitbag/router)
+[![Zip Size](https://img.badgesize.io/https:/unpkg.com/@kitbag/router/dist/kitbag-router?compression=gzip)](https:/unpkg.com/@kitbag/router/dist/kitbag-router)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/d6033c76-88c3-4963-b24f-7a0bda20f271/deploy-status)](https://app.netlify.com/sites/kitbag-router/deploys)
+
+Get started with the [documentation](https://kitbag-router.netlify.app/)
+
+## Installation
+
+Install Kitbag Router with your favorite package manager
+
+```bash
+# bun
+bun add @kitbag/router
+# yarn
+yarn add @kitbag/router
+# npm
+npm install @kitbag/router
+```
+
+## Define Basic Routes
+
+Create an array of possible routes. Learn more about [defining routes](/core-concepts/defining-routes).
+
+```js
+// /routes.ts
+import { Routes } from '@kitbag/router'
+
+const Home = { template: '<div>Home</div>' }
+const About = { template: '<div>About</div>' }
+
+export const routes = [
+  { name: 'home', path: '/', component: Home },
+  { name: 'path', path: '/about', component: About },
+] as const satisfies Routes 
+```
+
+## Plugin
+
+Create a router instance and pass it to the app as a plugin
+
+```js {2-3,6,9}
+import { createApp } from 'vue'
+import { createRouter } from '@kitbag/router'
+import { routes } from '/routes'
+import App from './App.vue'
+
+const router = createRouter(routes)
+const app = createApp(App)
+
+app.use(router)
+app.mount('#app')
+```
+
+## Update Registered Router
+
+This block utilizes [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html) to provide the internal types to match the actual router you're using. You put this in main.ts right after you call `createRouter`, or you can export your router and put this interface inside of a `router.d.ts` file, anywhere that your tsconfig can find it.
+
+```ts
+declare module '@kitbag/router' {
+  interface Register {
+    router: typeof router
+  }
+}
+```
+
+## RouterView
+
+Give your route components a place to be mounted
+
+```html {4-5}
+<!-- App.vue -->
+<div class="app">
+  ...
+  <!-- matched route.component gets rendered here -->
+  <router-view />
+</div>
+```
+
+This component can be mounted anywhere you want route components to be mounted. Nested routes can also have a nested `RouterView` which would be responsible for rendering any children that route may have. See more about [nested routes](/core-concepts/defining-routes#nested-routes).
+
+## RouterLink
+
+Use RouterLink for navigating between routes.
+
+```html {3-4}
+<template>
+  ...
+  <!-- router-link renders as <a> with href -->
+  <router-link :to="{ route: 'home' }">Go somewhere</router-link>
+</template>
+```
+
+This component gives the router the power to change the URL without reloading the page.

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ npm install @kitbag/router
 
 ## Define Basic Routes
 
-Create an array of possible routes. Learn more about [defining routes](/core-concepts/defining-routes).
+Create an array of possible routes. Learn more about [defining routes](https://kitbag-router.netlify.app/core-concepts/defining-routes).
 
-```js
+```ts
 // /routes.ts
 import { Routes } from '@kitbag/router'
 
@@ -42,7 +42,7 @@ export const routes = [
 
 Create a router instance and pass it to the app as a plugin
 
-```js {2-3,6,9}
+```ts
 import { createApp } from 'vue'
 import { createRouter } from '@kitbag/router'
 import { routes } from '/routes'
@@ -80,7 +80,7 @@ Give your route components a place to be mounted
 </div>
 ```
 
-This component can be mounted anywhere you want route components to be mounted. Nested routes can also have a nested `RouterView` which would be responsible for rendering any children that route may have. See more about [nested routes](/core-concepts/defining-routes#nested-routes).
+This component can be mounted anywhere you want route components to be mounted. Nested routes can also have a nested `RouterView` which would be responsible for rendering any children that route may have. See more about [nested routes](https://kitbag-router.netlify.app/core-concepts/defining-routes#nested-routes).
 
 ## RouterLink
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -17,7 +17,7 @@ npm install @kitbag/router
 
 Create an array of possible routes. Learn more about [defining routes](/core-concepts/defining-routes).
 
-```js
+```ts
 // /routes.ts
 import { Routes } from '@kitbag/router'
 
@@ -34,7 +34,7 @@ export const routes = [
 
 Create a router instance and pass it to the app as a plugin
 
-```js {2-3,6,9}
+```ts {2-3,6,9}
 import { createApp } from 'vue'
 import { createRouter } from '@kitbag/router'
 import { routes } from '/routes'


### PR DESCRIPTION
follows pattern established by @kitbag/mapper and @kitbag/events

- really only covers what's in "getting-started" of vitepress site
- links to vitepress site at the top
- note both `npm` and `zip` badges will not work until we have any version of @kitbag/router published on npm