### PR TITLE
Update docs to include a guide about narrowing the route

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -133,12 +133,14 @@ export default defineConfig({
             { text: 'Route Params', link: '/core-concepts/route-params' },
             { text: 'Query Params', link: '/core-concepts/query-params' },
             { text: 'Navigating', link: '/core-concepts/navigating' },
+            { text: 'Composables', link: '/core-concepts/composables' },
           ],
         },
         {
           text: 'Advanced Concepts',
           items: [
             { text: 'Route Matching', link: '/advanced-concepts/route-matching' },
+            { text: 'Route Narrowing', link: '/advanced-concepts/route-narrowing' },
             { text: 'Rejections', link: '/advanced-concepts/rejections' },
             { text: 'Hooks', link: '/advanced-concepts/hooks' },
             { text: 'Route Meta', link: '/advanced-concepts/route-meta' },

--- a/docs/advanced-concepts/route-narrowing.md
+++ b/docs/advanced-concepts/route-narrowing.md
@@ -1,0 +1,71 @@
+# Route Narrowing
+When accessing the current route, by default the type is a union of all possible routes. 
+
+```ts
+import { createRoutes, createRouter } from '@kitbag/router'
+
+const routes = createRoutes([
+  {
+    name: 'home',
+    path: '/',
+    component: ...,
+  },
+  {
+    name: 'user',
+    path: '/user/[userId]',
+    component: ...,
+    children: createRoutes([
+      {
+        name: 'profile',
+        path: '/profile',
+        query: '?tab=[tab]',
+        component: ...,
+      },
+      {
+        name: 'settings',
+        path: '/settings',
+        component: ...,
+      }
+    ])
+  }
+])
+
+const router = createRouter(routes)
+
+router.route.key // "home" | "user" | "user.profile" | "user.settings"
+```
+
+This can be narrowed by using the route key to check which route is the current route.
+
+```ts
+if(router.route.key === 'user') {
+  router.route.key // "user"
+  router.route.params // { userId: string }
+}
+```
+
+You can also use the `isRoute` type guard. You could write the same logic as above like this.
+
+```ts
+if(router.route, 'user', { exact: true }) {
+  router.route.key // "user"
+  router.route.params // { userId: string }
+}
+```
+
+Its recommended to use the `isRoute` type guard because it offers more flexibility by its use of `exact`. 
+
+```ts
+if(router.route, 'user', { exact: false }) {
+  router.route.key // "user" | "user.profile" | "user.settings"
+  router.route.params // { userId: string } | { userId: string, tab: string }
+```
+
+The `exact` option is optional and defaults to `false`.
+
+```ts
+if(router.route, 'user') {
+  router.route.key // "user" | "user.profile" | "user.settings"
+  router.route.params // { userId: string } | { userId: string, tab: string }
+}
+```

--- a/docs/advanced-concepts/route-narrowing.md
+++ b/docs/advanced-concepts/route-narrowing.md
@@ -35,7 +35,7 @@ const router = createRouter(routes)
 router.route.key // "home" | "user" | "user.profile" | "user.settings"
 ```
 
-This can be narrowed by using the route key to check which route is the current route.
+This can be narrowed like any union in Typescript, by checking the route key.
 
 ```ts
 if(router.route.key === 'user') {

--- a/docs/advanced-concepts/route-narrowing.md
+++ b/docs/advanced-concepts/route-narrowing.md
@@ -53,19 +53,9 @@ if(router.route, 'user', { exact: true }) {
 }
 ```
 
-Its recommended to use the `isRoute` type guard because it offers more flexibility by its use of `exact`. 
+The `isRoute` type guard offers more flexibility with the optional `exact` argument, which defaults to `false` and will return narrow to the target route or any of it's descendants. 
 
 ```ts
 if(router.route, 'user', { exact: false }) {
   router.route.key // "user" | "user.profile" | "user.settings"
   router.route.params // { userId: string } | { userId: string, tab: string }
-```
-
-The `exact` option is optional and defaults to `false`.
-
-```ts
-if(router.route, 'user') {
-  router.route.key // "user" | "user.profile" | "user.settings"
-  router.route.params // { userId: string } | { userId: string, tab: string }
-}
-```

--- a/docs/api/composables/useRoute.md
+++ b/docs/api/composables/useRoute.md
@@ -1,9 +1,15 @@
 # useRoute
 
-## useRoute(routeKey)
-
 ```ts
-function useRoute<TRouteKey>(routeKey): Route<ResolvedRoute<RegisteredRouteMap[TRouteKey]>>
+export function useRoute(): RegisteredRouterRoute
+
+export function useRoute<
+  TRouteKey extends RegisteredRoutesKey
+>(routeKey: TRouteKey, options: IsRouteOptions & { exact: true }): RegisteredRouterRoute & { key: TRouteKey }
+
+export function useRoute<
+  TRouteKey extends RegisteredRoutesKey
+>(routeKey: TRouteKey, options?: IsRouteOptions): RegisteredRouterRoute & { key: `${TRouteKey}${string}` }
 ```
 
 A composition to access the current route or verify a specific route key within a Vue component.
@@ -16,7 +22,7 @@ This function provides two overloads:
 
 | Type parameter | Description |
 | :------ | :------ |
-| `TRouteKey` *extends* `string` | A string type that should match route key of RegisteredRouteMap, ensuring the route key exists. |
+| `TRouteKey` *extends* `RegisteredRoutesKey` | A string type that should match RegisteredRoutesKey, ensuring the route key exists. |
 
 ### Parameters
 
@@ -27,7 +33,7 @@ This function provides two overloads:
 
 ### Returns
 
-[`Route`](/api/types/Route)\<[`ResolvedRoute`](/api/types/ResolvedRoute)\>
+`RegisteredRouterRoute`
 
 The current router route. If a route key is provided, it validates the route key first.
 

--- a/docs/api/guards/isRoute.md
+++ b/docs/api/guards/isRoute.md
@@ -2,7 +2,24 @@
 
 ```ts
 export function isRoute(route: unknown): route is RouterRoute
-function isRoute<TRouteKey>(route: RouterRoute, routeKey: TRouteKey, options?: isRouteOptions): route is RouterRoute<ResolvedRoute<RegisteredRouteMap[TRouteKey]>>
+
+export function isRoute<
+  TRoute extends RouterRoute,
+  TRouteKey extends TRoute['key']
+>(route: TRoute, routeKey: TRouteKey, options: IsRouteOptions & { exact: true }): route is TRoute & { key: TRouteKey }
+
+export function isRoute<
+  TRoute extends RouterRoute,
+  TRouteKey extends TRoute['key']
+>(route: TRoute, routeKey: TRouteKey, options?: IsRouteOptions): route is TRoute & { key: `${TRouteKey}${string}` }
+
+export function isRoute<
+  TRouteKey extends RegisteredRoutesKey
+>(route: unknown, routeKey: TRouteKey, options: IsRouteOptions & { exact: true }): route is RegisteredRouterRoute & { key: TRouteKey }
+
+export function isRoute<
+  TRouteKey extends RegisteredRoutesKey
+>(route: unknown, routeKey: TRouteKey, options?: IsRouteOptions): route is RegisteredRouterRoute & { key: `${TRouteKey}${string}` }
 ```
 
 Type guards that asserts a value is `RouterRoute` and optionally that it is also a specific route based on a route key.

--- a/docs/core-concepts/composables.md
+++ b/docs/core-concepts/composables.md
@@ -1,5 +1,15 @@
 # Composables
 
+## useRouter
+
+Returns the router, with types provided by [the `Register` interface](/getting-started#update-registered-router).
+
+```ts
+import { useRouter } from '@kitbag/router'
+
+const router = useRouter()
+```
+
 ## useRoute
 
 Returns the current route with built in type guard.
@@ -17,16 +27,6 @@ If you'd like to only match on an exact route match and not match on a parent ro
 
 ```ts
 const route = useRoute('route.key.here', { exact: true })
-```
-
-## useRouter
-
-Returns the router, with types provided by [the `Register` interface](/getting-started#update-registered-router).
-
-```ts
-import { useRouter } from '@kitbag/router'
-
-const router = useRouter()
 ```
 
 ## useLink

--- a/docs/core-concepts/defining-routes.md
+++ b/docs/core-concepts/defining-routes.md
@@ -49,7 +49,7 @@ Any Route can have `children`, though to have those children's components be ren
 
 ## Route Names
 
-Providing the `name` property for each route ensures that we have a way of programmatically navigating. Having names for parent methods also ensures that the parent is part of the ancestry chain of child route methods.
+Providing the `name` property for each route ensures that we have a way of programmatically navigating. Having names for parent routes also ensures that the parent is part of the hierarchal key of any child routes.
 
 With the example user routes above
 
@@ -60,10 +60,6 @@ router.push('user.settings.keys')
 ```
 
 Learn more about [navigating](/core-concepts/navigating) to routes.
-
-::: info
-While there are no constraints on what you pick for the name, we recommend camelCase strings which will feel the most natural when using the route methods for navigation.
-:::
 
 ## Disabled Routes
 


### PR DESCRIPTION
# Description
Little cleanup of docs in general. 

- Added the missing "Composables" page to core concepts (previously only accessible via search and was listed as an advanced concept). 
- Added "Route Narrowing" to advanced concepts
- Updated api docs for `isRoute` and `useRoute`
- Removed some references to "route methods" that were outdated