### PR TITLE
Route meta documented

### DIFF
--- a/docs/advanced-concepts/route-matching.md
+++ b/docs/advanced-concepts/route-matching.md
@@ -1,14 +1,12 @@
 # Route Matching
 
-## Rules
-
 There are several rules Kitbag Router uses to determine which of your routes corresponds to the current URL.
 
-### Named
+## Named
 
 Routes without a [name](/core-concepts/defining-routes#route-names) property cannot be a direct match.
 
-### Path Matches
+## Path Matches
 
 Routes `path` must match the structure of the URL pathname.
 
@@ -48,7 +46,7 @@ const route {
 :white_check_mark: parent//child  
 :x: parent/child  
 
-### Query Matches
+## Query Matches
 
 Routes `query` must match the structure of the URL search.
 
@@ -92,7 +90,7 @@ const route {
 when your query param is optional, the entire property can be missing and the route will still match. For the example above with query `foo=:?bar`, the url might be `/my-route` without any query, or it might have an unrelated query `/my-route?other=value`, and still be a match because the entire foo param is optional.
 :::
 
-### Params Are Valid
+## Params Are Valid
 
 Assuming a route's path and query match the structure of the URL, the last test is to make sure that values provided by the URL pass the Param parsing. By default params are assumed to be strings, so by default if structure matches, parsing will pass as well since the URL is a string. However, if you define your params with `Boolean`, `Number`, or a custom `Param` the value will be need to pass the param's `get` function.
 

--- a/docs/advanced-concepts/route-meta.md
+++ b/docs/advanced-concepts/route-meta.md
@@ -1,1 +1,42 @@
 # Route Meta
+
+It may be useful to store additional context on your route to be used in a hook, or within a component. Meta data might be useful for authorization, analytics, and much more. For example, below we will use route meta to configure the document title per route.
+
+```ts
+import { createRoutes, createRouter } from '@kitbag/router'
+
+const routes = createRoutes([
+  { 
+    name: 'home',
+    path: '/',
+    component: Home,
+    meta: {
+      pageTitle: 'Kitbag Home'
+    }
+  },
+  { 
+    name: 'path',
+    path: '/about',
+    component: About,
+    meta: {
+      pageTitle: 'Learn More About Kitbag'
+    }
+  },
+])
+
+const router = createRouter(routes)
+
+router.onAfterRouteEnter(to => {
+  document.title = to.matched.meta.pageTitle
+})
+```
+
+You might notice that the default type for `pageTitle` is `unknown`. By default meta is `Record<string, unknown>` but can be narrowed with [declaration merging](https://www.typescriptlang.org/docs/handbook/declaration-merging.html).
+
+```ts
+declare module '@kitbag/router' {
+  interface RouteMeta {
+    pageTitle?: string
+  }
+}
+```

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -1,8 +1,10 @@
 import { ExtractParamTypes, MergeParams, Param } from '@/types/params'
-import { RouteProps } from '@/types/routeProps'
+import { RouteMeta, RouteProps } from '@/types/routeProps'
 import { Path, Query, ToPath, ToQuery } from '@/utilities'
 
 export type Routes = Readonly<Route[]>
+
+type RoutePropsWithMeta = RouteProps & { meta: RouteMeta }
 
 export type Route<
   TKey extends string | undefined = any,
@@ -10,8 +12,8 @@ export type Route<
   TQuery extends string | Query | undefined = Query,
   TDisabled extends boolean | undefined = boolean
 > = {
-  matched: RouteProps,
-  matches: RouteProps[],
+  matched: RoutePropsWithMeta,
+  matches: RoutePropsWithMeta[],
   key: TKey,
   path: ToPath<TPath>,
   query: ToQuery<TQuery>,

--- a/src/types/routeProps.ts
+++ b/src/types/routeProps.ts
@@ -7,9 +7,7 @@ import { Query } from '@/utilities/query'
 
 export type RouteComponent = Component | DefineComponent | AsyncComponentLoader
 
-export interface RouteMeta {
-
-}
+export interface RouteMeta extends Record<string, unknown> {}
 
 type WithHooks = {
   onBeforeRouteEnter?: MaybeArray<BeforeRouteHook>,

--- a/src/utilities/createRouterReject.ts
+++ b/src/utilities/createRouterReject.ts
@@ -52,6 +52,7 @@ export function createRouterReject({
       name: type,
       path: '',
       component,
+      meta: {},
     }
 
     const resolved = readonly({

--- a/src/utilities/createRoutes.spec.ts
+++ b/src/utilities/createRoutes.spec.ts
@@ -66,3 +66,15 @@ test('given route without component, sets component default to RouterView', () =
 
   expect(route.matched.component).toMatchObject(RouterView)
 })
+
+test('given route without meta, sets meta equal to empty object', () => {
+  const [route] = createRoutes([
+    {
+      name: 'without-meta',
+      path: '/without-meta',
+      component,
+    },
+  ])
+
+  expect(route.matched.meta).toEqual({})
+})

--- a/src/utilities/createRoutes.ts
+++ b/src/utilities/createRoutes.ts
@@ -46,7 +46,7 @@ export function createRoutes(routesProps: Readonly<RouteProps[]>): Route[] {
 function createRoute(route: RouteProps): Route {
   const path = toPath(route.path)
   const query = toQuery(route.query)
-  const rawRoute = markRaw(route)
+  const rawRoute = markRaw({ meta: {}, ...route })
 
   return {
     matched: rawRoute,

--- a/src/utilities/getRouteHooks.spec.ts
+++ b/src/utilities/getRouteHooks.spec.ts
@@ -6,7 +6,9 @@ import { createResolvedRouteQuery } from '@/utilities/createResolvedRouteQuery'
 import { getBeforeRouteHooksFromRoutes } from '@/utilities/getRouteHooks'
 import { component } from '@/utilities/testHelpers'
 
-function mockRoute(name: string): RouteProps {
+type RoutePropsWithMeta = RouteProps & { meta: Record<string, unknown> }
+
+function mockRoute(name: string): RoutePropsWithMeta {
   return {
     name,
     path: `/${name}`,
@@ -14,10 +16,11 @@ function mockRoute(name: string): RouteProps {
     onBeforeRouteEnter: vi.fn(),
     onBeforeRouteUpdate: vi.fn(),
     onBeforeRouteLeave: vi.fn(),
+    meta: {},
   }
 }
 
-function mockResolvedRoute(matched: RouteProps, matches: RouteProps[]): ResolvedRoute {
+function mockResolvedRoute(matched: RoutePropsWithMeta, matches: RoutePropsWithMeta[]): ResolvedRoute {
   return readonly({
     matched,
     matches,

--- a/src/utilities/hooks.spec.ts
+++ b/src/utilities/hooks.spec.ts
@@ -16,6 +16,7 @@ test('calls hook with correct routes', () => {
     path: '/routeA',
     component,
     onBeforeRouteEnter: hook,
+    meta: {},
   }
 
   const resolvedRouteA: ResolvedRoute = {
@@ -30,6 +31,7 @@ test('calls hook with correct routes', () => {
     name: 'routeB',
     path: '/routeB',
     component,
+    meta: {},
   }
 
   const resolvedRouteB: ResolvedRoute = {
@@ -66,6 +68,7 @@ test.each<{ type: string, status: string, hook: BeforeRouteHook }>([
     path: '/routeA',
     component,
     onBeforeRouteEnter: hook,
+    meta: {},
   }
 
   const resolvedRoute: ResolvedRoute = {
@@ -80,6 +83,7 @@ test.each<{ type: string, status: string, hook: BeforeRouteHook }>([
     name: 'routeB',
     path: '/routeB',
     component,
+    meta: {},
   }
 
   const resolvedRouteB: ResolvedRoute = {
@@ -111,6 +115,7 @@ test('hook is called in order', async () => {
     path: '/routeA',
     component,
     onBeforeRouteEnter: [hookA, hookB, hookC],
+    meta: {},
   }
 
   const resolvedRoute: ResolvedRoute = {
@@ -125,6 +130,7 @@ test('hook is called in order', async () => {
     name: 'routeB',
     path: '/routeB',
     component,
+    meta: {},
   }
 
   const resolvedRouteB: ResolvedRoute = {


### PR DESCRIPTION
- normalize `matched.meta` to always be empty object so devs don't have to check for undefined

```ts
// without
route.metached.meta?.thing

// with
route.matched.meta.thing
```

- update types for RouteMeta to be `Record<string, unknown>` so regardless of if devs override interface all string keys will be accepted and value defaults to unknown
- docs updated