### PR TITLE
Remove spyOn generics

### DIFF
--- a/src/components/routerLink.browser.spec.ts
+++ b/src/components/routerLink.browser.spec.ts
@@ -64,7 +64,7 @@ test.each([
 
   await router.initialized
 
-  const spy = vi.spyOn<any, 'push'>(router, 'push')
+  const spy = vi.spyOn(router, 'push')
 
   const root = {
     template: '<RouterView />',
@@ -97,7 +97,7 @@ test('to prop as string renders and routes correctly', () => {
     initialUrl: '/route',
   })
 
-  const spy = vi.spyOn<any, 'push'>(router, 'push')
+  const spy = vi.spyOn(router, 'push')
 
   const wrapper = mount(routerLink, {
     props: {


### PR DESCRIPTION
# Description
Tiny cleanup. We don't need these anymore now that our types are not recursive. 