### PR TITLE
Make `route` a union of all possible routes and improve return types for `isRoute` and `useRoute`

### DIFF
--- a/src/components/routerView.browser.spec.ts
+++ b/src/components/routerView.browser.spec.ts
@@ -5,6 +5,7 @@ import helloWorld from '@/components/helloWorld'
 import { createRouter } from '@/services/createRouter'
 import { createRoutes } from '@/services/createRoutes'
 import { isRouteWithComponent } from '@/types/routeProps'
+import { routes } from '@/utilities/testHelpers'
 
 test('renders component for initial route', async () => {
   const routes = createRoutes([
@@ -170,7 +171,7 @@ test('Renders the genericRejection component when the initialUrl does not match'
 
 test('Renders custom genericRejection component when the initialUrl does not match', async () => {
   const NotFound = { template: 'Custom Not Found' }
-  const router = createRouter([], {
+  const router = createRouter(routes, {
     initialUrl: '/does-not-exist',
     rejections: {
       NotFound,

--- a/src/compositions/useRoute.ts
+++ b/src/compositions/useRoute.ts
@@ -22,7 +22,7 @@ export function useRoute(): RegisteredRouterRoute
 
 export function useRoute<
   TRouteKey extends RegisteredRoutesKey
->(routeKey: TRouteKey, options: IsRouteOptions<true>): RegisteredRouterRoute & { key: `${TRouteKey}` }
+>(routeKey: TRouteKey, options: IsRouteOptions<true>): RegisteredRouterRoute & { key: TRouteKey }
 
 export function useRoute<
   TRouteKey extends RegisteredRoutesKey

--- a/src/compositions/useRoute.ts
+++ b/src/compositions/useRoute.ts
@@ -2,7 +2,6 @@ import { watch } from 'vue'
 import { useRouter } from '@/compositions/useRouter'
 import { UseRouteInvalidError } from '@/errors'
 import { IsRouteOptions, isRoute } from '@/guards/routes'
-import { RouterRoute } from '@/services/createRouterRoute'
 import { RegisteredRouterRoute, RegisteredRoutesKey } from '@/types/register'
 
 /**
@@ -29,7 +28,7 @@ export function useRoute<
   TRouteKey extends RegisteredRoutesKey
 >(routeKey: TRouteKey, options?: IsRouteOptions<false>): RegisteredRouterRoute & { key: `${TRouteKey}${string}` }
 
-export function useRoute(routeKey?: string, options?: IsRouteOptions): RouterRoute {
+export function useRoute(routeKey?: string, options?: IsRouteOptions): RegisteredRouterRoute {
   const router = useRouter()
 
   function checkRouteKeyIsValid(): void {

--- a/src/compositions/useRoute.ts
+++ b/src/compositions/useRoute.ts
@@ -22,11 +22,11 @@ export function useRoute(): RegisteredRouterRoute
 
 export function useRoute<
   TRouteKey extends RegisteredRoutesKey
->(routeKey: TRouteKey, options: IsRouteOptions<true>): RegisteredRouterRoute & { key: TRouteKey }
+>(routeKey: TRouteKey, options: IsRouteOptions & { exact: true }): RegisteredRouterRoute & { key: TRouteKey }
 
 export function useRoute<
   TRouteKey extends RegisteredRoutesKey
->(routeKey: TRouteKey, options?: IsRouteOptions<false>): RegisteredRouterRoute & { key: `${TRouteKey}${string}` }
+>(routeKey: TRouteKey, options?: IsRouteOptions): RegisteredRouterRoute & { key: `${TRouteKey}${string}` }
 
 export function useRoute(routeKey?: string, options?: IsRouteOptions): RegisteredRouterRoute {
   const router = useRouter()

--- a/src/guards/routes.spec-d.ts
+++ b/src/guards/routes.spec-d.ts
@@ -1,0 +1,65 @@
+import { expectTypeOf, test } from 'vitest'
+import { isRoute } from '@/guards/routes'
+import { createRouter, createRoutes } from '@/services'
+import { component } from '@/utilities/testHelpers'
+
+test('router route can be narrowed', () => {
+  const routes = createRoutes([
+    {
+      name: 'parentA',
+      path: '/parentA',
+      children: createRoutes([
+        {
+          component,
+          name: 'childA',
+          path: '/childA/[childA]',
+        },
+      ]),
+    },
+    {
+      name: 'parentB',
+      path: '/parentB',
+      component,
+    },
+  ])
+
+  const { route } = createRouter(routes)
+
+  expectTypeOf<typeof route.key>().toMatchTypeOf<'parentA' | 'parentB' | 'parentA.childA'>()
+
+  if (route.key === 'parentA') {
+    expectTypeOf<typeof route.key>().toMatchTypeOf<'parentA'>()
+  }
+
+  if (isRoute(route, 'parentA', { exact: true })) {
+    expectTypeOf<typeof route.key>().toMatchTypeOf<'parentA'>()
+  }
+
+  if (isRoute(route, 'parentA', { exact: false })) {
+    expectTypeOf<typeof route.key>().toMatchTypeOf<'parentA' | 'parentA.childA'>()
+  }
+
+  if (isRoute(route, 'parentA')) {
+    expectTypeOf<typeof route.key>().toMatchTypeOf<'parentA' | 'parentA.childA'>()
+  }
+
+  if (route.key === 'parentA') {
+    expectTypeOf<typeof route.params>().toMatchTypeOf<{}>()
+  }
+
+  if (isRoute(route, 'parentA', { exact: true })) {
+    expectTypeOf<typeof route.params>().toMatchTypeOf<{}>()
+  }
+
+  if (isRoute(route, 'parentA', { exact: false })) {
+    expectTypeOf<typeof route.params>().toMatchTypeOf<{} | {
+      childA: string,
+    }>()
+  }
+
+  if (isRoute(route, 'parentA')) {
+    expectTypeOf<typeof route.params>().toMatchTypeOf<{} |{
+      childA: string,
+    }>()
+  }
+})

--- a/src/guards/routes.ts
+++ b/src/guards/routes.ts
@@ -13,7 +13,7 @@ export function isRoute(route: unknown): route is RouterRoute
 export function isRoute<
   TRoute extends RouterRoute,
   TRouteKey extends TRoute['key']
->(route: TRoute, routeKey: TRouteKey, options: IsRouteOptions<true>): route is TRoute & { key: `${TRouteKey}` }
+>(route: TRoute, routeKey: TRouteKey, options: IsRouteOptions<true>): route is TRoute & { key: TRouteKey }
 
 export function isRoute<
   TRoute extends RouterRoute,
@@ -22,7 +22,7 @@ export function isRoute<
 
 export function isRoute<
   TRouteKey extends RegisteredRoutesKey
->(route: unknown, routeKey: TRouteKey, options: IsRouteOptions<true>): route is RegisteredRouterRoute & { key: `${TRouteKey}` }
+>(route: unknown, routeKey: TRouteKey, options: IsRouteOptions<true>): route is RegisteredRouterRoute & { key: TRouteKey }
 
 export function isRoute<
   TRouteKey extends RegisteredRoutesKey

--- a/src/guards/routes.ts
+++ b/src/guards/routes.ts
@@ -2,10 +2,8 @@ import { combineName } from '@/services/combineName'
 import { RouterRoute, isRouterRoute } from '@/services/createRouterRoute'
 import { RegisteredRouterRoute, RegisteredRoutesKey } from '@/types/register'
 
-export type IsRouteOptions<
-  TExact extends boolean = boolean
-> = {
-  exact?: TExact,
+export type IsRouteOptions = {
+  exact?: boolean,
 }
 
 export function isRoute(route: unknown): route is RouterRoute
@@ -13,20 +11,20 @@ export function isRoute(route: unknown): route is RouterRoute
 export function isRoute<
   TRoute extends RouterRoute,
   TRouteKey extends TRoute['key']
->(route: TRoute, routeKey: TRouteKey, options: IsRouteOptions<true>): route is TRoute & { key: TRouteKey }
+>(route: TRoute, routeKey: TRouteKey, options: IsRouteOptions & { exact: true }): route is TRoute & { key: TRouteKey }
 
 export function isRoute<
   TRoute extends RouterRoute,
   TRouteKey extends TRoute['key']
->(route: TRoute, routeKey: TRouteKey, options?: IsRouteOptions<false>): route is TRoute & { key: `${TRouteKey}${string}` }
+>(route: TRoute, routeKey: TRouteKey, options?: IsRouteOptions): route is TRoute & { key: `${TRouteKey}${string}` }
 
 export function isRoute<
   TRouteKey extends RegisteredRoutesKey
->(route: unknown, routeKey: TRouteKey, options: IsRouteOptions<true>): route is RegisteredRouterRoute & { key: TRouteKey }
+>(route: unknown, routeKey: TRouteKey, options: IsRouteOptions & { exact: true }): route is RegisteredRouterRoute & { key: TRouteKey }
 
 export function isRoute<
   TRouteKey extends RegisteredRoutesKey
->(route: unknown, routeKey: TRouteKey, options?: IsRouteOptions<false>): route is RegisteredRouterRoute & { key: `${TRouteKey}${string}` }
+>(route: unknown, routeKey: TRouteKey, options?: IsRouteOptions): route is RegisteredRouterRoute & { key: `${TRouteKey}${string}` }
 
 export function isRoute(route: unknown, routeKey?: string, options?: IsRouteOptions): boolean
 

--- a/src/guards/routes.ts
+++ b/src/guards/routes.ts
@@ -1,14 +1,35 @@
 import { combineName } from '@/services/combineName'
 import { RouterRoute, isRouterRoute } from '@/services/createRouterRoute'
-import { RegisteredRouteMap, RegisteredRoutesKey } from '@/types/register'
-import { ResolvedRoute } from '@/types/resolved'
+import { RegisteredRouterRoute, RegisteredRoutesKey } from '@/types/register'
 
-export type IsRouteOptions = {
-  exact?: boolean,
+export type IsRouteOptions<
+  TExact extends boolean = boolean
+> = {
+  exact?: TExact,
 }
 
 export function isRoute(route: unknown): route is RouterRoute
-export function isRoute<TRouteKey extends RegisteredRoutesKey>(route: unknown, routeKey: TRouteKey, options?: IsRouteOptions): route is RouterRoute<ResolvedRoute<RegisteredRouteMap[TRouteKey]>>
+
+export function isRoute<
+  TRoute extends RouterRoute,
+  TRouteKey extends TRoute['key']
+>(route: TRoute, routeKey: TRouteKey, options: IsRouteOptions<true>): route is TRoute & { key: `${TRouteKey}` }
+
+export function isRoute<
+  TRoute extends RouterRoute,
+  TRouteKey extends TRoute['key']
+>(route: TRoute, routeKey: TRouteKey, options?: IsRouteOptions<false>): route is TRoute & { key: `${TRouteKey}${string}` }
+
+export function isRoute<
+  TRouteKey extends RegisteredRoutesKey
+>(route: unknown, routeKey: TRouteKey, options: IsRouteOptions<true>): route is RegisteredRouterRoute & { key: `${TRouteKey}` }
+
+export function isRoute<
+  TRouteKey extends RegisteredRoutesKey
+>(route: unknown, routeKey: TRouteKey, options?: IsRouteOptions<false>): route is RegisteredRouterRoute & { key: `${TRouteKey}${string}` }
+
+export function isRoute(route: unknown, routeKey?: string, options?: IsRouteOptions): boolean
+
 export function isRoute(route: unknown, routeKey?: string, { exact }: IsRouteOptions = {}): boolean {
   if (!isRouterRoute(route)) {
     return false

--- a/src/services/createCurrentRoute.ts
+++ b/src/services/createCurrentRoute.ts
@@ -1,16 +1,19 @@
 import { reactive } from 'vue'
-import { RouterRoute, createRouterRoute } from '@/services/createRouterRoute'
+import { createRouterRoute } from '@/services/createRouterRoute'
+import { RouterRoutes } from '@/types'
 import { ResolvedRoute } from '@/types/resolved'
+import { Routes } from '@/types/route'
 import { RouterPush } from '@/types/routerPush'
 
 type ResolvedRouteUpdate = (route: ResolvedRoute) => void
 
-type CurrentRouteContext = {
+type CurrentRouteContext<TRoutes extends Routes = Routes> = {
   currentRoute: ResolvedRoute,
-  routerRoute: RouterRoute,
+  routerRoute: RouterRoutes<TRoutes>,
   updateRoute: ResolvedRouteUpdate,
 }
 
+export function createCurrentRoute<TRoutes extends Routes>(fallbackRoute: ResolvedRoute, push: RouterPush): CurrentRouteContext<TRoutes>
 export function createCurrentRoute(fallbackRoute: ResolvedRoute, push: RouterPush): CurrentRouteContext {
   const route = reactive({ ...fallbackRoute })
 

--- a/src/services/createRouter.spec.ts
+++ b/src/services/createRouter.spec.ts
@@ -142,10 +142,12 @@ test('individual prams are writable', async () => {
 
   expect(route.params.param).toBe('again')
 
+  // @ts-expect-error
   route.params.nothing = 'nothing'
 
   await flushPromises()
 
+  // @ts-expect-error
   expect(route.params.nothing).toBeUndefined()
 })
 
@@ -188,9 +190,11 @@ test('setting an unknown param does not add its value to the route', async () =>
 
   await initialized
 
+  // @ts-expect-error
   route.params.nothing = 'nothing'
 
   await flushPromises()
 
+  // @ts-expect-error
   expect(route.params.nothing).toBeUndefined()
 })

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -179,8 +179,12 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
     app.provide(routerInjectionKey, router as any)
   }
 
+  // This cast is necessary because the implementation of routerRoute returns a RouterRoute (with no generic)
+  // and it doesn't match the expected route type. "Fixing" this is probably more trouble than its worth right now.
+  const route = routerRoute as unknown as Router<T>['route']
+
   const router: Router<T> = {
-    route: routerRoute,
+    route,
     resolve,
     push,
     replace,

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -171,9 +171,12 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
   function install(app: App): void {
     app.component('RouterView', RouterView)
     app.component('RouterLink', RouterLink)
-    app.provide(routerInjectionKey, router)
     app.provide(routerRejectionKey, rejection)
     app.provide(routeHookStoreKey, hooks)
+
+    // We cant technically guarantee that the user registered the same router that they installed
+    // So we're making an assumption here that when installing a router its the same as the RegisteredRouter
+    app.provide(routerInjectionKey, router as any)
   }
 
   const router: Router<T> = {

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -161,7 +161,7 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
   const find = createRouterFind(routes)
   const { setRejection, rejection, getRejectionRoute } = createRouterReject(options)
   const notFoundRoute = getRejectionRoute('NotFound')
-  const { currentRoute, routerRoute, updateRoute } = createCurrentRoute(notFoundRoute, push)
+  const { currentRoute, routerRoute, updateRoute } = createCurrentRoute<T>(notFoundRoute, push)
 
   history.startListening()
 
@@ -179,12 +179,8 @@ export function createRouter<const T extends Routes>(routes: T, options: RouterO
     app.provide(routerInjectionKey, router as any)
   }
 
-  // This cast is necessary because the implementation of routerRoute returns a RouterRoute (with no generic)
-  // and it doesn't match the expected route type. "Fixing" this is probably more trouble than its worth right now.
-  const route = routerRoute as unknown as Router<T>['route']
-
   const router: Router<T> = {
-    route,
+    route: routerRoute,
     resolve,
     push,
     replace,

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -82,7 +82,7 @@ export type ExtractRouteParamTypes<TRoute> = TRoute extends {
   query: { params: infer QueryParams extends Record<string, Param> },
 }
   ? ExtractParamTypes<MergeParams<PathParams, QueryParams>>
-  : Record<string, unknown>
+  : {}
 
 /**
  * Transforms a record of parameter types into a type with optional properties where the original type allows undefined.

--- a/src/types/register.ts
+++ b/src/types/register.ts
@@ -24,9 +24,16 @@ export interface Register {}
 /**
  * Represents the Router property within {@link Register}
  */
-export type RegisteredRouter = Register extends { router: infer TRouter }
+export type RegisteredRouter = Register extends { router: infer TRouter extends Router }
   ? TRouter
   : Router
+
+/**
+ * Represents the Router property within {@link Register}
+ */
+export type RegisteredRouterRoute = Register extends { router: infer TRouter extends Router }
+  ? TRouter['route']
+  : RouterRoute
 
 /**
  * Represents the Router routes property within {@link Register}

--- a/src/types/register.ts
+++ b/src/types/register.ts
@@ -24,16 +24,14 @@ export interface Register {}
 /**
  * Represents the Router property within {@link Register}
  */
-export type RegisteredRouter = Register extends { router: infer TRouter extends Router }
+export type RegisteredRouter = Register extends { router: infer TRouter }
   ? TRouter
   : Router
 
 /**
  * Represents the Router property within {@link Register}
  */
-export type RegisteredRouterRoute = Register extends { router: infer TRouter extends Router }
-  ? TRouter['route']
-  : RouterRoute
+export type RegisteredRouterRoute = RegisteredRouter['route']
 
 /**
  * Represents the Router routes property within {@link Register}

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -2,13 +2,11 @@ import { ExtractRouteParamTypes } from '@/types/params'
 import { ResolvedRouteQuery } from '@/types/resolvedQuery'
 import { Route } from '@/types/route'
 
-type BaseResolvedRoute = Route & { path: { params: Record<string, unknown> }, query: { params: Record<string, unknown> } }
-
 /**
  * Represents a route that the router has matched to current browser location.
  * @template TRoute - Underlying Route that has been resolved.
  */
-export type ResolvedRoute<TRoute extends Route = BaseResolvedRoute> = Readonly<{
+export type ResolvedRoute<TRoute extends Route = Route> = Readonly<{
   /**
    * The specific route properties that were matched in the current route.
   */
@@ -29,5 +27,5 @@ export type ResolvedRoute<TRoute extends Route = BaseResolvedRoute> = Readonly<{
   /**
    * Key value pair for route params, values will be the user provided value from current browser location.
   */
-  params: BaseResolvedRoute extends TRoute ? Record<string, unknown> : ExtractRouteParamTypes<TRoute>,
+  params: ExtractRouteParamTypes<TRoute>,
 }>

--- a/src/types/routeUpdate.ts
+++ b/src/types/routeUpdate.ts
@@ -1,7 +1,10 @@
 import { ResolvedRoute } from '@/types/resolved'
 import { RouterPushOptions } from '@/types/routerPush'
 
-export type RouteUpdate<TRoute extends ResolvedRoute = ResolvedRoute> = {
+export type RouteUpdate<TRoute extends ResolvedRoute = ResolvedRoute> = ResolvedRoute extends TRoute ? {
+  (key: string, value: unknown, options?: RouterPushOptions): Promise<void>,
+  (params: Partial<TRoute['params']>, options?: RouterPushOptions): Promise<void>,
+}: {
   <TKey extends keyof TRoute['params']>(key: TKey, value: TRoute['params'][TKey], options?: RouterPushOptions): Promise<void>,
   (params: Partial<TRoute['params']>, options?: RouterPushOptions): Promise<void>,
 }

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -5,6 +5,7 @@ import { RouterRejectionComponents, RouterRejectionType } from '@/services/creat
 import { RouterResolve } from '@/services/createRouterResolve'
 import { RouterRoute } from '@/services/createRouterRoute'
 import { AddAfterRouteHook, AddBeforeRouteHook } from '@/types/hooks'
+import { ResolvedRoute } from '@/types/resolved'
 import { Routes } from '@/types/route'
 import { RouterPush } from '@/types/routerPush'
 import { RouterReplace } from '@/types/routerReplace'
@@ -33,7 +34,7 @@ export type Router<
   /**
    * Manages the current route state.
    */
-  route: RouterRoute,
+  route: RouterRoutes<TRoutes>,
   /**
    * Resolves a URL to a route object.
    */
@@ -99,3 +100,10 @@ export type Router<
    */
   initialized: Promise<void>,
 }
+
+/**
+ * This type is the same as `RouterRoute<ResolvedRoute<TRoutes[number]>>` while remaining distributive
+ */
+type RouterRoutes<TRoutes extends Routes> = {
+  [K in keyof TRoutes]: RouterRoute<ResolvedRoute<TRoutes[K]>>
+}[number]

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -104,6 +104,6 @@ export type Router<
 /**
  * This type is the same as `RouterRoute<ResolvedRoute<TRoutes[number]>>` while remaining distributive
  */
-type RouterRoutes<TRoutes extends Routes> = {
+export type RouterRoutes<TRoutes extends Routes> = {
   [K in keyof TRoutes]: RouterRoute<ResolvedRoute<TRoutes[K]>>
 }[number]


### PR DESCRIPTION
# Description
This PR updates the type for the current route to be a discriminating union of possible routes. This means that when accessing the route via `router.route` or by using the `useRoute` composition the route can easily be narrowed. 

Given the following routes
```ts
const routes = createRoutes([
  {
    name: 'parentA',
    path: '/parentA',
    children: createRoutes([
      {
        component,
        name: 'childA',
        path: '/childA/[paramA]',
      },
    ]),
  },
  {
    name: 'parentB',
    path: '/parentB',
    component,
  },
])

const router = createRouter(routes)
```
`router.route.key` is type `'parentA' | 'parentB' | 'parentA.childA'`. And `router.route.params` is type `{} | { paramA: string }`. Which means you can narrow the route in a type safe way by doing things like this
```ts
const route = router.route

if(route.key === 'parentA.childA') {
  console.log(route.params.paramA) // correctly knows that `paramA` is a valid param
}
```
## `isRoute` and `useRoute`
This gets even more useful when combined with the `isRoute` type guard that is exported by router. By default `isRoute` is not an exact route match, meaning it will match any route AND any children of that route.
```ts
if(isRoute(route, 'parentA')) {
  // route.key is type 'parentA' | 'parentA.childA'
}
```
If you want to match only an exact route you can pass the exact option into `isRoute`
```ts
if(isRoute(route, 'parentA', { exact: true })) {
  // route.key is type 'parentA'
}
```
This works exactly the same when using `useRoute`
```ts
const route = useRoute('parentA')
// route.key is 'parentA' | 'parentA.childA'
```
```ts
const route = useRoute('parentA', { exact: true })
// route.key is 'parentA'
```
This makes working with routes in a type safe way much easier and more flexible. 