### PR TITLE
remove disabled concept

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ router.push('/user/settings')
 router.push('https://github.com/kitbagjs/router')
 ```
 
-This `source` argument is type safe, expecting either a Url or a valid route "key". Url is any string that starts with "http", "https", or a forward slash "/". Route key is a string of route names joined by a period `.` that lead to a non-disabled route. Additionally if using the route key, push will require params be passed in if there are any.
+This `source` argument is type safe, expecting either a Url or a valid route "key". Url is any string that starts with "http", "https", or a forward slash "/". Route key is a string of route names joined by a period `.`. Additionally if using the route key, push will require params be passed in if there are any.
 
 ## Update
 

--- a/docs/api/types/ParamGetSet.md
+++ b/docs/api/types/ParamGetSet.md
@@ -1,4 +1,4 @@
-# ParamGetSet\<T\>
+# ParamGetSet
 
 ```ts
 type ParamGetSet<T>: object;

--- a/docs/api/types/Route.md
+++ b/docs/api/types/Route.md
@@ -1,7 +1,7 @@
-# Route\<TKey, TPath, TQuery, TDisabled\>
+# Route
 
 ```ts
-type Route<TKey, TPath, TQuery, TDisabled>: object;
+type Route<TKey, TPath, TQuery>: object;
 ```
 
 Represents the structure of a route within the application. Return value of `createRoute`
@@ -13,7 +13,6 @@ Represents the structure of a route within the application. Return value of `cre
 | `TKey` *extends* `string` \| `undefined` | `string` | Represents the unique key identifying the route, typically a string. |
 | `TPath` *extends* `string` \| `Path` | `Path` | The type or structure of the route's path. |
 | `TQuery` *extends* `string` \| `Query` \| `undefined` | `Query` | The type or structure of the query parameters associated with the route. |
-| `TDisabled` *extends* `boolean` \| `undefined` | `boolean` | Indicates whether the route is disabled, which could affect routing logic. |
 
 ## Type declaration
 
@@ -22,14 +21,6 @@ Represents the structure of a route within the application. Return value of `cre
 ```ts
 depth: number;
 ```
-
-### disabled
-
-```ts
-disabled: TDisabled extends boolean ? TDisabled : false;
-```
-
-Indicates if the route is disabled.
 
 ### key
 

--- a/docs/core-concepts/defining-routes.md
+++ b/docs/core-concepts/defining-routes.md
@@ -79,30 +79,6 @@ router.push('user.settings.keys')
 
 Learn more about [navigating](/core-concepts/navigating) to routes.
 
-## Disabled Routes
-
-When an individual route is disabled, it will never count as an exact match. Children of disabled route behave normally and can still be matched. This gives the developer the ability to ensure that partial views are not loaded without having to flatten your routes and lose the context of nested routes.
-
-Let's update the example above
-
-```ts
-const user = createRoute({
-  name: 'user',
-  path: '/user',
-  disabled: true, // [!code focus] 
-  component: ...,
-})
-```
-
-Now developers would get a Typescript error if they try navigating to `routes.user`.
-
-```ts
-const router = createRouter(routes)
-
-router.push('routes.user') // [!code error] error
-router.push('routes.user.profile') // ok
-```
-
 ## Case Sensitivity
 
 By default route paths are NOT case sensitive. If you need part of your route to be case sensitive, we recommend using a [Regex Param](/core-concepts/route-params#regexp-params).

--- a/docs/core-concepts/navigating.md
+++ b/docs/core-concepts/navigating.md
@@ -41,7 +41,7 @@ router.push('/user/settings')
 router.push('https://github.com/kitbagjs/router')
 ```
 
-This `source` argument is type safe, expecting either a [`Url`](/api/types/Url) or a valid route [`Key`](/api/types/Route#key). URL is any string that starts with "http", "https", or a forward slash "/". Route key is a string of route names joined by a period `.` that lead to a non-disabled route. Additionally if using the route key, push will require params be passed in if there are any.
+This `source` argument is type safe, expecting either a [`Url`](/api/types/Url) or a valid route [`Key`](/api/types/Route#key). URL is any string that starts with "http", "https", or a forward slash "/". Route key is a string of route names joined by a period `.`. Additionally if using the route key, push will require params be passed in if there are any.
 
 ### Providing Params
 

--- a/src/errors/routeDisabledError.ts
+++ b/src/errors/routeDisabledError.ts
@@ -1,8 +1,0 @@
-/**
- * An error thrown when attempting to resolve a route that is disabled
- */
-export class RouteDisabledError extends Error {
-  public constructor(source: string) {
-    super(`Route disabled: "${source}"`)
-  }
-}

--- a/src/services/createExternalRoute.ts
+++ b/src/services/createExternalRoute.ts
@@ -39,7 +39,6 @@ export function createExternalRoute(options: CreateRouteOptions | CreateRouteOpt
     path,
     query,
     depth: 1,
-    disabled: options.disabled ?? false,
   }
 
   const merged = isRouteWithParent(options) ? combineRoutes(options.parent, route) : route

--- a/src/services/createRoute.ts
+++ b/src/services/createRoute.ts
@@ -39,7 +39,6 @@ export function createRoute(options: CreateRouteOptions | CreateRouteOptionsWith
     path,
     query,
     depth: 1,
-    disabled: options.disabled ?? false,
     host: host('', {}),
   }
 

--- a/src/services/createRouterResolve.ts
+++ b/src/services/createRouterResolve.ts
@@ -1,4 +1,3 @@
-import { RouteDisabledError } from '@/errors/routeDisabledError'
 import { RouteNotFoundError } from '@/errors/routeNotFoundError'
 import { assembleUrl } from '@/services/urlAssembly'
 import { withQuery } from '@/services/withQuery'
@@ -47,10 +46,6 @@ export function createRouterResolve<const TRoutes extends Routes>(routes: TRoute
 
     if (!match) {
       throw new RouteNotFoundError(String(source))
-    }
-
-    if (match.matched.disabled) {
-      throw new RouteDisabledError(String(source))
     }
 
     const url = assembleUrl(match, {

--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -91,8 +91,6 @@ export type CreateRouteOptions<
    * Represents additional metadata associated with a route, customizable via declaration merging.
    */
   meta?: RouteMeta,
-  // will be removed in follow-up PR
-  disabled?: boolean,
 }
 
 export type CreateRouteOptionsWithoutParent<

--- a/src/types/register.ts
+++ b/src/types/register.ts
@@ -1,6 +1,3 @@
-import { Host } from '@/types/host'
-import { Path } from '@/types/path'
-import { Query } from '@/types/query'
 import { Route, Routes } from '@/types/route'
 import { Router } from '@/types/router'
 import { RouterPush } from '@/types/routerPush'
@@ -39,7 +36,7 @@ export type RegisteredRouterRoute = RegisteredRouter['route']
  */
 export type RegisteredRoutes = Register extends { router: Router<infer TRoutes extends Routes> }
   ? TRoutes
-  : Route<string, Host, Path, Query, false>[]
+  : Route[]
 
 /**
  * Represents the possible Rejections registered within {@link Register}

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -19,14 +19,12 @@ export type CreateRouteOptionsWithMeta = CreateRouteOptions & { meta: RouteMeta 
  * @template TKey - Represents the unique key identifying the route, typically a string.
  * @template TPath - The type or structure of the route's path.
  * @template TQuery - The type or structure of the query parameters associated with the route.
- * @template TDisabled - Indicates whether the route is disabled, which could affect routing logic.
  */
 export type Route<
   TKey extends string = string,
   THost extends Host = Host,
   TPath extends Path = Path,
-  TQuery extends Query = Query,
-  TDisabled extends boolean = boolean
+  TQuery extends Query = Query
 > = {
   /**
    * The specific route properties that were matched in the current route.
@@ -54,8 +52,4 @@ export type Route<
   */
   query: TQuery,
   depth: number,
-  /**
-   * Indicates if the route is disabled.
-  */
-  disabled: TDisabled,
 }

--- a/src/types/routesMap.spec-ts.ts
+++ b/src/types/routesMap.spec-ts.ts
@@ -8,7 +8,7 @@ import { RoutesMap } from '@/types/routesMap'
 import { component } from '@/utilities/testHelpers'
 
 test('RoutesMap given generic routes, returns generic string', () => {
-  type Map = RoutesMap<Route<string, Host, Path<'', {}>, Query<'', {}>, false>[]>
+  type Map = RoutesMap<Route<string, Host, Path<'', {}>, Query<'', {}>>[]>
 
   type Source = Map[keyof Map]['key']
   type Expect = string

--- a/src/types/routesMap.ts
+++ b/src/types/routesMap.ts
@@ -1,16 +1,11 @@
 import { Route, Routes } from '@/types/route'
 import { StringHasValue } from '@/utilities'
 
-type RouteIsNamedAndNotDisabled<T extends Route> = IsRouteDisabled<T> extends true
-  ? never
-  : IsRouteUnnamed<T> extends true
-    ? never
-    : T
-type IsRouteDisabled<T extends Route> = T extends { disabled: true } ? true : false
 type IsRouteUnnamed<T extends Route> = StringHasValue<T['key']> extends true ? false : true
+type AsNamedRoute<T extends Route> = IsRouteUnnamed<T> extends true ? never : T
 
 export type RoutesMap<TRoutes extends Routes = []> = {
-  [K in TRoutes[number] as RouteIsNamedAndNotDisabled<K>['key']]: RouteIsNamedAndNotDisabled<K>
+  [K in TRoutes[number] as AsNamedRoute<K>['key']]: AsNamedRoute<K>
 }
 
 export type RoutesKey<TRoutes extends Routes> = string & keyof RoutesMap<TRoutes>


### PR DESCRIPTION
with the latest iteration of defining routes we can now define parent routes and choose to not include them when calling `createRouter`. This effectively does the task of what "disabled" did previously but in a more straight forward and hopefully obvious way to our developers.

Currently, kitbag router lets you set a route as "disabled".  A disabled route still effects the children, passing down params, path, query, host, and key but a disabled route can never be matched. So end users cannot create a `router-link` to a disabled route or navigate with `router.push` to a disabled route.

```ts
const routes = createRoutes([
  { name: 'parent', disabled: true, children: createRoutes([
    { name: 'foo', component: ... },
    { name: 'bar', component: ... },
  ])
])

const router = createRouter(routes)
```

With our new syntax `createRoute`, we can still create the parent route and assign as a parent but omit from our routes when calling `createRouter`.

```ts
const parent = createRoute({ name: 'parent' })

const routes = [
  createRoute({ parent, name: 'foo', component: ... }),
  createRoute({ parent, name: 'bar', component: ... },)
] as const

const router = createRouter(routes)
```