### PR TITLE
Fix router.find returning any route with `/` as the path when resolving an external url with no path

### DIFF
--- a/src/errors/routeDisabledError.ts
+++ b/src/errors/routeDisabledError.ts
@@ -1,0 +1,8 @@
+/**
+ * An error thrown when attempting to resolve a route that is disabled
+ */
+export class RouteDisabledError extends Error {
+  public constructor(source: string) {
+    super(`Route disabled: "${source}"`)
+  }
+}

--- a/src/errors/routeNotFoundError.ts
+++ b/src/errors/routeNotFoundError.ts
@@ -1,0 +1,8 @@
+/**
+ * An error thrown when attempting to resolve a route that does not exist
+ */
+export class RouteNotFoundError extends Error {
+  public constructor(source: string) {
+    super(`Route not found: "${source}"`)
+  }
+}

--- a/src/services/createRouterFind.spec.ts
+++ b/src/services/createRouterFind.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from 'vitest'
+import { RouteNotFoundError } from '@/errors/routeNotFoundError'
+import { createRouterFind } from '@/services/createRouterFind'
+import { routes } from '@/utilities'
+
+test('when given a key that matches a route return that route', () => {
+  const find = createRouterFind(routes)
+
+  const route = find('parentB')
+
+  expect(route).toBeDefined()
+  expect(route?.key).toBe('parentB')
+})
+
+test('when given a url that matches a route returns that route', () => {
+  const find = createRouterFind(routes)
+  const route = find('/parentB')
+
+  expect(route).toBeDefined()
+  expect(route?.key).toBe('parentB')
+})
+
+test('when given a key that does not match a route returns undefined', () => {
+  const find = createRouterFind(routes)
+
+  // @ts-expect-error
+  expect(() => find('parentD')).toThrow(RouteNotFoundError)
+})
+
+test('when given a url that does not match a route returns undefined', () => {
+  const find = createRouterFind(routes)
+  const route = find('/parentC')
+
+  expect(route).toBeUndefined()
+})
+
+test('when given a url that does not match a route returns undefined', () => {
+  const find = createRouterFind(routes)
+  const route = find('/does-not-exist')
+
+  expect(route).toBeUndefined()
+})
+
+test('when given an external url that does not match a route returns undefined', () => {
+  const find = createRouterFind(routes)
+  const route = find('https://example.com')
+
+  expect(route).toBeUndefined()
+})

--- a/src/services/createRouterResolve.spec.ts
+++ b/src/services/createRouterResolve.spec.ts
@@ -11,7 +11,7 @@ test('given a url returns that string', () => {
 test('given a route key with params returns the url', () => {
   const resolve = createRouterResolve(routes)
 
-  expect(resolve('parentA', { paramA: 'bar' })).toBe('/bar')
+  expect(resolve('parentA', { paramA: 'bar' })).toBe('/parentA/bar')
 })
 
 test('given a route key and a query appends query to the url', () => {
@@ -19,7 +19,7 @@ test('given a route key and a query appends query to the url', () => {
   const resolve = createRouterResolve(routes)
   const url = resolve('parentA', { paramA: 'bar' }, { query: { foo: 'foo' } })
 
-  expect(url).toBe('/bar?foo=foo')
+  expect(url).toBe('/parentA/bar?foo=foo')
 })
 
 test('given a route key with params cannot be matched, throws an error', () => {

--- a/src/services/createRouterResolve.ts
+++ b/src/services/createRouterResolve.ts
@@ -1,3 +1,5 @@
+import { RouteDisabledError } from '@/errors/routeDisabledError'
+import { RouteNotFoundError } from '@/errors/routeNotFoundError'
 import { assembleUrl } from '@/services/urlAssembly'
 import { withQuery } from '@/services/withQuery'
 import { Routes } from '@/types/route'
@@ -44,11 +46,11 @@ export function createRouterResolve<const TRoutes extends Routes>(routes: TRoute
     const match = routes.find((route) => route.key === source)
 
     if (!match) {
-      throw `Route not found: "${String(source)}"`
+      throw new RouteNotFoundError(String(source))
     }
 
     if (match.matched.disabled) {
-      throw `Route disabled: "${String(source)}"`
+      throw new RouteDisabledError(String(source))
     }
 
     const url = assembleUrl(match, {

--- a/src/services/getResolvedRouteForUrl.ts
+++ b/src/services/getResolvedRouteForUrl.ts
@@ -2,14 +2,21 @@ import { readonly } from 'vue'
 import { createMaybeRelativeUrl } from '@/services/createMaybeRelativeUrl'
 import { createResolvedRouteQuery } from '@/services/createResolvedRouteQuery'
 import { getRouteParamValues, routeParamsAreValid } from '@/services/paramValidation'
-import { routePathMatches, routeQueryMatches } from '@/services/routeMatchRegexRules'
+import { isNamedRoute, routeHostMatches, routePathMatches, routeQueryMatches } from '@/services/routeMatchRules'
 import { getRouteScoreSortMethod } from '@/services/routeMatchScore'
 import { ResolvedRoute } from '@/types/resolved'
 import { Routes } from '@/types/route'
 import { RouteMatchRule } from '@/types/routeMatchRule'
 
+const rules: RouteMatchRule[] = [
+  isNamedRoute,
+  routeHostMatches,
+  routePathMatches,
+  routeQueryMatches,
+  routeParamsAreValid,
+]
+
 export function getResolvedRouteForUrl(routes: Routes, url: string): ResolvedRoute | undefined {
-  const rules = [isNamedRoute, routePathMatches, routeQueryMatches, routeParamsAreValid]
   const sortByRouteScore = getRouteScoreSortMethod(url)
 
   const matches = routes
@@ -32,8 +39,4 @@ export function getResolvedRouteForUrl(routes: Routes, url: string): ResolvedRou
     query,
     params,
   })
-}
-
-const isNamedRoute: RouteMatchRule = (route) => {
-  return 'name' in route.matched && !!route.matched.name
 }

--- a/src/services/routeMatchRules.spec.ts
+++ b/src/services/routeMatchRules.spec.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
 import { createRoutes } from '@/services/createRoutes'
-import { routePathMatches, routeQueryMatches } from '@/services/routeMatchRegexRules'
+import { routePathMatches, routeQueryMatches } from '@/services/routeMatchRules'
 import { component } from '@/utilities/testHelpers'
 
 describe('routePathMatches', () => {

--- a/src/services/routeMatchRules.ts
+++ b/src/services/routeMatchRules.ts
@@ -2,6 +2,17 @@ import { createMaybeRelativeUrl } from '@/services/createMaybeRelativeUrl'
 import { generateRoutePathRegexPattern, generateRouteQueryRegexPatterns } from '@/services/routeRegex'
 import { RouteMatchRule } from '@/types/routeMatchRule'
 
+export const isNamedRoute: RouteMatchRule = (route) => {
+  return 'name' in route.matched && !!route.matched.name
+}
+
+export const routeHostMatches: RouteMatchRule = (route, url) => {
+  const { host: urlHost } = createMaybeRelativeUrl(url)
+  const { host: routeHost } = createMaybeRelativeUrl(route.path.toString())
+
+  return urlHost === routeHost
+}
+
 export const routePathMatches: RouteMatchRule = (route, url) => {
   const { pathname } = createMaybeRelativeUrl(url)
   const pathPattern = generateRoutePathRegexPattern(route)

--- a/src/types/routeWithParams.spec-d.ts
+++ b/src/types/routeWithParams.spec-d.ts
@@ -7,14 +7,14 @@ import { routes } from '@/utilities/testHelpers'
 
 test('CombineName returns correct keys for routes', () => {
   type Source = typeof routes[number]['key']
-  type Expect = 'parentA' | 'parentB' | 'parentA.childA' | 'parentA.childA.grandChildA' | 'parentA.childB'
+  type Expect = 'parentA' | 'parentB' | 'parentA.childA' | 'parentA.childA.grandChildA' | 'parentA.childB' | 'parentC'
 
   expectTypeOf<Source>().toEqualTypeOf<Expect>()
 })
 
 test('RouteGetByName works as expected', () => {
   type Source = RouteGetByKey<typeof routes, 'parentA'>
-  type Expect = Route<'parentA', Path<'/[paramA]', {}>, Query<'', {}>, false>
+  type Expect = Route<'parentA', Path<'/parentA/[paramA]', {}>, Query<'', {}>, false>
 
   expectTypeOf<Source>().toEqualTypeOf<Expect>()
 })

--- a/src/utilities/testHelpers.ts
+++ b/src/utilities/testHelpers.ts
@@ -14,7 +14,7 @@ export const component = { template: '<div>This is component</div>' }
 export const routes = createRoutes([
   {
     name: 'parentA',
-    path: '/[paramA]',
+    path: '/parentA/[paramA]',
     children: createRoutes([
       {
         name: 'childA',
@@ -37,6 +37,11 @@ export const routes = createRoutes([
   {
     name: 'parentB',
     path: '/parentB',
+    component,
+  },
+  {
+    name: 'parentC',
+    path: '/',
     component,
   },
 ])


### PR DESCRIPTION
# Description
Adds a route match rule for host to make sure that `http://example.com` doesn't match a route with path `/`. This would previously match because the path for `https://example.com` is `/`. So we need to check the host itself. 

Closes https://github.com/kitbagjs/router/issues/179