### PR TITLE
added host utility, similar to path and query

### DIFF
--- a/src/services/createExternalRoutes.spec.ts
+++ b/src/services/createExternalRoutes.spec.ts
@@ -10,7 +10,7 @@ test('when given external route props with a host return a route with a host', (
     },
   ])
 
-  expect(route.host).toBe('https://kitbag.dev')
+  expect(route.host.toString()).toBe('https://kitbag.dev')
 })
 
 test('when given external route props with a host and children return host for each route', () => {
@@ -27,6 +27,6 @@ test('when given external route props with a host and children return host for e
     },
   ])
 
-  expect(routeA.host).toBe('https://kitbag.dev')
-  expect(routeB.host).toBe('https://kitbag.dev')
+  expect(routeA.host.toString()).toBe('https://kitbag.dev')
+  expect(routeB.host.toString()).toBe('https://kitbag.dev')
 })

--- a/src/services/createExternalRoutes.ts
+++ b/src/services/createExternalRoutes.ts
@@ -5,6 +5,7 @@ import { combineQuery } from '@/services/combineQuery'
 import { throwIfDuplicateParamsAreFound } from '@/services/createRoutes'
 import { ExternalRouteProps } from '@/types/externalRouteProps'
 import { FlattenRoutes } from '@/types/flattenRoutes'
+import { toHost } from '@/types/host'
 import { toPath } from '@/types/path'
 import { toQuery } from '@/types/query'
 import { Route } from '@/types/route'
@@ -22,7 +23,7 @@ export function createExternalRoutes(routesProps: ExternalRouteProps[]): Route[]
         query: combineQuery(route.query, childRoute.query),
         matches: [route.matched, ...childRoute.matches],
         depth: childRoute.depth + 1,
-        host: routeProps.host ?? '',
+        host: route.host,
       })))
     }
 
@@ -44,16 +45,17 @@ export function createExternalRoutes(routesProps: ExternalRouteProps[]): Route[]
 function createExternalRoute(route: ExternalRouteProps): Route {
   const path = toPath(route.path)
   const query = toQuery(route.query)
+  const host = toHost(route.host ?? '')
   const rawRoute = markRaw({ meta: {}, ...route, name: route.name ?? '', children: [] })
 
   return {
     matched: rawRoute,
     matches: [],
     key: route.name ?? '',
+    host,
     path,
     query,
     depth: 1,
     disabled: route.disabled ?? false,
-    host: route.host ?? '',
   }
 }

--- a/src/services/createRouterResolve.spec.ts
+++ b/src/services/createRouterResolve.spec.ts
@@ -10,13 +10,13 @@ test('given a url returns that string', () => {
   expect(resolve('/bar')).toBe('/bar')
 })
 
-test('given a route key with params returns the url', () => {
+test('given a route key with params, interpolates param values', () => {
   const resolve = createRouterResolve(routes)
 
   expect(resolve('parentA', { paramA: 'bar' })).toBe('/parentA/bar')
 })
 
-test('given a route key and a query appends query to the url', () => {
+test('given a route key with query, interpolates param values', () => {
 
   const resolve = createRouterResolve(routes)
   const url = resolve('parentA', { paramA: 'bar' }, { query: { foo: 'foo' } })
@@ -68,7 +68,23 @@ test('when given an external route returns a fully qualified url', () => {
 
   const resolve = createRouterResolve(routes)
 
-  const url = resolve('external', { 'test-param': 'foo' })
+  const url = resolve('external')
 
   expect(url).toBe('https://kitbag.dev/')
+})
+
+test('when given an external route with params in host, interpolates param values', () => {
+  const routes = createExternalRoutes([
+    {
+      host: 'https://[subdomain].kitbag.dev',
+      name: 'external',
+      path: '/',
+    },
+  ])
+
+  const resolve = createRouterResolve(routes)
+
+  const url = resolve('external', { 'subdomain': 'router' })
+
+  expect(url).toBe('https://router.kitbag.dev/')
 })

--- a/src/services/createRoutes.ts
+++ b/src/services/createRoutes.ts
@@ -3,6 +3,7 @@ import RouterView from '@/components/routerView.vue'
 import { combineName } from '@/services/combineName'
 import { combinePath } from '@/services/combinePath'
 import { combineQuery } from '@/services/combineQuery'
+import { host } from '@/services/host'
 import { FlattenRoutes } from '@/types/flattenRoutes'
 import { toPath } from '@/types/path'
 import { toQuery } from '@/types/query'
@@ -57,7 +58,7 @@ function createRoute(route: RouteProps): Route {
     query,
     depth: 1,
     disabled: route.disabled ?? false,
-    host: '',
+    host: host('', {}),
   }
 }
 

--- a/src/services/createRoutes.ts
+++ b/src/services/createRoutes.ts
@@ -63,8 +63,8 @@ function createRoute(route: RouteProps): Route {
 }
 
 export function throwIfDuplicateParamsAreFound(routes: Route[]): void {
-  routes.forEach(({ path, query }) => {
-    checkDuplicateKeys(path.params, query.params)
+  routes.forEach(({ path, query, host }) => {
+    checkDuplicateKeys(path.params, query.params, host.params)
   })
 }
 

--- a/src/services/host.spec.ts
+++ b/src/services/host.spec.ts
@@ -1,0 +1,41 @@
+import { expect, test } from 'vitest'
+import { DuplicateParamsError } from '@/errors'
+import { host } from '@/services/host'
+
+test('given host without params, returns empty object', () => {
+  const response = host('https://kitbag.dev', {})
+
+  expect(response.params).toMatchObject({})
+})
+
+test('given host with simple params, returns each param name as type String', () => {
+  const response = host('https://[subdomain]kitbag.dev', {})
+
+  expect(response.params).toMatchObject({
+    subdomain: String,
+  })
+})
+
+test('given host with optional params, returns each param name as type String', () => {
+  const response = host('https://[?subdomain]kitbag.dev', {})
+
+  expect(JSON.stringify(response.params)).toMatch(JSON.stringify({
+    subdomain: String,
+  }))
+})
+
+test('given host with param types, returns each param with corresponding param', () => {
+  const response = host('https://[subdomain]kitbag.dev', {
+    subdomain: Boolean,
+  })
+
+  expect(response.params).toMatchObject({
+    subdomain: Boolean,
+  })
+})
+
+test('given host with the same param name, throws DuplicateParamsError', () => {
+  const action: () => void = () => host('https://[?subdomain]kitbag.[subdomain]', { })
+
+  expect(action).toThrowError(DuplicateParamsError)
+})

--- a/src/services/host.spec.ts
+++ b/src/services/host.spec.ts
@@ -3,13 +3,13 @@ import { DuplicateParamsError } from '@/errors'
 import { host } from '@/services/host'
 
 test('given host without params, returns empty object', () => {
-  const response = host('https://kitbag.dev', {})
+  const response = host('kitbag.dev', {})
 
   expect(response.params).toMatchObject({})
 })
 
 test('given host with simple params, returns each param name as type String', () => {
-  const response = host('https://[subdomain]kitbag.dev', {})
+  const response = host('[subdomain]kitbag.dev', {})
 
   expect(response.params).toMatchObject({
     subdomain: String,
@@ -17,7 +17,7 @@ test('given host with simple params, returns each param name as type String', ()
 })
 
 test('given host with optional params, returns each param name as type String', () => {
-  const response = host('https://[?subdomain]kitbag.dev', {})
+  const response = host('[?subdomain]kitbag.dev', {})
 
   expect(JSON.stringify(response.params)).toMatch(JSON.stringify({
     subdomain: String,
@@ -25,7 +25,7 @@ test('given host with optional params, returns each param name as type String', 
 })
 
 test('given host with param types, returns each param with corresponding param', () => {
-  const response = host('https://[subdomain]kitbag.dev', {
+  const response = host('[subdomain]kitbag.dev', {
     subdomain: Boolean,
   })
 
@@ -35,7 +35,7 @@ test('given host with param types, returns each param with corresponding param',
 })
 
 test('given host with the same param name, throws DuplicateParamsError', () => {
-  const action: () => void = () => host('https://[?subdomain]kitbag.[subdomain]', { })
+  const action: () => void = () => host('[?subdomain]kitbag.[subdomain]', { })
 
   expect(action).toThrowError(DuplicateParamsError)
 })

--- a/src/services/host.ts
+++ b/src/services/host.ts
@@ -4,7 +4,7 @@ import { Param } from '@/types/paramTypes'
 import { Identity } from '@/types/utilities'
 
 /**
- * Constructs a Host object, which enables assigning types for params.
+ * Constructs a Host object, which enables assigning types for params. Note, the host should not include protocol.
  *
  * @template THost - The string literal type that represents the host.
  * @template TParams - The type of the host parameters associated with the host.
@@ -20,7 +20,7 @@ import { Identity } from '@/types/utilities'
  * export const routes = createRoutes([
  *   {
  *     name: 'docs',
- *     host: host('https://[subdomain]', { foo: String }),
+ *     host: host('[subdomain]', { foo: String }),
  *     component: Docs
  *   },
  * ])

--- a/src/services/host.ts
+++ b/src/services/host.ts
@@ -1,0 +1,36 @@
+import { getParamsForString } from '@/services/getParamsForString'
+import { Host, HostParamsWithParamNameExtracted } from '@/types/host'
+import { Param } from '@/types/paramTypes'
+import { Identity } from '@/types/utilities'
+
+/**
+ * Constructs a Host object, which enables assigning types for params.
+ *
+ * @template THost - The string literal type that represents the host.
+ * @template TParams - The type of the host parameters associated with the host.
+ * @param host - The host string.
+ * @param params - The parameters associated with the host, typically as key-value pairs.
+ * @returns An object representing the host which includes the host string, its parameters,
+ *          and a toString method for getting the host as a string.
+ *
+ * @example
+ * ```ts
+ * import { createRoutes, host } from '@kitbag/router'
+ *
+ * export const routes = createRoutes([
+ *   {
+ *     name: 'docs',
+ *     host: host('https://[subdomain]', { foo: String }),
+ *     component: Docs
+ *   },
+ * ])
+ * ```
+ */
+export function host<THost extends string, TParams extends HostParamsWithParamNameExtracted<THost>>(host: THost, params: Identity<TParams>): Host<THost, TParams>
+export function host(host: string, params: Record<string, Param | undefined>): Host {
+  return {
+    host,
+    params: getParamsForString(host, params),
+    toString: () => host,
+  }
+}

--- a/src/services/paramValidation.spec.ts
+++ b/src/services/paramValidation.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from 'vitest'
 import { DuplicateParamsError } from '@/errors'
+import { createExternalRoutes } from '@/services/createExternalRoutes'
 import { createRoutes } from '@/services/createRoutes'
 import { getRouteParamValues, routeParamsAreValid } from '@/services/paramValidation'
 import { path } from '@/services/path'
@@ -163,12 +164,16 @@ test.each([
   expect(response).toBe(true)
 })
 
-test('given route with duplicate param names across path and query, throws DuplicateParamsError', () => {
-  const action: () => void = () => createRoutes([
+test.each([
+  { path: '/duplicate/[foo]', query: 'params=[?foo]' },
+  { path: '/duplicate/[foo]', host: 'https://[foo].kitbag.dev' },
+  { path: '/', host: 'https://[?foo].kitbag.dev', query: 'params=[?foo]' },
+  { path: '/duplicate/[foo]', host: 'https://[foo].kitbag.dev', query: 'params=[foo]' },
+])('given route with duplicate param names across path and query, throws DuplicateParamsError', (route) => {
+  const action: () => void = () => createExternalRoutes([
     {
       name: 'different-cased-params',
-      path: '/duplicate/[foo]',
-      query: 'params=[?foo]',
+      ...route,
       component,
     },
   ])

--- a/src/services/urlAssembly.spec.ts
+++ b/src/services/urlAssembly.spec.ts
@@ -299,8 +299,8 @@ describe('static query', () => {
 
 describe('host params', () => {
   test.each([
-    ['https://kitbag.dev'],
-    [host('https://kitbag.dev', {})],
+    ['kitbag.dev'],
+    [host('kitbag.dev', {})],
   ])('given simple route with string host and without params, returns route host', (host) => {
     const [route] = createExternalRoutes([
       {
@@ -313,13 +313,13 @@ describe('host params', () => {
 
     const url = assembleUrl(route)
 
-    expect(url).toBe('https://kitbag.dev/')
+    expect(url).toBe('kitbag.dev/')
   })
 
   test.each([
-    ['https://[?subdomain]kitbag.dev'],
-    [host('https://[?subdomain]kitbag.dev', { subdomain: String })],
-    [host('https://[?subdomain]kitbag.dev', { subdomain: withDefault(String, 'abc') })],
+    ['[?subdomain]kitbag.dev'],
+    [host('[?subdomain]kitbag.dev', { subdomain: String })],
+    [host('[?subdomain]kitbag.dev', { subdomain: withDefault(String, 'abc') })],
   ])('given route with optional param NOT provided, leaves entire key off', (host) => {
     const [route] = createExternalRoutes([
       {
@@ -332,12 +332,12 @@ describe('host params', () => {
 
     const url = assembleUrl(route)
 
-    expect(url).toBe('https://kitbag.dev/')
+    expect(url).toBe('kitbag.dev/')
   })
 
   test.each([
-    ['https://[?subdomain]kitbag.dev'],
-    [host('https://[?subdomain]kitbag.dev', { subdomain: String })],
+    ['[?subdomain]kitbag.dev'],
+    [host('[?subdomain]kitbag.dev', { subdomain: String })],
   ])('given route with optional string param provided, returns route Host with string with values interpolated', (host) => {
     const [route] = createExternalRoutes([
       {
@@ -352,7 +352,7 @@ describe('host params', () => {
       params: { subdomain: 'ABC.' },
     })
 
-    expect(url).toBe('https://ABC.kitbag.dev/')
+    expect(url).toBe('ABC.kitbag.dev/')
   })
 
 
@@ -361,7 +361,7 @@ describe('host params', () => {
       {
         name: 'simple',
         path: '/',
-        host: host('https://[?subdomain]kitbag.dev', { subdomain: withDefault(String, 'abc.') }),
+        host: host('[?subdomain]kitbag.dev', { subdomain: withDefault(String, 'abc.') }),
         component,
       },
     ])
@@ -370,12 +370,12 @@ describe('host params', () => {
       params: { subdomain: 'DEF.' },
     })
 
-    expect(url).toBe('https://DEF.kitbag.dev/')
+    expect(url).toBe('DEF.kitbag.dev/')
   })
 
   test.each([
-    ['https://[subdomain]kitbag.dev'],
-    [host('https://[subdomain]kitbag.dev', { subdomain: String })],
+    ['[subdomain]kitbag.dev'],
+    [host('[subdomain]kitbag.dev', { subdomain: String })],
   ])('given route with required string param NOT provided, throws error', (host) => {
     const [route] = createExternalRoutes([
       {
@@ -390,8 +390,8 @@ describe('host params', () => {
   })
 
   test.each([
-    ['https://[subdomain]kitbag.dev'],
-    [host('https://[subdomain]kitbag.dev', { subdomain: String })],
+    ['[subdomain]kitbag.dev'],
+    [host('[subdomain]kitbag.dev', { subdomain: String })],
   ])('given route with required string param provided, returns route Host with string with values interpolated', (host) => {
     const [route] = createExternalRoutes([
       {
@@ -406,6 +406,6 @@ describe('host params', () => {
       params: { subdomain: 'ABC.' },
     })
 
-    expect(url).toBe('https://ABC.kitbag.dev/')
+    expect(url).toBe('ABC.kitbag.dev/')
   })
 })

--- a/src/services/urlAssembly.ts
+++ b/src/services/urlAssembly.ts
@@ -25,10 +25,6 @@ export function assembleUrl(route: Route, options: AssembleUrlOptions = {}): str
 function assembleHostParamValues(host: Host, paramValues: Record<string, unknown>): string {
   const value = host.toString()
 
-  if (!value.length) {
-    return value
-  }
-
   return Object.entries(host.params).reduce((url, [name, param]) => {
     const paramName = getParamName(`${paramStart}${name}${paramEnd}`)
 
@@ -42,10 +38,6 @@ function assembleHostParamValues(host: Host, paramValues: Record<string, unknown
 
 function assemblePathParamValues(path: Path, paramValues: Record<string, unknown>): string {
   const value = path.toString()
-
-  if (!value.length) {
-    return value
-  }
 
   return Object.entries(path.params).reduce((url, [name, param]) => {
     const paramName = getParamName(`${paramStart}${name}${paramEnd}`)

--- a/src/services/urlAssembly.ts
+++ b/src/services/urlAssembly.ts
@@ -3,6 +3,7 @@ import { setParamValueOnUrl } from '@/services/paramsFinder'
 import { getParamName, isOptionalParamSyntax } from '@/services/routeRegex'
 import { QueryRecord, withQuery } from '@/services/withQuery'
 import { Route, paramEnd, paramStart } from '@/types'
+import { Host } from '@/types/host'
 import { Path } from '@/types/path'
 import { Query } from '@/types/query'
 
@@ -14,16 +15,29 @@ type AssembleUrlOptions = {
 export function assembleUrl(route: Route, options: AssembleUrlOptions = {}): string {
   const { params: paramValues = {}, query: queryValues } = options
 
+  const hostWithParamsSet = assembleHostParamValues(route.host, paramValues)
   const pathWithParamsSet = assemblePathParamValues(route.path, paramValues)
   const queryWithParamsSet = assembleQueryParamValues(route.query, paramValues)
 
-  const relativeUrl = withQuery(pathWithParamsSet, queryWithParamsSet, queryValues)
+  return withQuery(`${hostWithParamsSet}${pathWithParamsSet}`, queryWithParamsSet, queryValues)
+}
 
-  if (route.host) {
-    return `${route.host}${relativeUrl}`
+function assembleHostParamValues(host: Host, paramValues: Record<string, unknown>): string {
+  const value = host.toString()
+
+  if (!value.length) {
+    return value
   }
 
-  return relativeUrl
+  return Object.entries(host.params).reduce((url, [name, param]) => {
+    const paramName = getParamName(`${paramStart}${name}${paramEnd}`)
+
+    if (!paramName) {
+      return url
+    }
+
+    return setParamValueOnUrl(url, { name, param, value: paramValues[paramName] })
+  }, value)
 }
 
 function assemblePathParamValues(path: Path, paramValues: Record<string, unknown>): string {

--- a/src/types/externalRouteProps.ts
+++ b/src/types/externalRouteProps.ts
@@ -1,9 +1,10 @@
+import { Host } from '@/types/host'
 import { Path } from '@/types/path'
 import { Query } from '@/types/query'
 import { Route } from '@/types/route'
 
 // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
-export type ExternalRoutes = Route<string, '', Path, Query, boolean>[]
+export type ExternalRoutes = Route<string, Host, Path, Query, boolean>[]
 
 export type ExternalRouteParentProps = {
   /**
@@ -36,7 +37,7 @@ export type ExternalRouteChildProps = {
   /**
    * Represents the host for this route. Used for external routes.
   */
-  host?: string,
+  host?: string | Host,
   /**
    * Name for route, used to create route keys and in navigation.
    */

--- a/src/types/externalRouteProps.ts
+++ b/src/types/externalRouteProps.ts
@@ -3,14 +3,13 @@ import { Path } from '@/types/path'
 import { Query } from '@/types/query'
 import { Route } from '@/types/route'
 
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-arguments
-export type ExternalRoutes = Route<string, Host, Path, Query, boolean>[]
+type ExternalChildRoutes = Route<string, never>[]
 
 export type ExternalRouteParentProps = {
   /**
    * Represents the host for this route. Used for external routes.
   */
-  host?: string,
+  host?: string | Host,
   /**
    * Name for route, used to create route keys and in navigation.
    */
@@ -30,7 +29,7 @@ export type ExternalRouteParentProps = {
   /**
    * Children routes, expected type comes from `createExternalRoutes()`
    */
-  children: ExternalRoutes,
+  children: ExternalChildRoutes,
 }
 
 export type ExternalRouteChildProps = {

--- a/src/types/flattenRoutes.ts
+++ b/src/types/flattenRoutes.ts
@@ -2,6 +2,7 @@ import { CombineName } from '@/services/combineName'
 import { CombinePath } from '@/services/combinePath'
 import { CombineQuery } from '@/services/combineQuery'
 import { ExternalRouteProps } from '@/types/externalRouteProps'
+import { Host, ToHost } from '@/types/host'
 import { Path, ToPath } from '@/types/path'
 import { Query, ToQuery } from '@/types/query'
 import { Route } from '@/types/route'
@@ -14,7 +15,7 @@ export type FlattenRoutes<TRoutes extends Readonly<RouteProps[] | ExternalRouteP
 type FlattenRoute<
   TRoute extends RouteProps | ExternalRouteProps,
   TKey extends string = TRoute extends { name: infer T extends string } ? T : '',
-  THost extends string = TRoute extends { host: infer T extends string } ? T : '',
+  THost extends Host = TRoute extends { host: infer T extends Host | string } ? ToHost<T> : Host,
   TPath extends Path = ToPath<TRoute['path']>,
   TQuery extends Query = ToQuery<TRoute['query']>,
   TDisabled extends boolean = TRoute['disabled'] extends boolean ? TRoute['disabled'] : false,

--- a/src/types/flattenRoutes.ts
+++ b/src/types/flattenRoutes.ts
@@ -15,7 +15,7 @@ export type FlattenRoutes<TRoutes extends Readonly<RouteProps[] | ExternalRouteP
 type FlattenRoute<
   TRoute extends RouteProps | ExternalRouteProps,
   TKey extends string = TRoute extends { name: infer T extends string } ? T : '',
-  THost extends Host = TRoute extends { host: infer T extends Host | string } ? ToHost<T> : Host,
+  THost extends Host = TRoute extends { host: infer T extends Host | string } ? ToHost<T> : never,
   TPath extends Path = ToPath<TRoute['path']>,
   TQuery extends Query = ToQuery<TRoute['query']>,
   TDisabled extends boolean = TRoute['disabled'] extends boolean ? TRoute['disabled'] : false,

--- a/src/types/host.ts
+++ b/src/types/host.ts
@@ -1,0 +1,44 @@
+import { host } from '@/services/host'
+import { ExtractParamName, ExtractPathParamType, MergeParams, ParamEnd, ParamStart } from '@/types/params'
+import { Param } from '@/types/paramTypes'
+import { Identity } from '@/types/utilities'
+import { isRecord } from '@/utilities/guards'
+
+type ExtractParamsFromHostString<
+  THost extends string,
+  TParams extends Record<string, Param | undefined> = Record<never, never>
+> = THost extends `${string}${ParamStart}${infer Param}${ParamEnd}${infer Rest}`
+  ? MergeParams<{ [P in Param]: ExtractPathParamType<Param, TParams> }, ExtractParamsFromHostString<Rest, TParams>>
+  : Record<never, never>
+
+export type HostParams<THost extends string> = {
+  [K in keyof ExtractParamsFromHostString<THost>]?: Param
+}
+
+export type HostParamsWithParamNameExtracted<THost extends string> = {
+  [K in keyof ExtractParamsFromHostString<THost> as ExtractParamName<K>]?: Param
+}
+
+export type Host<
+  THost extends string = string,
+  TParams extends HostParamsWithParamNameExtracted<THost> = Record<string, Param | undefined>
+> = {
+  host: THost,
+  params: string extends THost ? Record<string, Param> : Identity<ExtractParamsFromHostString<THost, TParams>>,
+  toString: () => string,
+}
+
+export type ToHost<T extends string | Host> = T extends string ? Host<T, {}> : T
+
+function isHost(value: unknown): value is Host {
+  return isRecord(value) && typeof value.host === 'string'
+}
+
+export function toHost<T extends string | Host>(value: T): ToHost<T>
+export function toHost<T extends string | Host>(value: T): Host {
+  if (isHost(value)) {
+    return value
+  }
+
+  return host(value, {})
+}

--- a/src/types/register.ts
+++ b/src/types/register.ts
@@ -39,7 +39,7 @@ export type RegisteredRouterRoute = RegisteredRouter['route']
  */
 export type RegisteredRoutes = Register extends { router: Router<infer TRoutes extends Routes> }
   ? TRoutes
-  : Route<string, Host, Path<'', {}>, Query<'', {}>, false>[]
+  : Route<string, Host, Path, Query, false>[]
 
 /**
  * Represents the possible Rejections registered within {@link Register}

--- a/src/types/register.ts
+++ b/src/types/register.ts
@@ -1,3 +1,4 @@
+import { Host } from '@/types/host'
 import { Path } from '@/types/path'
 import { Query } from '@/types/query'
 import { Route, Routes } from '@/types/route'
@@ -38,7 +39,7 @@ export type RegisteredRouterRoute = RegisteredRouter['route']
  */
 export type RegisteredRoutes = Register extends { router: Router<infer TRoutes extends Routes> }
   ? TRoutes
-  : Route<string, '', Path<'', {}>, Query<'', {}>, false>[]
+  : Route<string, Host, Path<'', {}>, Query<'', {}>, false>[]
 
 /**
  * Represents the possible Rejections registered within {@link Register}

--- a/src/types/resolved.spec-d.ts
+++ b/src/types/resolved.spec-d.ts
@@ -1,12 +1,13 @@
 import { expectTypeOf, test } from 'vitest'
 import { RouterRoute } from '@/services/createRouterRoute'
+import { Host } from '@/types/host'
 import { Path } from '@/types/path'
 import { Query } from '@/types/query'
 import { ResolvedRoute } from '@/types/resolved'
 import { Route } from '@/types/route'
 
 test('given a specific Route, params are narrow', () => {
-    type TestRoute = Route<'parentA', '', Path<'/[paramA]', {}>, Query<'foo=[paramB]&bar=[?paramC]', { paramB: BooleanConstructor }>>
+    type TestRoute = Route<'parentA', Host, Path<'/[paramA]', {}>, Query<'foo=[paramB]&bar=[?paramC]', { paramB: BooleanConstructor }>>
 
     type Source = RouterRoute<ResolvedRoute<TestRoute>>['params']
     type Expect = { paramA: string, paramB: boolean, paramC?: string | undefined }

--- a/src/types/route.spec-d.ts
+++ b/src/types/route.spec-d.ts
@@ -1,4 +1,5 @@
 import { describe, expectTypeOf, test } from 'vitest'
+import { Host } from '@/types/host'
 import { ExtractRouteParamTypes } from '@/types/params'
 import { Path } from '@/types/path'
 import { Query } from '@/types/query'
@@ -6,7 +7,7 @@ import { Route } from '@/types/route'
 
 describe('ExtractRouteParamTypes', () => {
   test('given routes with different params, some optional, combines into expected args for developer', () => {
-    type TestRoute = Route<'parentA', '', Path<'/[paramA]', {}>, Query<'foo=[paramB]&bar=[?paramC]', { paramB: BooleanConstructor }>>
+    type TestRoute = Route<'parentA', Host, Path<'/[paramA]', {}>, Query<'foo=[paramB]&bar=[?paramC]', { paramB: BooleanConstructor }>>
 
     type Source = ExtractRouteParamTypes<TestRoute>
     type Expect = { paramA: string, paramB: boolean, paramC?: string }

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -1,3 +1,4 @@
+import { Host } from '@/types/host'
 import { Path } from '@/types/path'
 import { Query } from '@/types/query'
 import { RouteMeta, RouteProps } from '@/types/routeProps'
@@ -21,7 +22,7 @@ export type RoutePropsWithMeta = RouteProps & { meta: RouteMeta }
  */
 export type Route<
   TKey extends string = string,
-  THost extends string = string,
+  THost extends Host = Host,
   TPath extends Path = Path,
   TQuery extends Query = Query,
   TDisabled extends boolean = boolean

--- a/src/types/routeWithParams.spec-d.ts
+++ b/src/types/routeWithParams.spec-d.ts
@@ -1,4 +1,5 @@
 import { expectTypeOf, test } from 'vitest'
+import { Host } from '@/types/host'
 import { Path } from '@/types/path'
 import { Query } from '@/types/query'
 import { Route } from '@/types/route'
@@ -14,7 +15,7 @@ test('CombineName returns correct keys for routes', () => {
 
 test('RouteGetByName works as expected', () => {
   type Source = RouteGetByKey<typeof routes, 'parentA'>
-  type Expect = Route<'parentA', '', Path<'/parentA/[paramA]', {}>, Query<'', {}>, false>
+  type Expect = Route<'parentA', Host, Path<'/parentA/[paramA]', {}>, Query<'', {}>, false>
 
   expectTypeOf<Source>().toEqualTypeOf<Expect>()
 })

--- a/src/types/routeWithParams.spec-d.ts
+++ b/src/types/routeWithParams.spec-d.ts
@@ -1,5 +1,4 @@
 import { expectTypeOf, test } from 'vitest'
-import { Host } from '@/types/host'
 import { Path } from '@/types/path'
 import { Query } from '@/types/query'
 import { Route } from '@/types/route'
@@ -15,7 +14,7 @@ test('CombineName returns correct keys for routes', () => {
 
 test('RouteGetByName works as expected', () => {
   type Source = RouteGetByKey<typeof routes, 'parentA'>
-  type Expect = Route<'parentA', Host, Path<'/parentA/[paramA]', {}>, Query<'', {}>, false>
+  type Expect = Route<'parentA', never, Path<'/parentA/[paramA]', {}>, Query<'', {}>, false>
 
   expectTypeOf<Source>().toEqualTypeOf<Expect>()
 })

--- a/src/types/routeWithParams.ts
+++ b/src/types/routeWithParams.ts
@@ -13,10 +13,11 @@ export type RouteParamsByKey<
 > = ExtractRouteParamTypesWithoutLosingOptional<RouteGetByKey<TRoutes, TKey>>
 
 type ExtractRouteParamTypesWithoutLosingOptional<TRoute> = TRoute extends {
+  host: { params: infer HostParams extends Record<string, Param> },
   path: { params: infer PathParams extends Record<string, Param> },
   query: { params: infer QueryParams extends Record<string, Param> },
 }
-  ? ExtractParamTypesWithoutLosingOptional<MergeParams<PathParams, QueryParams>>
+  ? ExtractParamTypesWithoutLosingOptional<MergeParams<HostParams, MergeParams<PathParams, QueryParams>>>
   : Record<string, unknown>
 
 type ExtractParamTypesWithoutLosingOptional<TParams extends Record<string, Param>> = Identity<MakeOptional<{

--- a/src/types/routesMap.spec-ts.ts
+++ b/src/types/routesMap.spec-ts.ts
@@ -1,5 +1,6 @@
 import { expectTypeOf, test } from 'vitest'
 import { createRoutes } from '@/services'
+import { Host } from '@/types/host'
 import { Path } from '@/types/path'
 import { Query } from '@/types/query'
 import { Route } from '@/types/route'
@@ -7,7 +8,7 @@ import { RoutesMap } from '@/types/routesMap'
 import { component } from '@/utilities/testHelpers'
 
 test('RoutesMap given generic routes, returns generic string', () => {
-  type Map = RoutesMap<Route<string, '', Path<'', {}>, Query<'', {}>, false>[]>
+  type Map = RoutesMap<Route<string, Host, Path<'', {}>, Query<'', {}>, false>[]>
 
   type Source = Map[keyof Map]['key']
   type Expect = string

--- a/src/utilities/checkDuplicateKeys.spec.ts
+++ b/src/utilities/checkDuplicateKeys.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from 'vitest'
+import { DuplicateParamsError } from '@/errors'
+import { checkDuplicateKeys } from '@/utilities/checkDuplicateKeys'
+
+test('given a single array without duplicates, does nothing', () => {
+  const input = ['foo', 'bar', 'zoo']
+
+  const action: () => void = () => checkDuplicateKeys(input)
+
+  expect(action).not.toThrow()
+})
+
+test.each([
+  [['foo', 'bar', 'zoo', 'bar']],
+  [['foo', 'bar', 'zoo'], ['jar', 'zoo']],
+  [['foo', 'bar', 'zoo'], ['jar'], ['zoo']],
+])('given a multiple arrays with duplicates, throws DuplicateParamsError', (...arrays) => {
+  const action: () => void = () => checkDuplicateKeys(...arrays)
+
+  expect(action).toThrow(DuplicateParamsError)
+})
+
+test.each([
+  [['foo', 'bar', 'zoo']],
+  [['foo', 'bar', 'zoo'], ['jar']],
+  [['foo', 'bar'], ['jar'], ['zoo']],
+])('given a multiple arrays without duplicates, does nothing', () => {
+  const aArray = ['foo', 'bar', 'zoo']
+  const bArray = ['jar']
+
+  const action: () => void = () => checkDuplicateKeys(aArray, bArray)
+
+  expect(action).not.toThrow()
+})
+
+test.each([
+  [{ foo: 'foo', var: 'bar', zoo: 'zoo' }, { jar: 'jar', zoo: 'zoo' }],
+  [{ foo: 'foo', var: 'bar', zoo: 'zoo' }, { jar: 'jar' }, { zoo: 'zoo' }],
+])('given multiple records with duplicates keys, throws DuplicateParamsError', (...records) => {
+  const action: () => void = () => checkDuplicateKeys(...records)
+
+  expect(action).toThrow(DuplicateParamsError)
+})
+
+test.each([
+  [{ foo: 'foo', var: 'bar', zoo: 'zoo' }, { jar: 'jar' }],
+  [{ foo: 'foo', var: 'bar' }, { jar: 'jar' }, { zoo: 'zoo' }],
+])('given multiple records without duplicates keys, does nothing', () => {
+  const aRecord = { foo: 'foo', var: 'bar' }
+  const bRecord = { jar: 'jar', zoo: 'zoo' }
+
+  const action: () => void = () => checkDuplicateKeys(aRecord, bRecord)
+
+  expect(action).not.toThrow()
+})

--- a/src/utilities/checkDuplicateKeys.ts
+++ b/src/utilities/checkDuplicateKeys.ts
@@ -1,13 +1,17 @@
 import { DuplicateParamsError } from '@/errors/duplicateParamsError'
 
-export function checkDuplicateKeys(aParams: Record<string, unknown> | string[], bParams: Record<string, unknown> | string[]): void {
-  const aParamKeys = Array.isArray(aParams) ? aParams : Object.keys(aParams).map(removeLeadingQuestionMark)
-  const bParamKeys = Array.isArray(bParams) ? bParams : Object.keys(bParams).map(removeLeadingQuestionMark)
-  const duplicateKey = aParamKeys.find(key => bParamKeys.includes(key))
+export function checkDuplicateKeys(...withParams: (Record<string, unknown> | string[])[]): void {
+  const paramKeys = withParams.flatMap(params => Array.isArray(params) ? params : Object.keys(params).map(removeLeadingQuestionMark))
 
-  if (duplicateKey) {
-    throw new DuplicateParamsError(duplicateKey)
+  for (const key of paramKeys) {
+    if (getCount(paramKeys, key) > 1) {
+      throw new DuplicateParamsError(key)
+    }
   }
+}
+
+function getCount<T>(array: T[], item: T): number {
+  return array.filter(itemAtIndex => item === itemAtIndex).length
 }
 
 function removeLeadingQuestionMark(value: string): string {


### PR DESCRIPTION
This PR enables the same interpolation pattern with param support the the `host` part of a URL that we already support for `path` and `query`. 

Usage is exactly what you'd expect, you can define params as a plain string or with a new `host` utility.

```ts
const routes = createExternalRoutes([
  name: 'foo',
  host: 'https://[subdomain].kitbag.dev',
  path: '/'
])
```

```ts
const routes = createExternalRoutes([
  name: 'foo',
  host: host('https://[subdomain].kitbag.dev', {subdomain: availableSubdomainsParam}),
  path: '/'
])
```

as with other params
- they can be optional
- they support all the same type for params
- they can be passed when calling `router.resolve`, `router-link`, `router.push`, etc.