### PR TITLE
Param default docs

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -130,7 +130,7 @@ export default defineConfig({
           text: 'Core Concepts',
           items: [
             { text: 'Defining Routes', link: '/core-concepts/defining-routes' },
-            { text: 'Path Params', link: '/core-concepts/path-params' },
+            { text: 'Route Params', link: '/core-concepts/route-params' },
             { text: 'Query Params', link: '/core-concepts/query-params' },
             { text: 'Navigating', link: '/core-concepts/navigating' },
           ],

--- a/docs/api/functions/path.md
+++ b/docs/api/functions/path.md
@@ -43,4 +43,4 @@ export const routes = createRoutes([
 
 ## Custom Params
 
-Param types is customizable with [`ParamGetter`](/api/types/ParamGetter), [`ParamSetter`](/api/types/ParamSetter), and [`ParamGetSet`](/api/types/ParamGetSet). Read more about [custom params](/core-concepts/path-params#custom-param).
+Param types is customizable with [`ParamGetter`](/api/types/ParamGetter), [`ParamSetter`](/api/types/ParamSetter), and [`ParamGetSet`](/api/types/ParamGetSet). Read more about [custom params](/core-concepts/route-params#custom-param).

--- a/docs/api/functions/query.md
+++ b/docs/api/functions/query.md
@@ -43,4 +43,4 @@ export const routes = createRoutes([
 
 ## Custom Params
 
-Param types is customizable with [`ParamGetter`](/api/types/ParamGetter), [`ParamSetter`](/api/types/ParamSetter), and [`ParamGetSet`](/api/types/ParamGetSet). Read more about [custom params](/core-concepts/path-params#custom-param).
+Param types is customizable with [`ParamGetter`](/api/types/ParamGetter), [`ParamSetter`](/api/types/ParamSetter), and [`ParamGetSet`](/api/types/ParamGetSet). Read more about [custom params](/core-concepts/route-params#custom-param).

--- a/docs/core-concepts/defining-routes.md
+++ b/docs/core-concepts/defining-routes.md
@@ -96,4 +96,4 @@ router.push('routes.user.profile') // ok
 
 ## Case Sensitivity
 
-By default route paths are NOT case sensitive. If you need part of your route to be case sensitive, we recommend using a [Regex Param](/core-concepts/path-params#regexp-params).
+By default route paths are NOT case sensitive. If you need part of your route to be case sensitive, we recommend using a [Regex Param](/core-concepts/route-params#regexp-params).

--- a/docs/core-concepts/query-params.md
+++ b/docs/core-concepts/query-params.md
@@ -74,8 +74,8 @@ The name you provide for the param does not have to match the key from the URL. 
 ```ts
 const route = useRoute()
 
-route.params.paramSort
-route.params.query.keySort
+route.params.nameInParams // Kitbag router param
+route.query.nameInUrl // native URL search param
 ```
 
 As for the param name, query params follow the same rules as [route params](/core-concepts/route-params#param-name)

--- a/docs/core-concepts/query-params.md
+++ b/docs/core-concepts/query-params.md
@@ -1,6 +1,6 @@
 # Query Params
 
-Kitbag Router has first class support for query params.
+Kitbag Router lets you define your query just like the path.
 
 ```ts
 import { createRoutes } from '@kitbag/router'
@@ -17,7 +17,9 @@ const routes = createRoutes([
 
 This static value will be used in determining if a route matches a given URL. Unlike `path`, the order of params is not enforced and the presence of extra query params in the URL does not preclude the route from being considered a match.
 
-The router supports dynamic params declared in the query as well.
+## Route Params
+
+The query was also built to support all of the same [route params](/core-concepts/route-params) benefits as path.
 
 ```ts
 const routes = createRoutes([
@@ -30,7 +32,7 @@ const routes = createRoutes([
 ])
 ```
 
-Just like params declared in `path`, these values will be found in the `route.params`.
+Like params declared in `path`, these values will be found in the `route.params`.
 
 ```ts
 import { useRoute } from '@kitbag/router'
@@ -38,42 +40,6 @@ import { useRoute } from '@kitbag/router'
 const route = useRoute()
 
 route.params.sort
-```
-
-## Param Types
-
-Again like params declared in `path`, these params default as writable `string`, but can be overridden with built in `Number`, `Boolean`, `Date`, `JSON`, `RegExp`, or any `ParamGetter`/`ParamGetSet` you define.
-
-```ts
-import { 
-  createRoutes,
-  query, // [!code ++]
-} from '@kitbag/router'
-
-const routes = createRoutes([
-  {
-    name: 'users',
-    path: '/users',
-    query: 'sort=[sort]',// [!code --]
-    query: query('sort=[sort]', { sort: Number }),// [!code ++]
-    component: ...
-  }
-])
-```
-
-## Optional Params
-
-Add a question mark `:?` to your query param to make it optional.
-
-```ts
-const routes = createRoutes([
-  {
-    name: 'users',
-    path: '/users',
-    query: 'sort=[?sort]',// [!code focus]
-    component: ...
-  }
-])
 ```
 
 ## Unnamed Query Params
@@ -91,4 +57,4 @@ route.params.paramSort
 route.params.query.keySort
 ```
 
-As for the param name, query params follow the same rules as [path params](/core-concepts/path-params#param-name)
+As for the param name, query params follow the same rules as [route params](/core-concepts/route-params#param-name)

--- a/docs/core-concepts/query-params.md
+++ b/docs/core-concepts/query-params.md
@@ -22,11 +22,32 @@ This static value will be used in determining if a route matches a given URL. Un
 The query was also built to support all of the same [route params](/core-concepts/route-params) benefits as path.
 
 ```ts
+import { createRoutes } from '@kitbag/router'
+
 const routes = createRoutes([
   {
     name: 'users',
     path: '/users',
     query: 'sort=[sort]',
+    component: ...
+  },
+])
+```
+
+Kitbag router exports a `query` function, which offers support for changing param types in the query just like [path](/core-concepts/route-params#param-types).
+
+```ts
+import { 
+  createRoutes,
+  query, // [!code ++]
+} from '@kitbag/router'
+
+const routes = createRoutes([
+  {
+    name: 'users',
+    path: '/users'
+    query: 'sort=[sort]', // [!code --]
+    query: query('sort=[sort]', { sort: Number }), // [!code ++]
     component: ...
   }
 ])
@@ -46,9 +67,9 @@ route.params.sort
 
 The entire query is also available in `route.query`. This includes any named query params but with their raw value.
 
-### Query Param Naming
+## Query Param Naming
 
-The name you provide for the param does not have to match the key from the URL. `query: 'keySort=[paramSort]'`.
+The name you provide for the param does not have to match the key from the URL. `query: 'nameInUrl=[nameInParams]'`.
 
 ```ts
 const route = useRoute()

--- a/docs/core-concepts/route-params.md
+++ b/docs/core-concepts/route-params.md
@@ -1,0 +1,202 @@
+# Route Params
+
+When defining your route `path` and `query`, you can wrap part in square brackets `[]` to denote dynamic params.
+
+```ts
+import { createRoutes } from '@kitbag/router'
+
+const routes = createRoutes([
+  {
+    name: 'users',
+    path: '/users/[id]',
+    component: ...
+  }
+])
+```
+
+This means the route will expect 1+ extra string characters in order to be considered a match. This value can be anything, including forward slashes `/`. The value of these extra characters is captured and exposed in the `route.params`.
+
+```ts
+const route = useRoute()
+
+route.params.id
+```
+
+When defined this way, these params are reactive strings. If you update a param, the URL will be updated accordingly.
+
+## Param Types
+
+With the `path` function, Kitbag Router supports parsing params to types other than `string`.
+
+```ts
+import { 
+  createRoutes,
+  path, // [!code ++]
+} from '@kitbag/router'
+
+const routes = createRoutes([
+  {
+    name: 'users',
+    path: '/users/[id]', // [!code --]
+    path: path('/users/[id]', { id: Number }), // [!code ++]
+    component: ...
+  }
+])
+```
+
+This will automatically parse the param from `string` in the URL to `number` in `route.params`. If the value cannot be parsed, the route will not be considered a match.
+
+Kitbag Router ships with support for `String` (default), `Boolean`, `Number`, `Date`, `JSON`, and `RegExp`.
+
+### RegExp Params
+
+Using native RegExp is a powerful way of controlling route matching.
+
+```ts
+const routes = createRoutes([
+  {
+    name: 'users',
+    path: path('/users/[id]', { id: /^A[0-9]$/  }), // [!code focus]
+    component: ...
+  }
+])
+```
+
+### Custom Param
+
+You're not limited to the param types that ship with Kitbag Router, use `ParamGetter<T>` or `ParamGetSet<T>` to parse params to whatever type you need. For example, here is the ParamGetter Kitbag Router defines for Number params.
+
+```ts
+const numberParam: ParamGetter<number> = (value, { invalid }) => {
+  const number = Number(value)
+
+  if (isNaN(number)) {
+    // If any exception is thrown, the route will not match.
+    // Use the provided `invalid` function to provide additional context to the router.
+    throw invalid()
+  }
+
+  // Return value is what will be provided in route.params.id
+  return number
+}
+```
+
+Update your param assignment on the route's path
+
+```ts
+const routes = createRoutes([
+  {
+    name: 'users',
+    path: path('/users/[id]', { id: numberParam }), // [!code focus]
+    component: ...
+  }
+])
+```
+
+With this getter defined, now our route will only match if the param matches our rules above.
+
+As a `ParamGetter`, the value in `route.params` is still writable, but the set will assume `value.toString()` is sufficient. Alternatively if you use `ParamGetSet`, you can provide the same validation on value set as well.
+
+```ts
+const numberParam: ParamGetSet<number> = {
+  get: (value, { invalid }) => {
+    const number = Number(value)
+
+    if (isNaN(number)) {
+      throw invalid()
+    }
+
+    return number
+  },
+  set: (value, { invalid }) => {
+    if (typeof value !== 'number') {
+      // If any exception is thrown, the route will not match.
+      // Use the provided `invalid` function to provide additional context to the router.
+      throw invalid()
+    }
+
+    // Return value is what will be provided in route.params.id
+    return value.toString()
+  },
+}
+```
+
+## Optional Params
+
+If you define your path params with a question mark, `:?` the router assumes this param is not required.
+
+```ts
+const routes = createRoutes([
+  {
+    name: 'users',
+    path: '/users/[?id]', // [!code focus]
+    component: ...
+  }
+])
+```
+
+This means the route will match even if nothing is provided after `/users/`.
+
+This also works for non-string params.
+
+```ts
+const routes = createRoutes([
+  {
+    name: 'users',
+    path: path('/users/[?id]', { id: Number }), // [!code focus]
+    component: ...
+  }
+])
+```
+
+Which now, `router.params.id` has the type `number | undefined`, and will only match URL where the value passes as a number or is missing entirely.
+
+## Param Name
+
+There are no constraints on the name you choose for param names
+
+```ts
+const routes = createRoutes([
+  {
+    name: 'users',
+    path: '/users/[can-have#what.ever/you/want!?]',
+    component: ...
+  }
+])
+```
+
+Keep in mind that any special characters in the param name will make accessing the value slightly less pretty.
+
+```ts
+const route = useRoute()
+
+route.params['can-have#what.ever/you/want!?']
+```
+
+Also, route names that start with a question mark `?` are interpreted as optional params.
+
+Param names must be unique. This includes params defined in a path parent and params defined in the query.
+
+```ts
+// invalid
+const routes = createRoutes([
+  {
+    name: 'users',
+    path: '/users/[id]',
+    query: 'sortBy=[id]'
+  }
+])
+
+// invalid
+const routes = createRoutes([
+  {
+    name: 'users',
+    path: '/users/[id]',
+    children: createRoutes([
+      name: 'tokens',
+      path: '/tokens/[id]',
+      component: ...
+    ])
+  }
+])
+```

--- a/docs/core-concepts/route-params.md
+++ b/docs/core-concepts/route-params.md
@@ -151,6 +151,80 @@ const routes = createRoutes([
 
 Which now, `router.params.id` has the type `number | undefined`, and will only match URL where the value passes as a number or is missing entirely.
 
+## Default Value
+
+Often times when a param is optional, we want to assign a value to use as the default.
+
+```ts
+import { createRoutes, useRoute } from '@kitbag/router'
+
+const routes = createRoutes([
+  {
+    name: 'users',
+    path: '/users',
+    query: 'sort-by=[sort]'
+  }
+])
+
+const route = useRoute('users')
+const sort = computed(() => route.params.sort ?? 'asc')
+```
+
+With Kitbag Router we can configure this on the route or within custom params.
+
+```ts
+import { withDefault } from '@kitbag/router'
+
+const sortParam = withDefault(String, 'asc')
+```
+
+The `withDefault` utility accepts any param, including custom params and returns a custom param that can be used just like any other custom param.
+
+```ts
+const routes = createRoutes([
+  {
+    name: 'users',
+    path: '/users',
+    query: query('sort-by=[sort]', { sort: sortParam })// [!code focus]
+  }
+])
+```
+
+If you already have a `ParamGetSet`, you can also assign the default value right in your param definition
+
+```ts
+const sortParam: ParamGetSet<'asc' | 'desc'> = {
+  get: (value, { invalid }) => {
+    if (value !== 'asc' && value !== 'desc') {
+      throw invalid()
+    }
+
+    return value
+  },
+  set: (value) => {
+    return value.toString()
+  },
+  defaultValue: 'asc'// [!code focus]
+}
+```
+
+Params with a default value will remain optional when navigating.
+
+```ts
+const router = useRouter()
+
+router.push('users') // -> /users
+router.push('users', { sort: 'desc' }) // -> /users?sort=desc
+```
+
+However, the type when accessing the param will **not** be optional. Even if the value is not in the URL, your components can expect a value to be assigned.
+
+```ts
+const route = useRoute('users')
+
+route.params.sort // -> 'asc' | 'desc'
+```
+
 ## Param Name
 
 There are no constraints on the name you choose for param names
@@ -183,7 +257,7 @@ const routes = createRoutes([
   {
     name: 'users',
     path: '/users/[id]',
-    query: 'sortBy=[id]'
+    query: 'sort-by=[id]'
   }
 ])
 

--- a/docs/core-concepts/route-params.md
+++ b/docs/core-concepts/route-params.md
@@ -123,7 +123,7 @@ const numberParam: ParamGetSet<number> = {
 
 ## Optional Params
 
-If you define your path params with a question mark, `:?` the router assumes this param is not required.
+If you define your path params with a question mark, `?` the router assumes this param is not required.
 
 ```ts
 const routes = createRoutes([
@@ -162,7 +162,7 @@ const routes = createRoutes([
   {
     name: 'users',
     path: '/users',
-    query: 'sort-by=[sort]'
+    query: 'sort-by=[?sort]'
   }
 ])
 
@@ -185,7 +185,7 @@ const routes = createRoutes([
   {
     name: 'users',
     path: '/users',
-    query: query('sort-by=[sort]', { sort: sortParam })// [!code focus]
+    query: query('sort-by=[?sort]', { sort: sortParam })// [!code focus]
   }
 ])
 ```
@@ -193,7 +193,7 @@ const routes = createRoutes([
 If you already have a `ParamGetSet`, you can also assign the default value right in your param definition
 
 ```ts
-const sortParam: ParamGetSet<'asc' | 'desc'> = {
+const sortParam = {
   get: (value, { invalid }) => {
     if (value !== 'asc' && value !== 'desc') {
       throw invalid()
@@ -205,7 +205,7 @@ const sortParam: ParamGetSet<'asc' | 'desc'> = {
     return value.toString()
   },
   defaultValue: 'asc'// [!code focus]
-}
+} satisfies ParamGetSet<'asc' | 'desc'>
 ```
 
 Params with a default value will remain optional when navigating.


### PR DESCRIPTION
this PR updates documentation for [default value in params](https://github.com/kitbagjs/router/pull/195).

this PR merges path-params and query-params into route-params which removed much of the duplication of explaining params for both. There is still a page for query-params, which covers only the important differences.