### PR TITLE
should host params be included here?

### DIFF
--- a/src/services/paramValidation.ts
+++ b/src/services/paramValidation.ts
@@ -1,9 +1,10 @@
 import { createMaybeRelativeUrl } from '@/services/createMaybeRelativeUrl'
 import { getParamValue } from '@/services/params'
 import { getParamValueFromUrl } from '@/services/paramsFinder'
-import { Route } from '@/types'
+import { Host } from '@/types/host'
 import { Path } from '@/types/path'
 import { Query } from '@/types/query'
+import { Route } from '@/types/route'
 import { RouteMatchRule } from '@/types/routeMatchRule'
 
 export const routeParamsAreValid: RouteMatchRule = (route, url) => {
@@ -17,15 +18,24 @@ export const routeParamsAreValid: RouteMatchRule = (route, url) => {
 }
 
 export const getRouteParamValues = (route: Route, url: string): Record<string, unknown> => {
-  const { pathname, search } = createMaybeRelativeUrl(url)
+  const { host, pathname, search } = createMaybeRelativeUrl(url)
 
   return {
+    ...getHostParams(route.host, host),
     ...getPathParams(route.path, pathname),
     ...getQueryParams(route.query, search),
   }
 }
 
-function getPathParams(path: Path, url: string): Record<string, unknown> {
+function getHostParams(host: Host, url: string | undefined): Record<string, unknown> {
+  if (!url) {
+    return {}
+  }
+
+  return getPathParams(host, url)
+}
+
+function getPathParams(path: Path | Host, url: string): Record<string, unknown> {
   const params: Record<string, unknown> = {}
   const decodedValueFromUrl = decodeURIComponent(url)
 


### PR DESCRIPTION
I made this change because it felt obvious, but then after thinking about it some more I'm not sure. 

This utility is only used by `getResolvedRouteForUrl`. The `getResolvedRouteForUrl` utility is used in router for 2 things, to get the `to` for hooks and inside `router.find`. Both of which currently have escapes for situations where it's given an external route. 

I feel like it SHOULD be added, but maybe those places that use `getResolvedRouteForUrl` shouldn't just escape? If a user calls `router.find(https://my.example.com/clearly/external)`, maybe it SHOULD return the matched external route? Same for the `to` on hooks, it would be handy for executing before leave hooks to know you're about to go to your fancy external route?