### PR TITLE
RouterView as default route component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "@kitbag/router",
   "private": false,
-  "version": "0.0.3",
+  "version": "0.0.1",
   "bugs": {
     "url": "https://github.com/kitbagjs/router/issues"
   },
   "homepage": "https://github.com/kitbagjs/router#readme",
   "scripts": {
     "build": "vite build",
+    "build:watch": "vite build --watch",
     "test": "vitest",
     "test:types": "vitest typecheck",
     "lint": "eslint ./src",
@@ -41,7 +42,6 @@
     "vite-plugin-dts": "^3.8.1",
     "vitepress": "^1.0.1",
     "vitest": "^0.34.6",
-    "vue": "^3.4.5",
     "vue-tsc": "^2.0.7"
   },
   "peerDependencies": {

--- a/src/components/routerView.vue
+++ b/src/components/routerView.vue
@@ -10,7 +10,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { AsyncComponentLoader, DeepReadonly, computed, defineAsyncComponent, provide, resolveComponent } from 'vue'
+  import { AsyncComponentLoader, DeepReadonly, computed, defineAsyncComponent, provide } from 'vue'
   import { useRejection } from '@/compositions/useRejection'
   import { useRouter } from '@/compositions/useRouter'
   import { useRouterDepth } from '@/compositions/useRouterDepth'
@@ -19,7 +19,6 @@
   const router = useRouter()
   const rejection = useRejection()
   const depth = useRouterDepth()
-  const routerView = resolveComponent('RouterView', true)
 
   defineSlots<{
     default?: (props: {
@@ -31,16 +30,15 @@
   provide(depthInjectionKey, depth + 1)
 
   const component = computed(() => {
-    const routeComponent = router.route.matches[depth].component
+    const routeComponent = router.route.matches[depth]?.component
 
     if (routeComponent) {
       if (typeof routeComponent === 'function') {
         return defineAsyncComponent(routeComponent as AsyncComponentLoader)
       }
-
       return routeComponent
     }
 
-    return routerView
+    return 'span'
   })
 </script>

--- a/src/components/routerView.vue
+++ b/src/components/routerView.vue
@@ -39,6 +39,6 @@
       return routeComponent
     }
 
-    return 'span'
+    return null
   })
 </script>

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -18,7 +18,7 @@ export type RouterOptions = {
 
 export type Router<
   TRoutes extends Routes = []
-> = {
+> = Plugin & {
   route: DeepReadonly<ResolvedRoute>,
   resolve: RouterResolve<TRoutes>,
   push: RouterPush<TRoutes>,
@@ -36,4 +36,4 @@ export type Router<
   onAfterRouteLeave: AddAfterRouteHook,
   onAfterRouteUpdate: AddAfterRouteHook,
   initialized: Promise<void>,
-} & Plugin
+}

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -1,4 +1,4 @@
-import { App, DeepReadonly } from 'vue'
+import { DeepReadonly, Plugin } from 'vue'
 import { AddAfterRouteHook, AddBeforeRouteHook } from '@/types/hooks'
 import { ResolvedRoute } from '@/types/resolved'
 import { Routes } from '@/types/route'
@@ -29,7 +29,6 @@ export type Router<
   back: () => void,
   forward: () => void,
   go: (delta: number) => void,
-  install: (app: App) => void,
   onBeforeRouteEnter: AddBeforeRouteHook,
   onBeforeRouteLeave: AddBeforeRouteHook,
   onBeforeRouteUpdate: AddBeforeRouteHook,
@@ -37,4 +36,4 @@ export type Router<
   onAfterRouteLeave: AddAfterRouteHook,
   onAfterRouteUpdate: AddAfterRouteHook,
   initialized: Promise<void>,
-}
+} & Plugin

--- a/src/utilities/createRouter.ts
+++ b/src/utilities/createRouter.ts
@@ -136,7 +136,7 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
   function install(app: App): void {
     app.component('RouterView', RouterView)
     app.component('RouterLink', RouterLink)
-    app.provide(routerInjectionKey, router as any)
+    app.provide(routerInjectionKey, router)
     app.provide(routerRejectionKey, rejection)
     app.provide(routeHookStoreKey, hooks)
   }

--- a/src/utilities/createRoutes.spec.ts
+++ b/src/utilities/createRoutes.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'vitest'
+import RouterView from '@/components/routerView.vue'
 import { createRoutes } from '@/utilities/createRoutes'
 import { component } from '@/utilities/testHelpers'
 
@@ -52,4 +53,15 @@ describe('route key dot notation', () => {
     expect(childRoute?.key).toBe('child')
   })
 
+})
+
+test('given route without component, sets component default to RouterView', () => {
+  const [route] = createRoutes([
+    {
+      name: 'without-component',
+      path: '/without-component',
+    },
+  ])
+
+  expect(route.matched.component).toMatchObject(RouterView)
 })

--- a/src/utilities/createRoutes.ts
+++ b/src/utilities/createRoutes.ts
@@ -1,4 +1,5 @@
 import { markRaw } from 'vue'
+import RouterView from '@/components/routerView.vue'
 import { DuplicateParamsError } from '@/errors'
 import { ParentRouteProps, RouteProps, Route, isParentRoute } from '@/types'
 import { checkDuplicateKeys } from '@/utilities/checkDuplicateKeys'
@@ -11,7 +12,10 @@ import { Query, ToQuery, toQuery } from '@/utilities/query'
 export function createRoutes<const TRoutes extends Readonly<RouteProps[]>>(routes: TRoutes): FlattenRoutes<TRoutes>
 export function createRoutes(routesProps: Readonly<RouteProps[]>): Route[] {
   const routes = routesProps.reduce<Route[]>((routes, routeProps) => {
-    const route = createRoute(routeProps)
+    const route = createRoute({
+      ...routeProps,
+      component: routeProps.component ?? RouterView,
+    })
 
     if (isParentRoute(routeProps) && routeProps.children) {
       routes.push(...routeProps.children.map(childRoute => ({
@@ -19,7 +23,7 @@ export function createRoutes(routesProps: Readonly<RouteProps[]>): Route[] {
         key: combineName(route.key, childRoute.key),
         path: combinePath(route.path, childRoute.path),
         query: combineQuery(route.query, childRoute.query),
-        matches: [...childRoute.matches, route.matched],
+        matches: [route.matched, ...childRoute.matches],
         depth: childRoute.depth + 1,
       })))
     }

--- a/vite.config.js
+++ b/vite.config.js
@@ -28,6 +28,14 @@ export default defineConfig({
       name: '@kitbag/router',
       fileName: 'kitbag-router',
     },
+    rollupOptions: {
+      external: ['vue'],
+      output: {
+        globals: {
+          vue: 'Vue',
+        },
+      },
+    },
   },
   plugins: [
     vue(),
@@ -35,12 +43,4 @@ export default defineConfig({
       rollupTypes: true 
     })
   ],
-  rollupOptions: {
-    external: ['vue'],
-    output: {
-      globals: {
-        vue: 'Vue',
-      },
-    },
-  },
 })


### PR DESCRIPTION
previously, if a child route rendered RouterView it would cause infinite loop. This PR moves responsibility for defaulting component to `createRoutes` method. 

side quests
- fixes vue external dep on vite build
- fixed bug with incorrect sort for matches, should be greatest ancestor -> least descendent
- attempts to fix type error when using plugin (could have been related to npm link)
- bumps version back to what's published on npm
- moves vue to peerDep