### PR TITLE
make path optional

### DIFF
--- a/src/services/createExternalRoutes.spec.ts
+++ b/src/services/createExternalRoutes.spec.ts
@@ -19,7 +19,7 @@ test('when given external route props with a host and children return host for e
       children: createExternalRoutes([
         {
           name: 'foo',
-          path: 'child',
+          path: '/foo',
         },
       ]),
     },

--- a/src/services/createExternalRoutes.spec.ts
+++ b/src/services/createExternalRoutes.spec.ts
@@ -6,7 +6,6 @@ test('when given external route props with a host return a route with a host', (
     {
       host: 'https://kitbag.dev',
       name: 'kitbag',
-      path: '/',
     },
   ])
 
@@ -17,7 +16,6 @@ test('when given external route props with a host and children return host for e
   const [routeA, routeB] = createExternalRoutes([
     {
       host: 'https://kitbag.dev',
-      path: '/',
       children: createExternalRoutes([
         {
           name: 'foo',

--- a/src/services/createRoutes.spec.ts
+++ b/src/services/createRoutes.spec.ts
@@ -83,3 +83,14 @@ test('given route without meta, sets meta equal to empty object', () => {
 
   expect(route.matched.meta).toEqual({})
 })
+
+test('given route without path, sets path equal to empty string', () => {
+  const [route] = createRoutes([
+    {
+      name: 'without-path',
+      component,
+    },
+  ])
+
+  expect(route.path.toString()).toEqual('')
+})

--- a/src/types/externalRouteProps.ts
+++ b/src/types/externalRouteProps.ts
@@ -21,7 +21,7 @@ export type ExternalRouteParentProps = {
   /**
    * Path part of URL.
    */
-  path: string | Path,
+  path?: string | Path,
   /**
    * Query (aka search) part of URL.
    */
@@ -48,7 +48,7 @@ export type ExternalRouteChildProps = {
   /**
    * Path part of URL.
    */
-  path: string | Path,
+  path?: string | Path,
   /**
    * Query (aka search) part of URL.
    */

--- a/src/types/path.ts
+++ b/src/types/path.ts
@@ -27,14 +27,25 @@ export type Path<
   params: string extends TPath ? Record<string, Param> : Identity<ExtractParamsFromPathString<TPath, TParams>>,
   toString: () => string,
 }
-export type ToPath<T extends string | Path> = T extends string ? Path<T, {}> : T
+export type ToPath<T extends string | Path | undefined> =T extends string
+  ? Path<T, {}>
+  : T extends undefined
+    ? Path<'', {}>
+    : unknown extends T
+      ? Path<'', {}>
+      : T
+
 
 function isPath(value: unknown): value is Path {
   return isRecord(value) && typeof value.path === 'string'
 }
 
-export function toPath<T extends string | Path>(value: T): ToPath<T>
-export function toPath<T extends string | Path>(value: T): Path {
+export function toPath<T extends string | Path | undefined>(value: T): ToPath<T>
+export function toPath<T extends string | Path | undefined>(value: T): Path {
+  if (value === undefined) {
+    return path('', {})
+  }
+
   if (isPath(value)) {
     return value
   }

--- a/src/types/routeProps.ts
+++ b/src/types/routeProps.ts
@@ -55,7 +55,7 @@ export type ParentRouteProps = Partial<WithComponent | WithComponents> & WithHoo
   /**
    * Path part of URL.
    */
-  path: string | Path,
+  path?: string | Path,
   /**
    * Query (aka search) part of URL.
    */
@@ -89,7 +89,7 @@ export type ChildRouteProps = (WithComponent | WithComponents) & WithHooks & {
   /**
    * Path part of URL.
    */
-  path: string | Path,
+  path?: string | Path,
   /**
    * Query (aka search) part of URL.
    */


### PR DESCRIPTION
Not sure why it took this long but I think `path` should have always been optional. This felt especially true when defining parent routes, or external routes

```ts
createExternalRoutes([
  {
    host: 'https://kitbag.dev',
    path: '',
    children: createExternalRoutes([
      {
        name: 'foo',
        path: 'child',
      },
    ]),
  },
])
```

After this PR, path behaves like query. It's never required and when omitted is assumed to be an empty string.

```ts
createExternalRoutes([
  {
    host: 'https://kitbag.dev',
    children: createExternalRoutes([
      {
        name: 'foo',
        path: 'child',
      },
    ]),
  },
])
```