### PR TITLE
Fix `RouterRoute` type so that `isRoute` type guard works correctly when given a `RouterRoute`

### DIFF
--- a/src/components/routerView.vue
+++ b/src/components/routerView.vue
@@ -5,7 +5,7 @@
 </template>
 
 <script lang="ts" setup>
-  import { AsyncComponentLoader, Component, DeepReadonly, UnwrapRef, VNode, computed, defineAsyncComponent, provide } from 'vue'
+  import { AsyncComponentLoader, Component, UnwrapRef, VNode, computed, defineAsyncComponent, provide } from 'vue'
   import { useRejection } from '@/compositions/useRejection'
   import { useRoute } from '@/compositions/useRoute'
   import { useRouterDepth } from '@/compositions/useRouterDepth'
@@ -57,7 +57,7 @@
     return null
   })
 
-  function getComponents(route: DeepReadonly<RouteProps>): Record<string, DeepReadonly<Component> | undefined> {
+  function getComponents(route: RouteProps): Record<string, Component | undefined> {
     if (isRouteWithComponents(route)) {
       return route.components
     }

--- a/src/compositions/useLink.ts
+++ b/src/compositions/useLink.ts
@@ -1,4 +1,4 @@
-import { MaybeRefOrGetter, Ref, computed, readonly, toValue } from 'vue'
+import { MaybeRefOrGetter, Ref, computed, toValue } from 'vue'
 import { useRouter } from '@/compositions/useRouter'
 import { InvalidRouteParamValueError } from '@/errors/invalidRouteParamValueError'
 import { RouterResolveOptions } from '@/services/createRouterResolve'
@@ -87,7 +87,7 @@ export function useLink(
     return router.find(href.value, optionsRef.value)
   })
 
-  const isMatch = computed(() => !!route.value && router.route.matches.includes(readonly(route.value.matched)))
+  const isMatch = computed(() => !!route.value && router.route.matches.includes(route.value.matched))
   const isExactMatch = computed(() => !!route.value && router.route.matched === route.value.matched)
 
   return {

--- a/src/compositions/useLink.ts
+++ b/src/compositions/useLink.ts
@@ -2,7 +2,7 @@ import { MaybeRefOrGetter, Ref, computed, toValue } from 'vue'
 import { useRouter } from '@/compositions/useRouter'
 import { InvalidRouteParamValueError } from '@/errors/invalidRouteParamValueError'
 import { RouterResolveOptions } from '@/services/createRouterResolve'
-import { RegisteredRouteMap, RegisteredRoutes } from '@/types/register'
+import { RegisteredRoutes, RegisteredRoutesKey } from '@/types/register'
 import { ResolvedRoute } from '@/types/resolved'
 import { RouterPushOptions } from '@/types/routerPush'
 import { RouterReplaceOptions } from '@/types/routerReplace'
@@ -38,7 +38,7 @@ export type UseLink = {
 }
 
 type UseLinkArgs<
-  TSource extends string & keyof RegisteredRouteMap,
+  TSource extends RegisteredRoutesKey,
   TParams = RouteParamsByKey<RegisteredRoutes, TSource>
 > = AllPropertiesAreOptional<TParams> extends true
   ? [params?: MaybeRefOrGetter<TParams>, options?: MaybeRefOrGetter<RouterResolveOptions>]
@@ -55,7 +55,7 @@ type UseLinkArgs<
  * @returns {UseLink} Reactive context values for as well as navigation methods.
  *
  */
-export function useLink<TRouteKey extends string & keyof RegisteredRouteMap>(routeKey: MaybeRefOrGetter<TRouteKey>, ...args: UseLinkArgs<TRouteKey>): UseLink
+export function useLink<TRouteKey extends RegisteredRoutesKey>(routeKey: MaybeRefOrGetter<TRouteKey>, ...args: UseLinkArgs<TRouteKey>): UseLink
 export function useLink(url: MaybeRefOrGetter<Url>): UseLink
 export function useLink(
   source: MaybeRefOrGetter<string>,

--- a/src/services/combineName.spec.ts
+++ b/src/services/combineName.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from 'vitest'
+import { combineName } from '@/services/combineName'
+
+test('given 2 names, returns names joined together with period', () => {
+  const aName = 'foo'
+  const bName = 'bar'
+
+  const response = combineName(aName, bName)
+
+  expect(response.toString()).toBe('foo.bar')
+})
+
+test.each(['', undefined])('given 1 name and one empty or undefined, returns first name only', (bName) => {
+  const aName = 'foo'
+
+  const response = combineName(aName, bName)
+
+  expect(response.toString()).toBe('foo')
+})

--- a/src/services/createCurrentRoute.ts
+++ b/src/services/createCurrentRoute.ts
@@ -1,4 +1,4 @@
-import { readonly, reactive } from 'vue'
+import { reactive } from 'vue'
 import { RouterRoute, createRouterRoute } from '@/services/createRouterRoute'
 import { ResolvedRoute } from '@/types/resolved'
 import { RouterPush } from '@/types/routerPush'
@@ -18,7 +18,7 @@ export function createCurrentRoute(fallbackRoute: ResolvedRoute, push: RouterPus
     Object.assign(route, { ...newRoute })
   }
 
-  const currentRoute = readonly(route)
+  const currentRoute = route
   const routerRoute = createRouterRoute(currentRoute, push)
 
   return {

--- a/src/services/createRouter.spec.ts
+++ b/src/services/createRouter.spec.ts
@@ -82,7 +82,7 @@ test('route update updates the current route', async () => {
 
 })
 
-test('route is readonly except for individual params', async () => {
+test.fails('route is readonly except for individual params', async () => {
   const routes = createRoutes([
     {
       name: 'root',

--- a/src/services/createRouterFind.ts
+++ b/src/services/createRouterFind.ts
@@ -4,7 +4,7 @@ import { ResolvedRoute } from '@/types/resolved'
 import { Routes } from '@/types/route'
 import { RoutesKey } from '@/types/routesMap'
 import { RouteParamsByKey } from '@/types/routeWithParams'
-import { Url } from '@/types/url'
+import { isUrl, Url } from '@/types/url'
 import { AllPropertiesAreOptional } from '@/types/utilities'
 
 type RouterFindArgs<
@@ -24,12 +24,19 @@ export type RouterFind<
 
 export function createRouterFind<const TRoutes extends Routes>(routes: TRoutes): RouterFind<TRoutes> {
 
-  return <TRoutes extends Routes, TSource extends Url | RoutesKey<TRoutes>>(
-    source: TSource,
+  return <TSource extends RoutesKey<TRoutes>>(
+    source: Url | TSource,
     params: Record<PropertyKey, unknown> = {},
   ): ResolvedRoute | undefined => {
     const resolve = createRouterResolve(routes)
-    const url = resolve(source, params)
+
+    if (isUrl(source)) {
+      const url = resolve(source)
+
+      return getResolvedRouteForUrl(routes, url)
+    }
+
+    const url = resolve(source, params as RouteParamsByKey<TRoutes, TSource>)
 
     return getResolvedRouteForUrl(routes, url)
   }

--- a/src/services/createRouterFind.ts
+++ b/src/services/createRouterFind.ts
@@ -9,7 +9,7 @@ import { AllPropertiesAreOptional } from '@/types/utilities'
 
 type RouterFindArgs<
   TRoutes extends Routes,
-  TSource extends string & keyof RoutesKey<TRoutes>,
+  TSource extends RoutesKey<TRoutes>,
   TParams = RouteParamsByKey<TRoutes, TSource>
 > = AllPropertiesAreOptional<TParams> extends true
   ? [params?: TParams]

--- a/src/services/createRouterReject.ts
+++ b/src/services/createRouterReject.ts
@@ -24,8 +24,6 @@ type CreateRouterRejectContext = {
 
 const isRejectionRouteSymbol = Symbol()
 
-type RouterRejectionRoute = ResolvedRoute & { [isRejectionRouteSymbol]?: true }
-
 export type CreateRouterReject = {
   setRejection: RouterSetReject,
   rejection: RouterRejection,
@@ -67,8 +65,8 @@ export function createRouterReject({
     return resolved
   }
 
-  const isRejectionRoute: IsRejectionRoute = (route: RouterRejectionRoute) => {
-    return route[isRejectionRouteSymbol] === true
+  const isRejectionRoute: IsRejectionRoute = (route) => {
+    return isRejectionRouteSymbol in route
   }
 
   const setRejection: RouterSetReject = (type) => {

--- a/src/services/createRouterReject.ts
+++ b/src/services/createRouterReject.ts
@@ -1,4 +1,4 @@
-import { Ref, markRaw, ref, readonly, Component } from 'vue'
+import { Ref, markRaw, ref, Component } from 'vue'
 import { genericRejection } from '@/components/rejection'
 import { createResolvedRouteQuery } from '@/services/createResolvedRouteQuery'
 import { RegisteredRejectionType } from '@/types'
@@ -55,14 +55,14 @@ export function createRouterReject({
       meta: {},
     }
 
-    const resolved = readonly({
+    const resolved = {
       matched: route,
       matches: [route],
       key: type,
       query: createResolvedRouteQuery(''),
       params: {},
       [isRejectionRouteSymbol]: true,
-    })
+    }
 
     return resolved
   }

--- a/src/services/createRouterResolve.ts
+++ b/src/services/createRouterResolve.ts
@@ -30,8 +30,8 @@ export type RouterResolve<
 
 export function createRouterResolve<const TRoutes extends Routes>(routes: TRoutes): RouterResolve<TRoutes> {
 
-  return <TRoutes extends Routes, TSource extends Url | RoutesKey<TRoutes>>(
-    source: TSource,
+  return <TSource extends RoutesKey<TRoutes>>(
+    source: Url | TSource,
     paramsOrOptions?: Record<string, unknown>,
     maybeOptions?: RouterResolveOptions,
   ): string => {

--- a/src/services/createRouterResolve.ts
+++ b/src/services/createRouterResolve.ts
@@ -15,7 +15,7 @@ export type RouterResolveOptions = {
 
 type RouterResolveArgs<
   TRoutes extends Routes,
-  TSource extends string & keyof RoutesKey<TRoutes>,
+  TSource extends RoutesKey<TRoutes>,
   TParams = RouteParamsByKey<TRoutes, TSource>
 > = AllPropertiesAreOptional<TParams> extends true
   ? [params?: TParams, options?: RouterResolveOptions]

--- a/src/services/createRouterRoute.spec.ts
+++ b/src/services/createRouterRoute.spec.ts
@@ -1,0 +1,13 @@
+import { expect, test, vi } from 'vitest'
+import { createRouterRoute, isRouterRoute } from '@/services/createRouterRoute'
+import { mockResolvedRoute, mockRoute } from '@/utilities/testHelpers'
+
+test('isRouteRoute returns correct response', () => {
+  const resolved = mockResolvedRoute(mockRoute(''), [])
+  const push = vi.fn()
+
+  const route = createRouterRoute(resolved, push)
+
+  expect(isRouterRoute(route)).toBe(true)
+  expect(isRouterRoute({})).toBe(false)
+})

--- a/src/services/createRouterRoute.ts
+++ b/src/services/createRouterRoute.ts
@@ -1,3 +1,4 @@
+import { reactive, toRefs } from 'vue'
 import { ResolvedRoute } from '@/types/resolved'
 import { ResolvedRouteQuery } from '@/types/resolvedQuery'
 import { RouterPush, RouterPushOptions } from '@/types/routerPush'
@@ -39,23 +40,20 @@ export function createRouterRoute<TRoute extends ResolvedRoute>(route: TRoute, p
     return push(route.key, params, maybeOptions)
   }
 
-  return new Proxy(route as RouterRoute<TRoute>, {
-    has: (target, property) => {
-      if (['update', 'params', isRouterRouteSymbol].includes(property)) {
-        return true
-      }
+  const { matched, matches, key, query, params } = toRefs(route)
 
-      return Reflect.has(target, property)
-    },
+  const routerRoute: RouterRoute<TRoute> = reactive({
+    matched,
+    matches,
+    query,
+    params,
+    key,
+    update,
+    [isRouterRouteSymbol]: true,
+  })
+
+  return new Proxy(routerRoute, {
     get: (target, property, receiver) => {
-      if (property === isRouterRouteSymbol) {
-        return true
-      }
-
-      if (property === 'update') {
-        return update
-      }
-
       if (property === 'params') {
         return new Proxy(route.params, {
           set(_target, property, value) {

--- a/src/services/createRouterRoute.ts
+++ b/src/services/createRouterRoute.ts
@@ -1,11 +1,16 @@
 import { ResolvedRoute } from '@/types/resolved'
+import { ResolvedRouteQuery } from '@/types/resolvedQuery'
 import { RouterPush, RouterPushOptions } from '@/types/routerPush'
 import { RouteUpdate } from '@/types/routeUpdate'
 import { Writable } from '@/types/utilities'
 
 const isRouterRouteSymbol = Symbol('isRouterRouteSymbol')
 
-export type RouterRoute<TRoute extends ResolvedRoute = ResolvedRoute> = Omit<ResolvedRoute, 'params'> & Readonly<{
+export type RouterRoute<TRoute extends ResolvedRoute = ResolvedRoute> = Readonly<{
+  key: TRoute['key'],
+  matched: TRoute['matched'],
+  matches: TRoute['matches'],
+  query: ResolvedRouteQuery,
   params: Writable<TRoute['params']>,
   update: RouteUpdate<TRoute>,
   [isRouterRouteSymbol]: true,

--- a/src/services/createRouterRoute.ts
+++ b/src/services/createRouterRoute.ts
@@ -14,11 +14,10 @@ export type RouterRoute<TRoute extends ResolvedRoute = ResolvedRoute> = Readonly
   query: ResolvedRouteQuery,
   params: Writable<TRoute['params']>,
   update: RouteUpdate<TRoute>,
-  [isRouterRouteSymbol]: true,
 }>
 
 export function isRouterRoute(value: unknown): value is RouterRoute {
-  return typeof value === 'object' && value !== null && isRouterRouteSymbol in value && value[isRouterRouteSymbol] === true
+  return typeof value === 'object' && value !== null && isRouterRouteSymbol in value
 }
 
 export function createRouterRoute<TRoute extends ResolvedRoute>(route: TRoute, push: RouterPush): RouterRoute<TRoute> {

--- a/src/services/createRoutes.ts
+++ b/src/services/createRoutes.ts
@@ -57,7 +57,7 @@ function createRoute(route: RouteProps): Route {
   return {
     matched: rawRoute,
     matches: [rawRoute],
-    key: route.name,
+    key: route.name ?? '',
     path,
     query,
     depth: 1,
@@ -75,7 +75,7 @@ function addRouterViewComponentIfParentWithoutComponent(route: RouteProps): Rout
 
 type FlattenRoute<
   TRoute extends RouteProps,
-  TKey extends string | undefined = TRoute['name'],
+  TKey extends string = string & TRoute['name'],
   TPath extends Path = ToPath<TRoute['path']>,
   TQuery extends Query = ToQuery<TRoute['query']>,
   TDisabled extends boolean = TRoute['disabled'] extends boolean ? TRoute['disabled'] : false,

--- a/src/services/getResolvedRouteForUrl.ts
+++ b/src/services/getResolvedRouteForUrl.ts
@@ -1,4 +1,3 @@
-import { readonly } from 'vue'
 import { createMaybeRelativeUrl } from '@/services/createMaybeRelativeUrl'
 import { createResolvedRouteQuery } from '@/services/createResolvedRouteQuery'
 import { getRouteParamValues, routeParamsAreValid } from '@/services/paramValidation'
@@ -32,11 +31,11 @@ export function getResolvedRouteForUrl(routes: Routes, url: string): ResolvedRou
   const query = createResolvedRouteQuery(search)
   const params = getRouteParamValues(route, url)
 
-  return readonly({
+  return {
     matched: route.matched,
     matches: route.matches,
     key: route.key,
     query,
     params,
-  })
+  }
 }

--- a/src/services/getRouteHooks.spec.ts
+++ b/src/services/getRouteHooks.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test, vi } from 'vitest'
-import { readonly } from 'vue'
 import { createResolvedRouteQuery } from '@/services/createResolvedRouteQuery'
 import { getBeforeRouteHooksFromRoutes } from '@/services/getRouteHooks'
 import { ResolvedRoute } from '@/types/resolved'
@@ -21,13 +20,13 @@ function mockRoute(name: string): RoutePropsWithMeta {
 }
 
 function mockResolvedRoute(matched: RoutePropsWithMeta, matches: RoutePropsWithMeta[]): ResolvedRoute {
-  return readonly({
+  return {
     matched,
     matches,
     key: matched.name!,
     query: createResolvedRouteQuery(),
     params: {},
-  })
+  }
 }
 
 test('given two ResolvedRoutes returns before timing hooks in correct order', () => {

--- a/src/services/getRouteHooks.spec.ts
+++ b/src/services/getRouteHooks.spec.ts
@@ -1,33 +1,6 @@
-import { expect, test, vi } from 'vitest'
-import { createResolvedRouteQuery } from '@/services/createResolvedRouteQuery'
+import { expect, test } from 'vitest'
 import { getBeforeRouteHooksFromRoutes } from '@/services/getRouteHooks'
-import { ResolvedRoute } from '@/types/resolved'
-import { RouteProps } from '@/types/routeProps'
-import { component } from '@/utilities/testHelpers'
-
-type RoutePropsWithMeta = RouteProps & { meta: Record<string, unknown> }
-
-function mockRoute(name: string): RoutePropsWithMeta {
-  return {
-    name,
-    path: `/${name}`,
-    component,
-    onBeforeRouteEnter: vi.fn(),
-    onBeforeRouteUpdate: vi.fn(),
-    onBeforeRouteLeave: vi.fn(),
-    meta: {},
-  }
-}
-
-function mockResolvedRoute(matched: RoutePropsWithMeta, matches: RoutePropsWithMeta[]): ResolvedRoute {
-  return {
-    matched,
-    matches,
-    key: matched.name!,
-    query: createResolvedRouteQuery(),
-    params: {},
-  }
-}
+import { mockResolvedRoute, mockRoute } from '@/utilities/testHelpers'
 
 test('given two ResolvedRoutes returns before timing hooks in correct order', () => {
   const grandchildA = mockRoute('grandchildA')

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -1,4 +1,3 @@
-import { DeepReadonly } from 'vue'
 import { ExtractRouteParamTypes } from '@/types/params'
 import { ResolvedRouteQuery } from '@/types/resolvedQuery'
 import { Route } from '@/types/route'
@@ -9,7 +8,7 @@ type BaseResolvedRoute = Route & { path: { params: Record<string, unknown> }, qu
  * Represents a route that the router has matched to current browser location.
  * @template TRoute - Underlying Route that has been resolved.
  */
-export type ResolvedRoute<TRoute extends Route = BaseResolvedRoute> = DeepReadonly<{
+export type ResolvedRoute<TRoute extends Route = BaseResolvedRoute> = Readonly<{
   /**
    * The specific route properties that were matched in the current route.
   */

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -20,7 +20,7 @@ type RoutePropsWithMeta = RouteProps & { meta: RouteMeta }
  * @template TDisabled - Indicates whether the route is disabled, which could affect routing logic.
  */
 export type Route<
-  TKey extends string | undefined = any,
+  TKey extends string | undefined = string,
   TPath extends string | Path = Path,
   TQuery extends string | Query | undefined = Query,
   TDisabled extends boolean | undefined = boolean

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -20,10 +20,10 @@ type RoutePropsWithMeta = RouteProps & { meta: RouteMeta }
  * @template TDisabled - Indicates whether the route is disabled, which could affect routing logic.
  */
 export type Route<
-  TKey extends string | undefined = string,
+  TKey extends string = string,
   TPath extends string | Path = Path,
-  TQuery extends string | Query | undefined = Query,
-  TDisabled extends boolean | undefined = boolean
+  TQuery extends string | Query = Query,
+  TDisabled extends boolean = boolean
 > = {
   /**
    * The specific route properties that were matched in the current route.

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -10,7 +10,7 @@ export type Routes = Readonly<Route[]>
 /**
  * The Route properties originally provided to `createRoutes`. The only change is normalizing meta to always default to an empty object.
  */
-type RoutePropsWithMeta = RouteProps & { meta: RouteMeta }
+export type RoutePropsWithMeta = RouteProps & { meta: RouteMeta }
 
 /**
  * Represents the structure of a route within the application. Return value of `createRoutes`

--- a/src/types/routeProps.ts
+++ b/src/types/routeProps.ts
@@ -1,4 +1,4 @@
-import { Component, DeepReadonly } from 'vue'
+import { Component } from 'vue'
 import { AfterRouteHook, BeforeRouteHook } from '@/types/hooks'
 import { Path } from '@/types/path'
 import { Query } from '@/types/query'
@@ -120,14 +120,12 @@ export function isParentRouteWithoutComponent(value: RouteProps): value is Omit<
 
 export function isRouteWithComponent(value: RouteProps): value is RouteProps & WithComponent
 export function isRouteWithComponent(value: Readonly<RouteProps>): value is Readonly<RouteProps & WithComponent>
-export function isRouteWithComponent(value: DeepReadonly<RouteProps>): value is DeepReadonly<RouteProps & WithComponent>
 export function isRouteWithComponent(value: unknown): boolean {
   return typeof value === 'object' && value !== null && 'component' in value
 }
 
 export function isRouteWithComponents(value: RouteProps): value is RouteProps & WithComponents
 export function isRouteWithComponents(value: Readonly<RouteProps>): value is Readonly<RouteProps & WithComponents>
-export function isRouteWithComponents(value: DeepReadonly<RouteProps>): value is DeepReadonly<RouteProps & WithComponents>
 export function isRouteWithComponents(value: unknown): boolean {
   return typeof value === 'object' && value !== null && 'components' in value
 }

--- a/src/types/routerPush.ts
+++ b/src/types/routerPush.ts
@@ -11,7 +11,7 @@ export type RouterPushOptions = {
 
 type RouterPushArgs<
   TRoutes extends Routes,
-  TSource extends string & keyof RoutesKey<TRoutes>,
+  TSource extends RoutesKey<TRoutes>,
   TParams = RouteParamsByKey<TRoutes, TSource>
 > = AllPropertiesAreOptional<TParams> extends true
   ? [params?: TParams, options?: RouterPushOptions]

--- a/src/types/routerReplace.ts
+++ b/src/types/routerReplace.ts
@@ -9,7 +9,7 @@ export type RouterReplaceOptions = Omit<RouterPushOptions, 'replace'>
 
 type RouterReplaceArgs<
   TRoutes extends Routes,
-  TSource extends string & keyof RoutesKey<TRoutes>,
+  TSource extends RoutesKey<TRoutes>,
   TParams = RouteParamsByKey<TRoutes, TSource>
 > = AllPropertiesAreOptional<TParams> extends true
   ? [params?: TParams, options?: RouterReplaceOptions]

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -1,5 +1,3 @@
-import { DeepReadonly } from 'vue'
-
 // Utility type that converts types like `{ foo: string } & { bar: string, baz: never }`
 // into `{ foo: string, bar: string }`
 //
@@ -16,8 +14,6 @@ export type IsEmptyObject<T> = T extends Record<string, never> ? (keyof T extend
 export type MaybeArray<T> = T | T[]
 
 export type MaybePromise<T> = T | Promise<T>
-
-export type MaybeDeepReadonly<T> = T | DeepReadonly<T>
 
 // Copied and modified from [type-fest](https://github.com/sindresorhus/type-fest/blob/main/source/replace.d.ts)
 export type ReplaceAll<

--- a/src/utilities/testHelpers.ts
+++ b/src/utilities/testHelpers.ts
@@ -1,4 +1,8 @@
+import { vi } from 'vitest'
+import { createResolvedRouteQuery } from '@/services/createResolvedRouteQuery'
 import { createRoutes } from '@/services/createRoutes'
+import { ResolvedRoute } from '@/types/resolved'
+import { RoutePropsWithMeta } from '@/types/route'
 
 export const random = {
   number(options: { min?: number, max?: number } = {}): number {
@@ -55,3 +59,25 @@ export const routes = createRoutes([
     component,
   },
 ])
+
+export function mockRoute(name: string): RoutePropsWithMeta {
+  return {
+    name,
+    path: `/${name}`,
+    component,
+    onBeforeRouteEnter: vi.fn(),
+    onBeforeRouteUpdate: vi.fn(),
+    onBeforeRouteLeave: vi.fn(),
+    meta: {},
+  }
+}
+
+export function mockResolvedRoute(matched: RoutePropsWithMeta, matches: RoutePropsWithMeta[]): ResolvedRoute {
+  return {
+    matched,
+    matches,
+    key: matched.name!,
+    query: createResolvedRouteQuery(),
+    params: {},
+  }
+}


### PR DESCRIPTION
# Description
The `isRoute` type guard was functionally sound and types work just fine. But `RouterRoute` produced a type that was too specific and to wide. So when passing a `RouterRoute` into `isRoute` the types conflicted and effectively didn't narrow properly. A few changes were necessary to fix this.

1. Update `Route` type to default to a `string` for the key rather than `any`. Because `any & 'key'` is still `any`. But `string & 'key'` is `'key'`. Which is what we want. 
2. Remove `Omit` utility from `RouterRoute` declaration. This produces a much simpler type and one that typescript can reason about without evaluating it.
3. Replace all `DeepReadonly` types with `Readonly` to produce simpler types that typescript can reason about more easily (and produce much more readable types)
4. Remove all uses of `readonly` (to satisfy the `DeepReadonly` removal)

3 & 4 were not strictly necessary. I had a working version that still used the readonly types, but everything looks much better without it. I want to revisit this in a follow up PR. For now I've marked the one test that covered the readonly pieces as `fails`.