### PR TITLE
fixed a couple bugs with query regex

### DIFF
--- a/docs/advanced-concepts/route-matching.md
+++ b/docs/advanced-concepts/route-matching.md
@@ -62,7 +62,7 @@ const route {
 :white_check_mark: ?foo=bar  
 :white_check_mark: ?kitbag=cat&foo=bar  
 :x: ?foo=123  
-:x: ?foo=  
+:x: ?foo  
 
 ```ts
 const route {
@@ -74,7 +74,7 @@ const route {
 :white_check_mark: ?foo=bar  
 :white_check_mark: ?kitbag=cat&foo=bar  
 :white_check_mark: ?foo=123  
-:x: ?foo=  
+:x: ?foo  
 
 ```ts
 const route {
@@ -86,7 +86,11 @@ const route {
 :white_check_mark: ?foo=bar  
 :white_check_mark: ?kitbag=cat&foo=bar  
 :white_check_mark: ?foo=123  
-:white_check_mark: ?foo=  
+:white_check_mark: ?foo  
+
+::: tip
+when your query param is optional, the entire property can be missing and the route will still match. For the example above with query `foo=:?bar`, the url might be `/my-route` without any query, or it might have an unrelated query `/my-route?other=value`, and still be a match because the entire foo param is optional.
+:::
 
 ### Params Are Valid
 

--- a/src/utilities/paramsFinder.ts
+++ b/src/utilities/paramsFinder.ts
@@ -1,10 +1,9 @@
 import { Param } from '@/types'
 import { setParamValue } from '@/utilities/params'
-import { Path } from '@/utilities/path'
 import { replaceParamSyntaxWithCatchAlls } from '@/utilities/routeRegex'
 import { stringHasValue } from '@/utilities/string'
 
-export function getParamValueFromUrl(url: string, path: Path | string, paramName: string): string | undefined {
+export function getParamValueFromUrl(url: string, path: string, paramName: string): string | undefined {
   const regexPattern = getParamRegexPattern(path.toString(), paramName)
   const [paramValue] = getCaptureGroups(url, regexPattern)
 
@@ -46,13 +45,13 @@ function getParamRegexPattern(path: string, paramName: string): RegExp {
 function replaceOptionalParamSyntaxWithCaptureGroup(path: string, paramName: string): string {
   const optionalParamRegex = new RegExp(`(:\\?${paramName})(?=\\W|$)`, 'g')
 
-  return path.replace(optionalParamRegex, '([^/]*)')
+  return path.replace(optionalParamRegex, '([^\\/]*)')
 }
 
 function replaceRequiredParamSyntaxWithCaptureGroup(path: string, paramName: string): string {
   const requiredParamRegex = new RegExp(`(:${paramName})(?=\\W|$)`, 'g')
 
-  return path.replace(requiredParamRegex, '([^/]+)')
+  return path.replace(requiredParamRegex, '([^\\/]+)')
 }
 
 function getCaptureGroups(value: string, pattern: RegExp): string[] {

--- a/src/utilities/routeMatchScore.ts
+++ b/src/utilities/routeMatchScore.ts
@@ -37,7 +37,7 @@ export function countExpectedPathParams(route: Route, actualPath: string): numbe
     .filter(([, value]) => isOptionalParam(value))
     .map(([key]) => key)
 
-  const missing = optionalParams.filter(expected => getParamValueFromUrl(actualPath, route.path, expected) === undefined)
+  const missing = optionalParams.filter(expected => getParamValueFromUrl(actualPath, route.path.toString(), expected) === undefined)
 
   return optionalParams.length - missing.length
 }

--- a/src/utilities/routeRegex.spec.ts
+++ b/src/utilities/routeRegex.spec.ts
@@ -29,7 +29,7 @@ describe('generateRoutePathRegexPattern', () => {
 
     const result = generateRoutePathRegexPattern(route)
 
-    const catchAll = '[^/]+'
+    const catchAll = '[^\\/]+'
     const expected = new RegExp(`^parent/child/${catchAll}/grand-child/${catchAll}$`, 'i')
     expect(result.toString()).toBe(expected.toString())
   })
@@ -45,7 +45,7 @@ describe('generateRoutePathRegexPattern', () => {
 
     const result = generateRoutePathRegexPattern(route)
 
-    const catchAll = '[^/]*'
+    const catchAll = '[^\\/]*'
     const expected = new RegExp(`^parent/child/${catchAll}/grand-child/${catchAll}$`, 'i')
     expect(result.toString()).toBe(expected.toString())
   })
@@ -66,7 +66,7 @@ describe('generateRouteQueryRegexPatterns', () => {
     expect(result).toMatchObject([])
   })
 
-  test('given query with params, returns value with params replaced with catchall', () => {
+  test('given query with required params, returns value with params replaced with catchall', () => {
     const [route] = createRoutes([
       {
         name: 'query-with-params',
@@ -82,7 +82,7 @@ describe('generateRouteQueryRegexPatterns', () => {
     expect(result).toMatchObject([new RegExp(`dynamic=${catchAll}`), new RegExp('static=params'), new RegExp(`dynamic=${catchAll}`)])
   })
 
-  test('given query with optional params, returns value with params replaced with catchall', () => {
+  test('given query with optional params, returns value without params', () => {
     const [route] = createRoutes([
       {
         name: 'query-with-optional-params',
@@ -94,7 +94,6 @@ describe('generateRouteQueryRegexPatterns', () => {
 
     const result = generateRouteQueryRegexPatterns(route)
 
-    const catchAll = '([^/]*)'
-    expect(result).toMatchObject([new RegExp(`dynamic=${catchAll}`), new RegExp('static=params'), new RegExp(`dynamic=${catchAll}`)])
+    expect(result).toMatchObject([new RegExp('static=params')])
   })
 })

--- a/src/utilities/routeRegex.ts
+++ b/src/utilities/routeRegex.ts
@@ -11,7 +11,8 @@ export function generateRouteQueryRegexPatterns(route: Route): RegExp[] {
 
   return Array
     .from(queryParams.entries())
-    .map(([key, value]) => new RegExp(`${key}(=${replaceParamSyntaxWithCatchAlls(value)})?(&|$)`, 'i'))
+    .filter(([, value]) => !isOptionalParamSyntax(value))
+    .map(([key, value]) => new RegExp(`${key}=${replaceParamSyntaxWithCatchAlls(value)}(&|$)`, 'i'))
 }
 
 export function replaceParamSyntaxWithCatchAlls(value: string): string {
@@ -23,14 +24,18 @@ export function replaceParamSyntaxWithCatchAlls(value: string): string {
   }, value)
 }
 
-function replaceOptionalParamSyntaxWithCatchAll(value: string): string {
-  const optionalParamRegex = /(:\?[\w]+)(?=\W|$)/g
+const optionalParamRegex = /(:\?[\w]+)(?=\W|$)/g
+const requiredParamRegex = /(:[\w]+)(?=\W|$)/g
 
-  return value.replace(optionalParamRegex, '[^/]*')
+function replaceOptionalParamSyntaxWithCatchAll(value: string): string {
+  return value.replace(optionalParamRegex, '[^\\/]*')
+}
+
+function isOptionalParamSyntax(value: string): boolean {
+  return optionalParamRegex.test(value)
 }
 
 function replaceRequiredParamSyntaxWithCatchAll(value: string): string {
-  const requiredParamRegex = /(:[\w]+)(?=\W|$)/g
 
-  return value.replace(requiredParamRegex, '[^/]+')
+  return value.replace(requiredParamRegex, '[^\\/]+')
 }

--- a/src/utilities/urlAssembly.ts
+++ b/src/utilities/urlAssembly.ts
@@ -1,4 +1,4 @@
-import { Route } from '@/types'
+import { Param, Route } from '@/types'
 import { setParamValueOnUrl } from '@/utilities/paramsFinder'
 import { withQuery } from '@/utilities/withQuery'
 
@@ -12,11 +12,19 @@ export function assembleUrl(route: Route, options: AssembleUrlOptions = {}): str
   const params = Object.entries({ ...route.pathParams, ...route.queryParams })
   const path = route.path.toString()
   const query = route.query.toString()
-  const pathWithQuery = query.length ? `${path}?${query}` : path
 
-  const url = params.reduce<string>((url, [name, param]) => {
+  const pathWithParamsSet = assembleParamValues(path, params, paramValues)
+  const queryWithParamsSet = assembleParamValues(query, params, paramValues)
+
+  return withQuery(pathWithParamsSet, queryWithParamsSet, queryValues)
+}
+
+function assembleParamValues(part: string, params: [string, Param][], paramValues: Record<string, unknown>): string {
+  if (!part.length) {
+    return part
+  }
+
+  return params.reduce<string>((url, [name, param]) => {
     return setParamValueOnUrl(url, { name, param, value: paramValues[name] })
-  }, pathWithQuery)
-
-  return withQuery(url, queryValues)
+  }, part)
 }

--- a/src/utilities/withQuery.ts
+++ b/src/utilities/withQuery.ts
@@ -1,17 +1,19 @@
-export function withQuery(url: string, query?: Record<string, string>): string {
-  if (!query) {
-    return url
-  }
+export function withQuery(url: string, ...queries: (string | URLSearchParams | Record<string, string> | undefined)[]): string {
+  return queries.reduce<string>((value, query) => {
+    if (!query) {
+      return value
+    }
 
-  if (Object.keys(query).length === 0) {
-    return url
-  }
+    const queryString = new URLSearchParams(query).toString()
 
-  const queryString = new URLSearchParams(query).toString()
+    if (Object.keys(queryString).length === 0) {
+      return value
+    }
 
-  if (url.includes('?')) {
-    return `${url}&${queryString}`
-  }
+    if (value.includes('?')) {
+      return `${value}&${queryString}`
+    }
 
-  return `${url}?${queryString}`
+    return `${value}?${queryString}`
+  }, url)
 }


### PR DESCRIPTION
fixes (2) bugs discovered in testing a recent PR

- because setting param values on query was trying to set params across both path and query it wasn't escaping the "?" in regex which caused some weird downstream effects. Now I set values like I get the values, separately on path and query THEN combine
- optional query params still expected the "key" to be present. So `/route?with=:?param` would match `/route?with=`, `/route?with`, but not  `/route`. My solution to this was to update the RouteMatchRule for query matches to only check required params. Any mis-types for optional params would get caught in the RouteMatchRule for params. 