### PR TITLE
Remove `as const` to fix build

### DIFF
--- a/src/services/createRouterReject.ts
+++ b/src/services/createRouterReject.ts
@@ -4,7 +4,7 @@ import { createResolvedRouteQuery } from '@/services/createResolvedRouteQuery'
 import { RegisteredRejectionType } from '@/types'
 import { ResolvedRoute } from '@/types/resolved'
 
-export const builtInRejections = ['NotFound'] as const
+export const builtInRejections: ['NotFound'] = ['NotFound']
 export type BuiltInRejectionType = typeof builtInRejections[number]
 
 export type RouterRejectionType = BuiltInRejectionType | RegisteredRejectionType


### PR DESCRIPTION
# Description
Hopefully temporary fix to get the build working again. Related to 
https://github.com/qmhc/vite-plugin-dts/issues/283 and https://github.com/microsoft/rushstack/issues/3875

Might look at removing `vite-plugin-dts` in favor of using `vue-tsc` to extract types. 