### PR TITLE
bug with `isRoute` param types

### DIFF
--- a/src/guards/routes.spec-d.ts
+++ b/src/guards/routes.spec-d.ts
@@ -54,15 +54,15 @@ test('router route can be narrowed', () => {
 
   if (isRoute(route, 'parentA', { exact: false })) {
     expectTypeOf<typeof route.params>().toMatchTypeOf<{
-      foo: string,
-      bar: boolean,
+      foo?: string | undefined,
+      bar?: boolean | undefined,
     }>()
   }
 
   if (isRoute(route, 'parentA')) {
     expectTypeOf<typeof route.params>().toMatchTypeOf<{
-      foo: string,
-      bar: boolean,
+      foo?: string | undefined,
+      bar?: boolean | undefined,
     }>()
   }
 })

--- a/src/guards/routes.spec-d.ts
+++ b/src/guards/routes.spec-d.ts
@@ -1,6 +1,6 @@
 import { expectTypeOf, test } from 'vitest'
 import { isRoute } from '@/guards/routes'
-import { createRouter, createRoutes } from '@/services'
+import { createRouter, createRoutes, query } from '@/services'
 import { component } from '@/utilities/testHelpers'
 
 test('router route can be narrowed', () => {
@@ -10,9 +10,10 @@ test('router route can be narrowed', () => {
       path: '/parentA',
       children: createRoutes([
         {
-          component,
           name: 'childA',
-          path: '/childA/[childA]',
+          path: '[?foo]',
+          query: query('bar=[?bar]', { bar: Boolean }),
+          component,
         },
       ]),
     },
@@ -52,14 +53,16 @@ test('router route can be narrowed', () => {
   }
 
   if (isRoute(route, 'parentA', { exact: false })) {
-    expectTypeOf<typeof route.params>().toMatchTypeOf<{} | {
-      childA: string,
+    expectTypeOf<typeof route.params>().toMatchTypeOf<{
+      foo: string,
+      bar: boolean,
     }>()
   }
 
   if (isRoute(route, 'parentA')) {
-    expectTypeOf<typeof route.params>().toMatchTypeOf<{} |{
-      childA: string,
+    expectTypeOf<typeof route.params>().toMatchTypeOf<{
+      foo: string,
+      bar: boolean,
     }>()
   }
 })

--- a/src/services/combinePath.ts
+++ b/src/services/combinePath.ts
@@ -1,5 +1,5 @@
-import { MergeParams } from '@/types/params'
-import { Path, PathParams, ToPath } from '@/types/path'
+import { MergeParams, RemoveLeadingQuestionMarkFromKeys } from '@/types/params'
+import { Path, PathParamsWithParamNameExtracted, ToPath } from '@/types/path'
 import { checkDuplicateKeys } from '@/utilities/checkDuplicateKeys'
 
 export type CombinePath<
@@ -7,8 +7,8 @@ export type CombinePath<
   TChild extends Path
 > = ToPath<TParent> extends { path: infer TParentPath extends string, params: infer TParentParams extends Record<string, unknown> }
   ? ToPath<TChild> extends { path: infer TChildPath extends string, params: infer TChildParams extends Record<string, unknown> }
-    ? MergeParams<TParentParams, TChildParams> extends PathParams<`${TParentPath}${TChildPath}`>
-      ? Path<`${TParentPath}${TChildPath}`, MergeParams<TParentParams, TChildParams>>
+    ? MergeParams<RemoveLeadingQuestionMarkFromKeys<TParentParams>, RemoveLeadingQuestionMarkFromKeys<TChildParams>> extends PathParamsWithParamNameExtracted<`${TParentPath}${TChildPath}`>
+      ? Path<`${TParentPath}${TChildPath}`, MergeParams<RemoveLeadingQuestionMarkFromKeys<TParentParams>, RemoveLeadingQuestionMarkFromKeys<TChildParams>>>
       : Path<'', {}>
     : Path<'', {}>
   : Path<'', {}>

--- a/src/services/combineQuery.ts
+++ b/src/services/combineQuery.ts
@@ -1,5 +1,5 @@
-import { MergeParams } from '@/types/params'
-import { Query, QueryParams, ToQuery } from '@/types/query'
+import { MergeParams, RemoveLeadingQuestionMarkFromKeys } from '@/types/params'
+import { Query, QueryParamsWithParamNameExtracted, ToQuery } from '@/types/query'
 import { checkDuplicateKeys } from '@/utilities/checkDuplicateKeys'
 import { StringHasValue, stringHasValue } from '@/utilities/string'
 
@@ -14,8 +14,8 @@ export type CombineQuery<
   TChild extends Query | undefined
 > = ToQuery<TParent> extends { query: infer TParentQuery extends string, params: infer TParentParams extends Record<string, unknown> }
   ? ToQuery<TChild> extends { query: infer TChildQuery extends string, params: infer TChildParams extends Record<string, unknown> }
-    ? MergeParams<TParentParams, TChildParams> extends QueryParams<CombineQueryString<TParentQuery, TChildQuery>>
-      ? Query<CombineQueryString<TParentQuery, TChildQuery>, MergeParams<TParentParams, TChildParams>>
+    ? MergeParams<RemoveLeadingQuestionMarkFromKeys<TParentParams>, RemoveLeadingQuestionMarkFromKeys<TChildParams>> extends QueryParamsWithParamNameExtracted<CombineQueryString<TParentQuery, TChildQuery>>
+      ? Query<CombineQueryString<TParentQuery, TChildQuery>, MergeParams<RemoveLeadingQuestionMarkFromKeys<TParentParams>, RemoveLeadingQuestionMarkFromKeys<TChildParams>>>
       : Query<'', {}>
     : Query<'', {}>
   : Query<'', {}>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 export * from './hooks'
-export * from './params'
+export type { ParamStart, ParamEnd, ExtractParamName, ExtractPathParamType, ExtractRouteParamTypes, ExtractParamTypes, ExtractParamType, MergeParams } from './params'
+export { paramStart, paramEnd, isParamGetter, isParamGetSet } from './params'
 export * from './paramTypes'
 export * from './register'
 export * from './route'

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -131,3 +131,8 @@ export type MergeParams<
         ? TBeta[K]
         : never
 }
+
+type RemoveLeadingQuestionMark<T extends PropertyKey> = T extends `?${infer TRest extends string}` ? TRest : T
+export type RemoveLeadingQuestionMarkFromKeys<T extends Record<string, unknown>> = {
+  [K in keyof T as RemoveLeadingQuestionMark<K>]: T[K]
+}


### PR DESCRIPTION
Seems that all params are coming in as `string`, updated test to test param types other than just string.

This issue was previously discovered at runtime when calling `path` (or `query`) and passing in an existing `path` (or `query`). The issue is that the user facing type for params argument is without leading "?", but the internal return type will use leading "?" to denote optional params. 

So a route defined as 

```ts
path('[?foo]', ...)
```

will expect a 2nd argument with key `foo` (no question mark) 

```ts
path('[?foo]', { foo: Number })
```

even though the return type for params will be

```ts
{ '?foo': Number }
```

When passing those params in for a subsequent creation of `path` will look for `foo` in params and not find it because of the leading question mark present. This was already accounted for at runtime, however the types did not which caused this error.

The solution is to update `combinePath` and `combineQuery` to utilize a new TS utility `RemoveLeadingQuestionMarkFromKeys` which normalizes keys before sending back through `Path` (or `Query`). 

This is not the first bugfix for question marks in param keys, it might be nice to explore alternatives for capturing which params should be optional that doesn't require modifying keys in this way to sometimes want leading question marks and sometimes not.