### PR TITLE
Named router views

### DIFF
--- a/src/components/routerView.browser.spec.ts
+++ b/src/components/routerView.browser.spec.ts
@@ -260,3 +260,39 @@ test('Renders the route component when the router.push does match after a reject
 
   expect(app.text()).toBe('hello world')
 })
+
+test('Renders the multiple components when using named route views', async () => {
+  const routes = createRoutes([
+    {
+      name: 'parent',
+      path: '/',
+      components: {
+        default: { template: '_default_' },
+        one: { template: '_one_' },
+        two: { template: '_two_' },
+      },
+    },
+  ])
+
+  const router = createRouter(routes, {
+    initialUrl: '/',
+  })
+
+  await router.initialized
+
+  const root = {
+    template: `
+      <RouterView name="one" />
+      <RouterView />
+      <RouterView name="two" />
+    `,
+  }
+
+  const app = mount(root, {
+    global: {
+      plugins: [router],
+    },
+  })
+
+  expect(app.text()).toBe('_one__default__two_')
+})

--- a/src/components/routerView.browser.spec.ts
+++ b/src/components/routerView.browser.spec.ts
@@ -4,6 +4,7 @@ import { defineAsyncComponent } from 'vue'
 import helloWorld from '@/components/helloWorld'
 import { createRouter } from '@/services/createRouter'
 import { createRoutes } from '@/services/createRoutes'
+import { isRouteWithComponent } from '@/types/routeProps'
 
 test('renders component for initial route', async () => {
   const routes = createRoutes([
@@ -187,6 +188,10 @@ test('Renders custom genericRejection component when the initialUrl does not mat
       plugins: [router],
     },
   })
+
+  if (!isRouteWithComponent(router.route.matched)) {
+    throw 'Matched route does not have a single component'
+  }
 
   const route = mount(router.route.matched.component)
 

--- a/src/components/routerView.vue
+++ b/src/components/routerView.vue
@@ -5,13 +5,18 @@
 </template>
 
 <script lang="ts" setup>
-  import { AsyncComponentLoader, Component, UnwrapRef, VNode, computed, defineAsyncComponent, provide } from 'vue'
+  import { AsyncComponentLoader, Component, DeepReadonly, UnwrapRef, VNode, computed, defineAsyncComponent, provide } from 'vue'
   import { useRejection } from '@/compositions/useRejection'
   import { useRoute } from '@/compositions/useRoute'
   import { useRouterDepth } from '@/compositions/useRouterDepth'
   import { RouterRejection } from '@/services/createRouterReject'
   import { RouterRoute } from '@/services/createRouterRoute'
   import { depthInjectionKey } from '@/types/injectionDepth'
+  import { RouteProps, isWithComponent, isWithComponents } from '@/types/routeProps'
+
+  const { name = 'default' } = defineProps<{
+    name?: string,
+  }>()
 
   const route = useRoute()
   const rejection = useRejection()
@@ -32,15 +37,35 @@
       return rejection.value.component
     }
 
-    const routeComponent = route.matches[depth]?.component
+    const match = route.matches.at(depth)
 
-    if (routeComponent) {
-      if (typeof routeComponent === 'function') {
-        return defineAsyncComponent(routeComponent as AsyncComponentLoader)
+    if (!match) {
+      return null
+    }
+
+    const components = getComponents(match)
+    const component = components[name]
+
+    if (component) {
+      if (typeof component === 'function') {
+        return defineAsyncComponent(component as AsyncComponentLoader)
       }
-      return routeComponent
+
+      return component
     }
 
     return null
   })
+
+  function getComponents(route: DeepReadonly<RouteProps>): Record<string, DeepReadonly<Component> | undefined> {
+    if (isWithComponents(route)) {
+      return route.components
+    }
+
+    if (isWithComponent(route)) {
+      return { default: route.component }
+    }
+
+    return {}
+  }
 </script>

--- a/src/components/routerView.vue
+++ b/src/components/routerView.vue
@@ -12,7 +12,7 @@
   import { RouterRejection } from '@/services/createRouterReject'
   import { RouterRoute } from '@/services/createRouterRoute'
   import { depthInjectionKey } from '@/types/injectionDepth'
-  import { RouteProps, isWithComponent, isWithComponents } from '@/types/routeProps'
+  import { RouteProps, isRouteWithComponent, isRouteWithComponents } from '@/types/routeProps'
 
   const { name = 'default' } = defineProps<{
     name?: string,
@@ -58,11 +58,11 @@
   })
 
   function getComponents(route: DeepReadonly<RouteProps>): Record<string, DeepReadonly<Component> | undefined> {
-    if (isWithComponents(route)) {
+    if (isRouteWithComponents(route)) {
       return route.components
     }
 
-    if (isWithComponent(route)) {
+    if (isRouteWithComponent(route)) {
       return { default: route.component }
     }
 

--- a/src/services/createRoutes.spec.ts
+++ b/src/services/createRoutes.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import RouterView from '@/components/routerView.vue'
 import { createRoutes } from '@/services/createRoutes'
+import { isRouteWithComponent } from '@/types/routeProps'
 import { component } from '@/utilities/testHelpers'
 
 describe('route key dot notation', () => {
@@ -63,6 +64,10 @@ test('given route without component, sets component default to RouterView', () =
       children: [],
     },
   ])
+
+  if (!isRouteWithComponent(route.matched)) {
+    throw 'Matched route does not have a single component'
+  }
 
   expect(route.matched.component).toMatchObject(RouterView)
 })

--- a/src/types/routeProps.ts
+++ b/src/types/routeProps.ts
@@ -1,4 +1,4 @@
-import { Component } from 'vue'
+import { Component, DeepReadonly } from 'vue'
 import { AfterRouteHook, BeforeRouteHook } from '@/types/hooks'
 import { Path } from '@/types/path'
 import { Query } from '@/types/query'
@@ -30,10 +30,24 @@ type WithHooks = {
   onAfterRouteLeave?: MaybeArray<AfterRouteHook>,
 }
 
+type WithComponent = {
+  /**
+   * A Vue component, which can be either synchronous or asynchronous components.
+   */
+  component: Component,
+}
+
+type WithComponents = {
+  /**
+   * Multiple components for named views, which can be either synchronous or asynchronous components.
+   */
+  components: Record<string, Component>,
+}
+
 /**
  * Represents properties common to parent routes in a route configuration, including hooks, path, and optional query parameters.
  */
-export type ParentRouteProps = WithHooks & {
+export type ParentRouteProps = Partial<WithComponent | WithComponents> & WithHooks & {
   /**
    * Name for route, used to create route keys and in navigation.
    */
@@ -55,10 +69,6 @@ export type ParentRouteProps = WithHooks & {
    */
   children: Routes,
   /**
-   * A Vue component, which can be either synchronous or asynchronous components.
-   */
-  component?: Component,
-  /**
    * Represents additional metadata associated with a route, customizable via declaration merging.
    */
   meta?: RouteMeta,
@@ -67,7 +77,7 @@ export type ParentRouteProps = WithHooks & {
 /**
  * Represents properties for child routes, including required component, name, and path.
  */
-export type ChildRouteProps = WithHooks & {
+export type ChildRouteProps = (WithComponent | WithComponents) & WithHooks & {
   /**
    * Name for route, used to create route keys and in navigation.
    */
@@ -84,10 +94,6 @@ export type ChildRouteProps = WithHooks & {
    * Query (aka search) part of URL.
    */
   query?: string | Query,
-  /**
-   * A Vue component, which can be either synchronous or asynchronous components.
-   */
-  component: Component,
   /**
    * Represents additional metadata associated with a route, customizable via declaration merging.
    */
@@ -106,4 +112,18 @@ export type RouteProps = Readonly<ParentRouteProps | ChildRouteProps>
  */
 export function isParentRoute(value: RouteProps): value is ParentRouteProps {
   return 'children' in value
+}
+
+export function isWithComponent(value: RouteProps): value is RouteProps & WithComponent
+export function isWithComponent(value: Readonly<RouteProps>): value is Readonly<RouteProps & WithComponent>
+export function isWithComponent(value: DeepReadonly<RouteProps>): value is DeepReadonly<RouteProps & WithComponent>
+export function isWithComponent(value: unknown): boolean {
+  return typeof value === 'object' && value !== null && 'component' in value
+}
+
+export function isWithComponents(value: RouteProps): value is RouteProps & WithComponents
+export function isWithComponents(value: Readonly<RouteProps>): value is Readonly<RouteProps & WithComponents>
+export function isWithComponents(value: DeepReadonly<RouteProps>): value is DeepReadonly<RouteProps & WithComponents>
+export function isWithComponents(value: unknown): boolean {
+  return typeof value === 'object' && value !== null && 'components' in value
 }

--- a/src/types/routeProps.ts
+++ b/src/types/routeProps.ts
@@ -114,16 +114,20 @@ export function isParentRoute(value: RouteProps): value is ParentRouteProps {
   return 'children' in value
 }
 
-export function isWithComponent(value: RouteProps): value is RouteProps & WithComponent
-export function isWithComponent(value: Readonly<RouteProps>): value is Readonly<RouteProps & WithComponent>
-export function isWithComponent(value: DeepReadonly<RouteProps>): value is DeepReadonly<RouteProps & WithComponent>
-export function isWithComponent(value: unknown): boolean {
+export function isParentRouteWithoutComponent(value: RouteProps): value is Omit<ParentRouteProps, 'component' | 'components'> {
+  return isParentRoute(value) && !('component' in value) && !('components' in value)
+}
+
+export function isRouteWithComponent(value: RouteProps): value is RouteProps & WithComponent
+export function isRouteWithComponent(value: Readonly<RouteProps>): value is Readonly<RouteProps & WithComponent>
+export function isRouteWithComponent(value: DeepReadonly<RouteProps>): value is DeepReadonly<RouteProps & WithComponent>
+export function isRouteWithComponent(value: unknown): boolean {
   return typeof value === 'object' && value !== null && 'component' in value
 }
 
-export function isWithComponents(value: RouteProps): value is RouteProps & WithComponents
-export function isWithComponents(value: Readonly<RouteProps>): value is Readonly<RouteProps & WithComponents>
-export function isWithComponents(value: DeepReadonly<RouteProps>): value is DeepReadonly<RouteProps & WithComponents>
-export function isWithComponents(value: unknown): boolean {
+export function isRouteWithComponents(value: RouteProps): value is RouteProps & WithComponents
+export function isRouteWithComponents(value: Readonly<RouteProps>): value is Readonly<RouteProps & WithComponents>
+export function isRouteWithComponents(value: DeepReadonly<RouteProps>): value is DeepReadonly<RouteProps & WithComponents>
+export function isRouteWithComponents(value: unknown): boolean {
   return typeof value === 'object' && value !== null && 'components' in value
 }


### PR DESCRIPTION
# Description
Adds the ability for a route to define multiple components rather than a single component. These components can then be rendered using named router views. A router view with no name will render the `default` component which is either `route.component` or `route.components.default`.

Closes https://github.com/kitbagjs/router/issues/174

Needs docs

**main.ts**
```ts
const routes = createRoutes([
  {
    name: 'parent',
    path: '/',
    components: {
      default: { template: '<p>default</p>' },
      one: { template: '<p>one</p>' },
      two: { template: '<p>two</p>' },
    },
  },
])

...
```
**App.vue**
```vue
<template>
    <RouterView name="one" />
    <RouterView />
    <RouterView name="two" />
</template>
```
**Rendered html** 
```html
<p>one</p>
<p>default</p>
<p>two</p>
```