### PR TITLE
0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kitbag/router",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kitbag/router",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "history": "^5.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kitbag/router",
   "private": false,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "bugs": {
     "url": "https://github.com/kitbagjs/router/issues"
   },


### PR DESCRIPTION
pushed with `git push --follow-tags`, looks like it might be pushing the tags from previous releases as well

https://stackoverflow.com/a/3745250/3511012