### PR TITLE
fix children not having param context of parent

### DIFF
--- a/src/services/createRoutes.ts
+++ b/src/services/createRoutes.ts
@@ -55,8 +55,6 @@ function createRoute(route: RouteProps): Route {
     key: route.name,
     path,
     query,
-    pathParams: path.params,
-    queryParams: query.params,
     depth: 1,
     disabled: route.disabled ?? false,
   }

--- a/src/services/paramValidation.ts
+++ b/src/services/paramValidation.ts
@@ -19,8 +19,8 @@ export const getRouteParamValues = (route: Route, url: string): Record<string, u
   const { pathname, search } = createMaybeRelativeUrl(url)
 
   return {
-    ...getRouteParams(route.pathParams, route.path.toString(), pathname),
-    ...getRouteParams(route.queryParams, route.query.toString(), search),
+    ...getRouteParams(route.path.params, route.path.toString(), pathname),
+    ...getRouteParams(route.query.params, route.query.toString(), search),
   }
 }
 

--- a/src/services/routeMatchScore.ts
+++ b/src/services/routeMatchScore.ts
@@ -35,7 +35,7 @@ export function getRouteScoreSortMethod(url: string): RouteSortMethod {
 }
 
 export function countExpectedPathParams(route: Route, actualPath: string): number {
-  const optionalParams = Object.entries(route.pathParams)
+  const optionalParams = Object.entries(route.path.params)
     .filter(([, value]) => isOptionalParam(value))
     .map(([key]) => key)
 

--- a/src/services/urlAssembly.ts
+++ b/src/services/urlAssembly.ts
@@ -10,7 +10,7 @@ type AssembleUrlOptions = {
 
 export function assembleUrl(route: Route, options: AssembleUrlOptions = {}): string {
   const { params: paramValues = {}, query: queryValues } = options
-  const params = Object.entries({ ...route.pathParams, ...route.queryParams })
+  const params = Object.entries({ ...route.path.params, ...route.query.params })
   const path = route.path.toString()
   const query = route.query.toString()
 

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -3,7 +3,7 @@ import { ResolvedRouteQuery } from '@/types/resolvedQuery'
 import { ExtractRouteParamTypes, Route } from '@/types/route'
 import { RouteProps } from '@/types/routeProps'
 
-type BaseResolvedRoute = Route & { pathParams: Record<string, unknown>, queryParams: Record<string, unknown> }
+type BaseResolvedRoute = Route & { path: { params: Record<string, unknown> }, query: { params: Record<string, unknown> } }
 
 export type ResolvedRoute<TRoute extends Route = BaseResolvedRoute> = DeepReadonly<{
   matched: TRoute['matched'],

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -19,12 +19,10 @@ export type Route<
   key: TKey,
   path: ToPath<TPath>,
   query: ToQuery<TQuery>,
-  pathParams: ToPath<TPath>['params'],
-  queryParams: ToQuery<TQuery>['params'],
   depth: number,
   disabled: TDisabled extends boolean ? TDisabled : false,
 }
 
-export type ExtractRouteParamTypes<TRoute extends { pathParams: Record<string, unknown>, queryParams: Record<string, unknown> }> = TRoute extends { pathParams: infer PathParams extends Record<string, Param | undefined>, queryParams: infer QueryParams extends Record<string, Param | undefined> }
+export type ExtractRouteParamTypes<TRoute extends { path: { params: Record<string, unknown> }, query: { params: Record<string, unknown> } }> = TRoute extends { path: { params: infer PathParams extends Record<string, Param | undefined> }, query: { params: infer QueryParams extends Record<string, Param | undefined> } }
   ? ExtractParamTypes<MergeParams<PathParams, QueryParams>>
   : Record<string, unknown>

--- a/src/types/routesMap.ts
+++ b/src/types/routesMap.ts
@@ -1,6 +1,6 @@
 import { Routes } from '@/types/route'
 
-type BaseRoute = { key: string, disabled: false, pathParams: Record<string, unknown>, queryParams: Record<string, unknown> }
+type BaseRoute = { key: string, disabled: false, path: { params: Record<string, unknown> }, query: { params: Record<string, unknown> } }
 type NamedNotDisabled<T> = T extends BaseRoute ? T : never
 
 export type RoutesMap<TRoutes extends Routes = []> = {


### PR DESCRIPTION
drop separate params buckets in favor of combined path and query which also contain params