### PR TITLE
Improved path query types

### DIFF
--- a/src/services/params.ts
+++ b/src/services/params.ts
@@ -9,8 +9,11 @@ export function getParam<P extends Record<string, Param | undefined>>(params: P,
 
 const optionalKey = Symbol()
 
-type OptionalParamGetSet<TParam extends Param, TValue = ExtractParamType<TParam> | undefined> = ParamGetSet<TValue> & {
+export type IsOptionalParam = {
   [optionalKey]: true,
+}
+
+export type OptionalParamGetSet<TParam extends Param, TValue = ExtractParamType<TParam> | undefined> = ParamGetSet<TValue> & IsOptionalParam & {
   get: (value: string | undefined, extras: ParamExtras) => TValue,
 }
 

--- a/src/types/path.ts
+++ b/src/types/path.ts
@@ -16,11 +16,11 @@ export type PathParams<TPath extends string> = {
 }
 
 export type Path<
-  TPath extends string = any,
-  TParams extends PathParams<TPath> = any
+  TPath extends string = string,
+  TParams extends PathParams<TPath> = Record<string, Param | undefined>
 > = {
   path: TPath,
-  params: Identity<ExtractParamsFromPathString<TPath, TParams>>,
+  params: string extends TPath ? Record<string, Param> : Identity<ExtractParamsFromPathString<TPath, TParams>>,
   toString: () => string,
 }
 export type ToPath<T extends string | Path> = T extends string ? Path<T, {}> : T

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -16,11 +16,11 @@ export type QueryParams<T extends string> = {
 }
 
 export type Query<
-  T extends string = any,
-  P extends QueryParams<T> = any
+  TQuery extends string = string,
+  TQueryParams extends QueryParams<TQuery> = Record<string, Param | undefined>
 > = {
-  query: T,
-  params: Identity<ExtractQueryParamsFromQueryString<T, P>>,
+  query: TQuery,
+  params: string extends TQuery ? Record<string, Param> : Identity<ExtractQueryParamsFromQueryString<TQuery, TQueryParams>>,
   toString: () => string,
 }
 

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -1,6 +1,7 @@
 import { DeepReadonly } from 'vue'
+import { ExtractRouteParamTypes } from '@/types/params'
 import { ResolvedRouteQuery } from '@/types/resolvedQuery'
-import { ExtractRouteParamTypes, Route } from '@/types/route'
+import { Route } from '@/types/route'
 
 type BaseResolvedRoute = Route & { path: { params: Record<string, unknown> }, query: { params: Record<string, unknown> } }
 
@@ -29,5 +30,5 @@ export type ResolvedRoute<TRoute extends Route = BaseResolvedRoute> = DeepReadon
   /**
    * Key value pair for route params, values will be the user provided value from current browser location.
   */
-  params: ExtractRouteParamTypes<TRoute>,
+  params: BaseResolvedRoute extends TRoute ? Record<string, unknown> : ExtractRouteParamTypes<TRoute>,
 }>

--- a/src/types/route.spec-d.ts
+++ b/src/types/route.spec-d.ts
@@ -1,7 +1,8 @@
 import { describe, expectTypeOf, test } from 'vitest'
+import { ExtractRouteParamTypes } from '@/types/params'
 import { Path } from '@/types/path'
 import { Query } from '@/types/query'
-import { ExtractRouteParamTypes, Route } from '@/types/route'
+import { Route } from '@/types/route'
 
 describe('ExtractRouteParamTypes', () => {
   test('given routes with different params, some optional, combines into expected args for developer', () => {

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -1,5 +1,3 @@
-import { ExtractParamTypes, MergeParams } from '@/types/params'
-import { Param } from '@/types/paramTypes'
 import { Path, ToPath } from '@/types/path'
 import { Query, ToQuery } from '@/types/query'
 import { RouteMeta, RouteProps } from '@/types/routeProps'
@@ -54,18 +52,3 @@ export type Route<
   */
   disabled: TDisabled extends boolean ? TDisabled : false,
 }
-
-/**
- * Extracts combined types of path and query parameters for a given route, creating a unified parameter object.
- * @template TRoute - The route type from which to extract and merge parameter types.
- * @returns A record of parameter names to their respective types, extracted and merged from both path and query parameters.
- */
-export type ExtractRouteParamTypes<TRoute extends {
-  path: { params: Record<string, unknown> },
-  query: { params: Record<string, unknown> },
-}> = TRoute extends {
-  path: { params: infer PathParams extends Record<string, Param | undefined> },
-  query: { params: infer QueryParams extends Record<string, Param | undefined> },
-}
-  ? ExtractParamTypes<MergeParams<PathParams, QueryParams>>
-  : Record<string, unknown>

--- a/src/types/routeWithParams.ts
+++ b/src/types/routeWithParams.ts
@@ -1,4 +1,5 @@
-import { ExtractRouteParamTypes, Routes } from '@/types/route'
+import { ExtractRouteParamTypes } from '@/types/params'
+import { Routes } from '@/types/route'
 import { RoutesKey, RoutesMap } from '@/types/routesMap'
 
 export type RouteGetByKey<TRoutes extends Routes, TKey extends RoutesKey<TRoutes>> = RoutesMap<TRoutes>[TKey]


### PR DESCRIPTION
- Improved the way we capture optional params in type system. 
  - previously we were defining the param inside of `params` as `StringConstructor | undefined` for example. So basically if a Param has `| undefined`, it meant it should be optional. 
  - this adds the complication of having to check for missing values and is redundant since we can derive the fact that it's optional by looking for the optional symbol in the Param.
- I updated the definition for `ResolvedRoute` so that if it's created without a generic (using the default), it will widen params to `Record<string, unknown>`, otherwise it would be `{}`.
- path and query types have stronger typed defaults, when used without defaults will have `Record<string, Param>` for `params`.
