### PR TITLE
Remove children check in createRoutes

### DIFF
--- a/src/utilities/createRoutes.ts
+++ b/src/utilities/createRoutes.ts
@@ -17,7 +17,7 @@ export function createRoutes(routesProps: Readonly<RouteProps[]>): Route[] {
       component: routeProps.component ?? RouterView,
     })
 
-    if (isParentRoute(routeProps) && routeProps.children) {
+    if (isParentRoute(routeProps)) {
       routes.push(...routeProps.children.map(childRoute => ({
         ...childRoute,
         key: combineName(route.key, childRoute.key),


### PR DESCRIPTION
# Description
`isParentRoute` accurately guards that `children` will exist. 