### PR TITLE
updated docs for optional path, external routes, and host

### DIFF
--- a/docs/api/functions/createExternalRoutes.md
+++ b/docs/api/functions/createExternalRoutes.md
@@ -1,0 +1,26 @@
+# createExternalRoutes
+
+```ts
+function createExternalRoutes<TRoutes>(routes): FlattenRoutes<TRoutes>
+```
+
+Creates an array of routes from a defined set of external route properties, handling hierarchical route combinations.
+This function also validates for duplicate parameter keys across the combined routes.
+
+## Type parameters
+
+| Type parameter |
+| :------ |
+| `TRoutes` *extends* readonly [`ExternalRouteProps`](/api/types/ExternalRouteProps)[] |
+
+## Parameters
+
+| Parameter | Type |
+| :------ | :------ |
+| `routes` | `TRoutes` |
+
+## Returns
+
+`FlattenRoutes`\<`TRoutes`\>
+
+An array of fully configured Route instances.

--- a/docs/api/functions/host.md
+++ b/docs/api/functions/host.md
@@ -1,0 +1,44 @@
+# host
+
+```ts
+function host<THost, TParams>(host, params): Host<THost, TParams>
+```
+
+Constructs a Host object, which enables assigning types for params.
+
+## Type parameters
+
+| Type parameter | Description |
+| :------ | :------ |
+| `THost` *extends* `string` | The string literal type that represents the host. |
+| `TParams` *extends* `HostParams`\<`THost`\> | The type of the host parameters associated with the host. |
+
+## Parameters
+
+| Parameter | Type | Description |
+| :------ | :------ | :------ |
+| `host` | `THost` | The host string. |
+| `params` | `Identity`\<`TParams`\> | The parameters associated with the host, typically as key-value pairs. |
+
+## Returns
+
+`Host`\<`THost`, `TParams`\>
+
+An object representing the host which includes the host string, its parameters, and a toString method for getting the host as a string.
+
+## Example
+
+```ts
+import { createExternalRoutes, host } from '@kitbag/router'
+
+export const routes = createExternalRoutes([
+  {
+    name: 'home',
+    host: host('https://[subdomain].kitbag.dev', { subdomain: Number })
+  },
+])
+```
+
+## Custom Params
+
+Param types is customizable with [`ParamGetter`](/api/types/ParamGetter), [`ParamSetter`](/api/types/ParamSetter), and [`ParamGetSet`](/api/types/ParamGetSet). Read more about [custom params](/core-concepts/route-params#custom-param).

--- a/docs/api/functions/path.md
+++ b/docs/api/functions/path.md
@@ -24,8 +24,7 @@ Constructs a Path object, which enables assigning types for params.
 
 `Path`\<`TPath`, `TParams`\>
 
-An object representing the path which includes the path string, its parameters,
-         and a toString method for getting the path as a string.
+An object representing the path which includes the path string, its parameters, and a toString method for getting the path as a string.
 
 ## Example
 

--- a/docs/api/functions/query.md
+++ b/docs/api/functions/query.md
@@ -24,8 +24,7 @@ Constructs a Query object, which enables assigning types for params.
 
 `Query`\<`TQuery`, `TParams`\>
 
-An object representing the query which includes the query string, its parameters,
-         and a toString method for getting the query as a string.
+An object representing the query which includes the query string, its parameters, and a toString method for getting the query as a string.
 
 ## Example
 

--- a/docs/api/types/ExternalRouteProps.md
+++ b/docs/api/types/ExternalRouteProps.md
@@ -1,0 +1,59 @@
+# ExternalRouteProps
+
+Unifies the properties of both parent and child routes, ensuring type safety and consistency across route configurations.
+
+## ExternalRouteParentProps
+
+Represents properties common to parent routes in a route configuration, including hooks, path, and optional query parameters.
+
+### name
+
+Name for route, used to create route keys and in navigation. Read more about [route naming](/core-concepts/defining-routes#route-names).
+
+```ts
+name: string | undefined;
+```
+
+### host
+
+Host part of URL. If value is provided as `string`, assumes any params will be `string`. See [Host](/api/functions/host).
+
+```ts
+host?: : string | Host | undefined;
+```
+
+### path
+
+Path part of URL. If value is provided as `string`, assumes any params will be `string`. See [Path](/api/functions/path).
+
+```ts
+path?: : string | Path | undefined;
+```
+
+### query
+
+Query (aka search) part of URL. If value is provided as `string`, assumes any params will be `string`. See [Query](/api/functions/query).
+
+```ts
+query: string | Query | undefined;
+```
+
+### disabled
+
+Disabled routes will not ever match but can still provide physical structure, nested children behave normally.
+
+```ts
+disabled: boolean | undefined;
+```
+
+### children
+
+Children routes, expected type comes from [createExternalRoutes()](/api/functions/createExternalRoutes). Read more about [nesting routes](/core-concepts/defining-routes#nested-routes).
+
+```ts
+children: ExternalChildRoutes;
+```
+
+## ExternalRouteChildProps
+
+Represents properties for child routes, has same properties as ExternalRouteParentProps except `name` is no longer optional.

--- a/docs/api/types/RouteProps.md
+++ b/docs/api/types/RouteProps.md
@@ -19,7 +19,7 @@ name: string | undefined;
 Path part of URL. If value is provided as `string`, assumes any params will be `string`. See [Path](/api/functions/path).
 
 ```ts
-path: : string | Path;
+path?: : string | Path | undefined;
 ```
 
 ### query

--- a/docs/core-concepts/defining-routes.md
+++ b/docs/core-concepts/defining-routes.md
@@ -93,3 +93,75 @@ router.push('routes.user.profile') // ok
 ## Case Sensitivity
 
 By default route paths are NOT case sensitive. If you need part of your route to be case sensitive, we recommend using a [Regex Param](/core-concepts/route-params#regexp-params).
+
+## External Routes
+
+Kitbag Router supports defining routes that are "external" to your single-page app (SPA). With `createExternalRoutes`, you can get all of the benefits of defined routes for routing that takes the user to another website, like perhaps your docs.
+
+```ts
+import { createExternalRoutes } from '@kitbag/router'
+
+export const documentationRoutes = createExternalRoutes([
+  {
+    host: 'https://router.kitbag.dev/',
+    name: 'docs',
+    children: createExternalRoutes([
+      {
+        name: 'api',
+        path: '/api/[topic]',
+      },
+    ]),
+  },
+])
+```
+
+Now we can include these routes with all of the internal routes your app already uses.
+
+```ts
+import { createRoutes, createRouter } from '@kitbag/router'
+import { documentationRoutes } from './documentationRoutes'
+
+export const routes = createRoutes([
+  {
+    name: 'home',
+    path: '/',
+    component: () => import('@/views/HomeView.vue'),
+  },
+  ...
+])
+
+export const router = createRouter([routes, documentationRoutes])
+```
+
+Now your router has all the context it needs to not only handle routing between your internal views, but also for sending users to your external docs site.
+
+```ts
+import { useRouter } from '@kitbag/router'
+
+const router = useRouter()
+
+function goToTopic(topic: string): void {
+  router.push('docs.api', { topic })
+}
+```
+
+### Host
+
+External routes support route params inside of the `host`, just like `path` and `query`.
+
+```ts
+import { createExternalRoutes } from '@kitbag/router'
+
+export const documentationRoutes = createExternalRoutes([
+  {
+    host: 'https://[subdomain].kitbag.dev/',
+    name: 'docs',
+    children: createExternalRoutes([
+      {
+        name: 'api',
+        path: '/api/[topic]',
+      },
+    ]),
+  },
+])
+```

--- a/docs/core-concepts/defining-routes.md
+++ b/docs/core-concepts/defining-routes.md
@@ -103,7 +103,7 @@ import { createExternalRoutes } from '@kitbag/router'
 
 export const documentationRoutes = createExternalRoutes([
   {
-    host: 'https://router.kitbag.dev/',
+    host: 'https://router.kitbag.dev',
     name: 'docs',
     children: createExternalRoutes([
       {

--- a/docs/core-concepts/defining-routes.md
+++ b/docs/core-concepts/defining-routes.md
@@ -154,7 +154,7 @@ import { createExternalRoutes } from '@kitbag/router'
 
 export const documentationRoutes = createExternalRoutes([
   {
-    host: 'https://[subdomain].kitbag.dev/',
+    host: 'https://[subdomain].kitbag.dev',
     name: 'docs',
     children: createExternalRoutes([
       {


### PR DESCRIPTION
With recent patch releases the docs has fallen slightly behind. This PR updates the topics for recent work.
- path is now optional on `routeProps` and `externalRouteProps`
- there was no documentation for external routes
- with external routes also comes new `host` utility