### PR TITLE
Fix param names unable to be snake or kebab case

### DIFF
--- a/src/services/createRouterResolve.spec.ts
+++ b/src/services/createRouterResolve.spec.ts
@@ -1,6 +1,7 @@
 import { expect, test } from 'vitest'
 import { createRouterResolve } from '@/services/createRouterResolve'
-import { routes } from '@/utilities/testHelpers'
+import { createRoutes } from '@/services/createRoutes'
+import { component, routes } from '@/utilities/testHelpers'
 
 test('given a url returns that string', () => {
   const resolve = createRouterResolve(routes)
@@ -27,4 +28,30 @@ test('given a route key with params cannot be matched, throws an error', () => {
 
   // @ts-expect-error
   expect(() => resolve({ route: 'foo' })).toThrowError()
+})
+
+
+test('given a param with a dash or underscore resolves the correct url', () => {
+  const routes = createRoutes([
+    {
+      name: 'kebab',
+      path: '/[test-param]',
+      component,
+    },
+    {
+      name: 'snake',
+      path: '/[test_param]',
+      component,
+    },
+  ])
+
+  const resolve = createRouterResolve(routes)
+
+  const kebab = resolve('kebab', { 'test-param': 'foo' })
+
+  expect(kebab).toBe('/foo')
+
+  const snake = resolve('snake', { 'test_param': 'foo' })
+
+  expect(snake).toBe('/foo')
 })

--- a/src/services/getParamsForString.ts
+++ b/src/services/getParamsForString.ts
@@ -4,7 +4,7 @@ import { paramEnd, paramStart } from '@/types/params'
 import { Param } from '@/types/paramTypes'
 
 export function getParamsForString<TInput extends string, TParams extends Record<string, Param | undefined>>(string: TInput, params: TParams): Record<string, Param> {
-  const paramPattern = new RegExp(`\\${paramStart}\\??([\\w]+)\\${paramEnd}`, 'g')
+  const paramPattern = new RegExp(`\\${paramStart}\\??([\\w-_]+)\\${paramEnd}`, 'g')
   const matches = Array.from(string.matchAll(paramPattern))
 
   return matches.reduce<Record<string, Param>>((value, [match, paramName]) => {

--- a/src/services/routeRegex.ts
+++ b/src/services/routeRegex.ts
@@ -26,8 +26,8 @@ export function replaceParamSyntaxWithCatchAlls(value: string): string {
   }, value)
 }
 
-const optionalParamRegex = `\\${paramStart}\\?([\\w]+)\\${paramEnd}`
-const requiredParamRegex = `\\${paramStart}([\\w]+)\\${paramEnd}`
+const optionalParamRegex = `\\${paramStart}\\?([\\w-_]+)\\${paramEnd}`
+const requiredParamRegex = `\\${paramStart}([\\w-_]+)\\${paramEnd}`
 
 function replaceOptionalParamSyntaxWithCatchAll(value: string): string {
   return value.replace(new RegExp(optionalParamRegex, 'g'), '.*')


### PR DESCRIPTION
# Description
Since the param regex only looked for `\w` characters any param name that was snake or kebab case would not work. Adding `-` and `_` to the regex patterns fixes this.

Closes https://github.com/kitbagjs/router/issues/144