### PR TITLE
Route matching updates

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -53,6 +53,7 @@ export default defineConfig({
         {
           text: 'Advanced Concepts',
           items: [
+            { text: 'Route Matching', link: '/advanced-concepts/route-matching' },
             { text: 'Rejections', link: '/advanced-concepts/rejections' },
             { text: 'Hooks', link: '/advanced-concepts/hooks' },
             { text: 'Route Meta', link: '/advanced-concepts/route-meta' },

--- a/docs/advanced-concepts/route-matching.md
+++ b/docs/advanced-concepts/route-matching.md
@@ -1,0 +1,139 @@
+# Route Matching
+
+## Rules
+
+There are several rules Kitbag Router uses to determine which of your routes corresponds to the current URL.
+
+### Named
+
+Routes without a [name](/core-concepts/defining-routes#route-names) property cannot be a direct match.
+
+### Path Matches
+
+Routes `path` must match the structure of the URL pathname.
+
+```ts
+const route {
+  ...
+  path: '/parent/anything/child'
+}
+```
+
+:white_check_mark: parent/anything/child  
+:x: parent/123/child  
+:x: parent//child  
+:x: parent/child  
+
+```ts
+const route {
+  ...
+  path: '/parent/:myParam/child'
+}
+```
+
+:white_check_mark: parent/anything/child  
+:white_check_mark: parent/123/child  
+:x: parent//child  
+:x: parent/child  
+
+```ts
+const route {
+  ...
+  path: '/parent/:?myParam/child'
+}
+```
+
+:white_check_mark: parent/anything/child  
+:white_check_mark: parent/123/child  
+:white_check_mark: parent//child  
+:x: parent/child  
+
+### Query Matches
+
+Routes `query` must match the structure of the URL search.
+
+```ts
+const route {
+  ...
+  query: 'foo=bar'
+}
+```
+
+:white_check_mark: ?foo=bar  
+:white_check_mark: ?kitbag=cat&foo=bar  
+:x: ?foo=123  
+:x: ?foo=  
+
+```ts
+const route {
+  ...
+  query: 'foo=:bar'
+}
+```
+
+:white_check_mark: ?foo=bar  
+:white_check_mark: ?kitbag=cat&foo=bar  
+:white_check_mark: ?foo=123  
+:x: ?foo=  
+
+```ts
+const route {
+  ...
+  query: 'foo=:?bar'
+}
+```
+
+:white_check_mark: ?foo=bar  
+:white_check_mark: ?kitbag=cat&foo=bar  
+:white_check_mark: ?foo=123  
+:white_check_mark: ?foo=  
+
+### Params Are Valid
+
+Assuming a route's path and query match the structure of the URL, the last test is to make sure that values provided by the URL pass the Param parsing. By default params are assumed to be strings, so by default if structure matches, parsing will pass as well since the URL is a string. However, if you define your params with `Boolean`, `Number`, or a custom `Param` the value will be need to pass the param's `get` function.
+
+```ts
+const route {
+  ...
+  path: '/parent/:id'
+  query: 'tab=:?tab'
+}
+```
+
+:white_check_mark: parent/123  
+:white_check_mark: parent/123?tab=true  
+:white_check_mark: parent/123?tab=github  
+:white_check_mark: parent/ABC?tab=true  
+
+```ts
+const route {
+  ...
+  path: path('/parent/:id', { id: Number })
+  query: 'tab=:?tab'
+}
+```
+
+:white_check_mark: parent/123  
+:white_check_mark: parent/123?tab=true  
+:white_check_mark: parent/123?tab=github  
+:x: parent/ABC?tab=true  
+
+```ts
+const route {
+  ...
+  path: path('/parent/:id', { id: Number })
+  query: query('tab=:?tab', { tab: Boolean })
+}
+```
+
+:white_check_mark: parent/123  
+:white_check_mark: parent/123?tab=true  
+:x: parent/123?tab=github  
+:x: parent/ABC?tab=true  
+
+## Ranking
+
+If there are more than 1 routes that pass the rules then we sort the results by the following.
+
+1. **Optional Params:** prioritize routes that match the greater number of optional path and query params
+2. **Route Depth:** prioritize routes that are more deeply nested

--- a/docs/core-concepts/navigating.md
+++ b/docs/core-concepts/navigating.md
@@ -41,7 +41,7 @@ router.push('/user/settings')
 router.push('https://github.com/kitbagjs/router')
 ```
 
-This `source` argument is type safe, expecting either a Url or a valid route "key". Url is any string that starts with "http", "https", or a forward slash "/". Route key is a string of route names joined by a period `.` that lead to a non-disabled route. Additionally if using the route key, push will require params be passed in if there are any.
+This `source` argument is type safe, expecting either a URL or a valid route "key". URL is any string that starts with "http", "https", or a forward slash "/". Route key is a string of route names joined by a period `.` that lead to a non-disabled route. Additionally if using the route key, push will require params be passed in if there are any.
 
 ### Providing Params
 
@@ -86,7 +86,7 @@ router.push('user.settings', params, {
 })
 ```
 
-If using push with a Url, there is no params argument so options will be the 2nd arg
+If using push with a URL, there is no params argument so options will be the 2nd arg
 
 ```ts
 router.push('/user/settings', {

--- a/docs/core-concepts/route-params.md
+++ b/docs/core-concepts/route-params.md
@@ -157,7 +157,7 @@ const routes = createRoutes([
 ])
 ```
 
-Which now, `router.params.id` has the type `number | undefined`, and will only match url where the value passes as a number or is missing entirely.
+Which now, `router.params.id` has the type `number | undefined`, and will only match URL where the value passes as a number or is missing entirely.
 
 ## Param Name
 

--- a/src/utilities/params.ts
+++ b/src/utilities/params.ts
@@ -13,7 +13,7 @@ type OptionalParamGetSet<TParam extends Param, TValue = ExtractParamType<TParam>
   get: (value: string | undefined, extras: ParamExtras) => TValue,
 }
 
-function isOptionalParam(param: Param | OptionalParamGetSet<Param>): param is OptionalParamGetSet<Param> {
+export function isOptionalParam(param: Param | OptionalParamGetSet<Param>): param is OptionalParamGetSet<Param> {
   return optionalKey in param
 }
 

--- a/src/utilities/paramsFinder.ts
+++ b/src/utilities/paramsFinder.ts
@@ -1,10 +1,11 @@
 import { Param } from '@/types'
 import { setParamValue } from '@/utilities/params'
+import { Path } from '@/utilities/path'
 import { replaceParamSyntaxWithCatchAlls } from '@/utilities/routeRegex'
 import { stringHasValue } from '@/utilities/string'
 
-export function getParamValueFromUrl(url: string, path: string, paramName: string): string | undefined {
-  const regexPattern = getParamRegexPattern(path, paramName)
+export function getParamValueFromUrl(url: string, path: Path | string, paramName: string): string | undefined {
+  const regexPattern = getParamRegexPattern(path.toString(), paramName)
   const [paramValue] = getCaptureGroups(url, regexPattern)
 
   return paramValue

--- a/src/utilities/routeMatchRegexRules.spec.ts
+++ b/src/utilities/routeMatchRegexRules.spec.ts
@@ -91,9 +91,9 @@ describe('routeQueryMatches', () => {
     ['we*23mf#0'],
     ['http://www.kitbag.io'],
     ['http://www.kitbag.io/'],
-    ['http://www.kitbag.io/is/empty'],
-    ['http://www.kitbag.io/is/empty?with=query'],
-    ['http://www.kitbag.io/is/empty?not=emptyish'],
+    ['http://www.kitbag.io/empty'],
+    ['http://www.kitbag.io/empty?with=query'],
+    ['http://www.kitbag.io/empty?not=emptyish'],
   ])('given url and route.query that does NOT match, returns false', (url) => {
     const [route] = createRoutes([
       {
@@ -138,6 +138,26 @@ describe('routeQueryMatches', () => {
         name: 'no-params',
         path: '',
         query: 'with=:params&static=:dynamic',
+        component,
+      },
+    ])
+
+    const response = routeQueryMatches(route, url)
+
+    expect(response).toBe(true)
+  })
+
+  test.each([
+    ['?optional'],
+    ['?optional='],
+    ['?optional=true'],
+    ['http://www.kitbag.io?extra=params&optional=provided'],
+  ])('given url and route.query with optional params that does match, returns true', (url) => {
+    const [route] = createRoutes([
+      {
+        name: 'optional-params',
+        path: '',
+        query: 'optional=:?optional',
         component,
       },
     ])

--- a/src/utilities/routeMatchRegexRules.spec.ts
+++ b/src/utilities/routeMatchRegexRules.spec.ts
@@ -93,6 +93,7 @@ describe('routeQueryMatches', () => {
     ['http://www.kitbag.io/'],
     ['http://www.kitbag.io/is/empty'],
     ['http://www.kitbag.io/is/empty?with=query'],
+    ['http://www.kitbag.io/is/empty?not=emptyish'],
   ])('given url and route.query that does NOT match, returns false', (url) => {
     const [route] = createRoutes([
       {

--- a/src/utilities/routeMatchScore.ts
+++ b/src/utilities/routeMatchScore.ts
@@ -1,21 +1,23 @@
 import { Route } from '@/types'
-import { createMaybeRelativeUrl } from '@/utilities'
+import { createMaybeRelativeUrl, getParamValueFromUrl, isOptionalParam } from '@/utilities'
 
 type RouteSortMethod = (aRoute: Route, bRoute: Route) => number
 
 export function getRouteScoreSortMethod(url: string): RouteSortMethod {
-  const { searchParams: actualQuery } = createMaybeRelativeUrl(url)
+  const { searchParams: actualQuery, pathname: actualPath } = createMaybeRelativeUrl(url)
   const sortBefore = -1
   const sortAfter = +1
 
   return (aRoute, bRoute) => {
-    const aRouteQueryScore = countExpectedQueryKeys(aRoute, actualQuery)
-    const bRouteQueryScore = countExpectedQueryKeys(bRoute, actualQuery)
+    const aRouteQueryScore = countExpectedQueryParams(aRoute, actualQuery)
+    const aRoutePathScore = countExpectedPathParams(aRoute, actualPath)
+    const bRouteQueryScore = countExpectedQueryParams(bRoute, actualQuery)
+    const bRoutePathScore = countExpectedPathParams(bRoute, actualPath)
 
-    if (aRouteQueryScore > bRouteQueryScore) {
+    if (aRouteQueryScore + aRoutePathScore > bRouteQueryScore + bRoutePathScore) {
       return sortBefore
     }
-    if (aRouteQueryScore < bRouteQueryScore) {
+    if (aRouteQueryScore + aRoutePathScore < bRouteQueryScore + bRoutePathScore) {
       return sortAfter
     }
 
@@ -30,7 +32,17 @@ export function getRouteScoreSortMethod(url: string): RouteSortMethod {
   }
 }
 
-export function countExpectedQueryKeys(route: Route, actualQuery: URLSearchParams): number {
+export function countExpectedPathParams(route: Route, actualPath: string): number {
+  const optionalParams = Object.entries(route.pathParams)
+    .filter(([, value]) => isOptionalParam(value))
+    .map(([key]) => key)
+
+  const missing = optionalParams.filter(expected => getParamValueFromUrl(actualPath, route.path, expected) === undefined)
+
+  return optionalParams.length - missing.length
+}
+
+export function countExpectedQueryParams(route: Route, actualQuery: URLSearchParams): number {
   const expectedQuery = new URLSearchParams(route.query.toString())
   const expectedQueryKeys = Array.from(expectedQuery.keys())
 

--- a/src/utilities/routeRegex.ts
+++ b/src/utilities/routeRegex.ts
@@ -11,7 +11,7 @@ export function generateRouteQueryRegexPatterns(route: Route): RegExp[] {
 
   return Array
     .from(queryParams.entries())
-    .map(([key, value]) => new RegExp(`${key}=${replaceParamSyntaxWithCatchAlls(value)}(&|$)`, 'i'))
+    .map(([key, value]) => new RegExp(`${key}(=${replaceParamSyntaxWithCatchAlls(value)})?(&|$)`, 'i'))
 }
 
 export function replaceParamSyntaxWithCatchAlls(value: string): string {

--- a/src/utilities/routeRegex.ts
+++ b/src/utilities/routeRegex.ts
@@ -11,7 +11,7 @@ export function generateRouteQueryRegexPatterns(route: Route): RegExp[] {
 
   return Array
     .from(queryParams.entries())
-    .map(([key, value]) => new RegExp(`${key}=${replaceParamSyntaxWithCatchAlls(value)}`, 'i'))
+    .map(([key, value]) => new RegExp(`${key}=${replaceParamSyntaxWithCatchAlls(value)}(&|$)`, 'i'))
 }
 
 export function replaceParamSyntaxWithCatchAlls(value: string): string {


### PR DESCRIPTION
while documenting route matching I discovered a bug with query regex matching when the value is static

```ts
const route = {
  ...
  query: 'foo=bar'
}
```

the regex was not asserting end of the value as either `&` or `$` (ampersand or end of input). This meant the following would be considered a match

- ?foo=bar
- ?foo=barrrr
- ?foo=barameter&zoo=keeper

Also while documenting route scoring I thought it was strange that we rank routes higher for having provided query params that are optional but not doing the same for path params. This  means

```ts
const route = {
  ...
  path: /:?optionalA/:?optionalB/:?optionalC
  query: 'foo=:?optionalFoo'
}
``` 

would choose 

- "///?foo=bar"

over

- "/fulfilledA/fulfilledB/fulfilledC"

even though the ladder fulfills 3 optional params and the former only 1

both are fixed by this PR