### PR TITLE
fix bug where duplicate keys aren't caught

### DIFF
--- a/src/services/combinePath.ts
+++ b/src/services/combinePath.ts
@@ -1,4 +1,3 @@
-import { DuplicateParamsError } from '@/errors'
 import { MergeParams } from '@/types/params'
 import { Path, PathParams, ToPath } from '@/types/path'
 import { checkDuplicateKeys } from '@/utilities/checkDuplicateKeys'
@@ -16,10 +15,7 @@ export type CombinePath<
 
 export function combinePath<TParentPath extends Path, TChildPath extends Path>(parentPath: TParentPath, childPath: TChildPath): CombinePath<TParentPath, TChildPath>
 export function combinePath(parentPath: Path, childPath: Path): Path {
-  const { hasDuplicates, key } = checkDuplicateKeys(parentPath.params, childPath.params)
-  if (hasDuplicates) {
-    throw new DuplicateParamsError(key)
-  }
+  checkDuplicateKeys(parentPath.params, childPath.params)
 
   const newPathString = `${parentPath.path}${childPath.path}`
 

--- a/src/services/combineQuery.ts
+++ b/src/services/combineQuery.ts
@@ -1,4 +1,3 @@
-import { DuplicateParamsError } from '@/errors'
 import { MergeParams } from '@/types/params'
 import { Query, QueryParams, ToQuery } from '@/types/query'
 import { checkDuplicateKeys } from '@/utilities/checkDuplicateKeys'
@@ -23,10 +22,7 @@ export type CombineQuery<
 
 export function combineQuery<TParentQuery extends Query, TChildQuery extends Query>(parentQuery: TParentQuery, childQuery: TChildQuery): CombineQuery<TParentQuery, TChildQuery>
 export function combineQuery(parentQuery: Query, childQuery: Query): Query {
-  const { hasDuplicates, key } = checkDuplicateKeys(parentQuery.params, childQuery.params)
-  if (hasDuplicates) {
-    throw new DuplicateParamsError(key)
-  }
+  checkDuplicateKeys(parentQuery.params, childQuery.params)
 
   const newQueryString = [parentQuery.query, childQuery.query]
     .filter(stringHasValue)

--- a/src/services/createRoutes.ts
+++ b/src/services/createRoutes.ts
@@ -1,6 +1,5 @@
 import { markRaw } from 'vue'
 import RouterView from '@/components/routerView.vue'
-import { DuplicateParamsError } from '@/errors'
 import { combineName } from '@/services/combineName'
 import { combinePath } from '@/services/combinePath'
 import { combineQuery } from '@/services/combineQuery'
@@ -64,10 +63,7 @@ function createRoute(route: RouteProps): Route {
 
 export function throwIfDuplicateParamsAreFound(routes: Route[]): void {
   routes.forEach(({ path, query }) => {
-    const { hasDuplicates, key } = checkDuplicateKeys(path.params, query.params)
-    if (hasDuplicates) {
-      throw new DuplicateParamsError(key)
-    }
+    checkDuplicateKeys(path.params, query.params)
   })
 }
 

--- a/src/services/getParamsForString.ts
+++ b/src/services/getParamsForString.ts
@@ -1,8 +1,8 @@
-import { DuplicateParamsError } from '@/errors'
 import { getParam } from '@/services/params'
 import { getParamName } from '@/services/routeRegex'
 import { paramEnd, paramStart } from '@/types/params'
 import { Param } from '@/types/paramTypes'
+import { checkDuplicateKeys } from '@/utilities/checkDuplicateKeys'
 
 export function getParamsForString<TInput extends string, TParams extends Record<string, Param | undefined>>(string: TInput, params: TParams): Record<string, Param> {
   const paramPattern = new RegExp(`\\${paramStart}(\\??[\\w-_]+)\\${paramEnd}`, 'g')
@@ -17,9 +17,7 @@ export function getParamsForString<TInput extends string, TParams extends Record
 
     const param = getParam(params, paramName)
 
-    if (paramName in value) {
-      throw new DuplicateParamsError(key)
-    }
+    checkDuplicateKeys([paramName], value)
 
     value[key] = param
 

--- a/src/services/path.spec.ts
+++ b/src/services/path.spec.ts
@@ -26,7 +26,7 @@ test('given path with optional params, returns each param name as type String', 
   }))
 })
 
-test('given path not as string, returns each param with corresponding param', () => {
+test('given path with param types, returns each param with corresponding param', () => {
   const response = path('/parent/[parentId]/child/[childId]', {
     parentId: Boolean,
   })

--- a/src/services/query.spec.ts
+++ b/src/services/query.spec.ts
@@ -26,7 +26,7 @@ test('given query with optional params, returns each param name as type String',
   }))
 })
 
-test('given query not as string, returns each param with corresponding param', () => {
+test('given query with param types, returns each param with corresponding param', () => {
   const response = query('parent=[parentId]&child=[childId]', {
     parentId: Boolean,
   })

--- a/src/utilities/checkDuplicateKeys.ts
+++ b/src/utilities/checkDuplicateKeys.ts
@@ -1,18 +1,12 @@
-export function checkDuplicateKeys(aParams: Record<string, unknown>, bParams: Record<string, unknown>): { key: string, hasDuplicates: true } | { key: undefined, hasDuplicates: false } {
-  const aParamKeys = Object.keys(aParams).map(removeLeadingQuestionMark)
-  const bParamKeys = Object.keys(bParams).map(removeLeadingQuestionMark)
+import { DuplicateParamsError } from '@/errors/duplicateParamsError'
+
+export function checkDuplicateKeys(aParams: Record<string, unknown> | string[], bParams: Record<string, unknown> | string[]): void {
+  const aParamKeys = Array.isArray(aParams) ? aParams : Object.keys(aParams).map(removeLeadingQuestionMark)
+  const bParamKeys = Array.isArray(bParams) ? bParams : Object.keys(bParams).map(removeLeadingQuestionMark)
   const duplicateKey = aParamKeys.find(key => bParamKeys.includes(key))
 
   if (duplicateKey) {
-    return {
-      key: duplicateKey,
-      hasDuplicates: true,
-    }
-  }
-
-  return {
-    key: undefined,
-    hasDuplicates: false,
+    throw new DuplicateParamsError(duplicateKey)
   }
 }
 


### PR DESCRIPTION
Before this PR, the logic for checking duplicate keys always relied on `checkDuplicateKeys` utility except in src/services/getParamsForString.ts, where it would just look for the param value to be inside the object we're building for "paramsForString". 

The issue with this is the "paramName" is assumed to be without leading "?", but the keys of the "paramsForString" might include a leading "?" so it will appear to not be a duplicate.

The solution to this issue is to use `checkDuplicateKeys` like we do everywhere else, but offer an overload to make it easier to use here.

(optionally) I decided to also move the responsibility of throwing `DuplicateParamsError` inside the utility. This means not having to import and use the error in all the places we check, but also removes a weird return type for the utility where it returns both a `boolean` for "is there a duplicate" and also a `key` for "what one was the duplciate" which was supposed to be passed into the error constructor.