### PR TITLE
bug: external `to` on router-link was rendering NotFound before navigating

### DIFF
--- a/src/components/routerLink.vue
+++ b/src/components/routerLink.vue
@@ -50,6 +50,10 @@
   })
 
   function onClick(event: MouseEvent): void {
+    if (isExternal.value) {
+      return
+    }
+
     event.preventDefault()
 
     router.push(href.value, options.value)


### PR DESCRIPTION
Solution was to update click handler on underlying `a` tag, avoid pushing to router if route is external.

This solution is incomplete. A better solution will be moving this responsibility deeper into router. That would also prevent this bug if a developer calls `router.push('https://router.kitbag.dev')`. Currently the router-link compares the host of the resolved url against `window.location.host`. We probably shouldn't move that similar logic into the router since we can't guarantee the user isn't in a Node environment. 

I will continue working towards a more complete solution. I'm considering, and welcome feedback on the following ideas:  
- adding `host` as an option when calling `createRouter` 
- pulling host off the `initialUrl`
- checking what history mode, possibly using `window` else throwing error