### PR TITLE
Refactor types for creating routes and add overloads and generics to `createRoute` for component types

### DIFF
--- a/src/components/routerView.browser.spec.ts
+++ b/src/components/routerView.browser.spec.ts
@@ -4,7 +4,7 @@ import { defineAsyncComponent } from 'vue'
 import helloWorld from '@/components/helloWorld'
 import { createRoute } from '@/services/createRoute'
 import { createRouter } from '@/services/createRouter'
-import { isRouteWithComponent } from '@/types/createRouteOptions'
+import { isWithComponent } from '@/types/createRouteOptions'
 import { routes } from '@/utilities/testHelpers'
 
 test('renders component for initial route', async () => {
@@ -186,7 +186,7 @@ test('Renders custom genericRejection component when the initialUrl does not mat
     },
   })
 
-  if (!isRouteWithComponent(router.route.matched)) {
+  if (!isWithComponent(router.route.matched)) {
     throw 'Matched route does not have a single component'
   }
 

--- a/src/components/routerView.vue
+++ b/src/components/routerView.vue
@@ -11,7 +11,7 @@
   import { useRouterDepth } from '@/compositions/useRouterDepth'
   import { RouterRejection } from '@/services/createRouterReject'
   import { RouterRoute } from '@/services/createRouterRoute'
-  import { CreateRouteOptions, isRouteWithComponent, isRouteWithComponents } from '@/types/createRouteOptions'
+  import { CreateRouteOptions, isWithComponent, isWithComponents } from '@/types/createRouteOptions'
   import { depthInjectionKey } from '@/types/injectionDepth'
 
   const { name = 'default' } = defineProps<{
@@ -58,11 +58,11 @@
   })
 
   function getComponents(options: CreateRouteOptions): Record<string, Component | undefined> {
-    if (isRouteWithComponents(options)) {
+    if (isWithComponents(options)) {
       return options.components
     }
 
-    if (isRouteWithComponent(options)) {
+    if (isWithComponent(options)) {
       return { default: options.component }
     }
 

--- a/src/services/component.ts
+++ b/src/services/component.ts
@@ -4,15 +4,15 @@ import { MaybePromise } from '@/types/utilities'
 
 type Constructor = new (...args: any) => any
 
-export type ComponentProps<TComponent extends Component> = TComponent extends Constructor
+type Props<TComponent extends Component> = TComponent extends Constructor
   ? InstanceType<TComponent>['$props']
   : TComponent extends AsyncComponentLoader<infer T extends Component>
-    ? ComponentProps<T>
+    ? Props<T>
     : TComponent extends FunctionalComponent<infer T>
       ? T
       : never
 
-type ComponentPropsGetter<TComponent extends Component> = () => MaybePromise<ComponentProps<TComponent>>
+type PropsGetter<TComponent extends Component> = () => MaybePromise<Props<TComponent>>
 
 /**
  * Creates a component wrapper which has no props itself but mounts another component within while binding its props
@@ -32,7 +32,7 @@ type ComponentPropsGetter<TComponent extends Component> = () => MaybePromise<Com
  * })
  * ```
  */
-export function component<TComponent extends Component>(component: TComponent, props: ComponentPropsGetter<TComponent>): Component {
+export function component<TComponent extends Component>(component: TComponent, props: PropsGetter<TComponent>): Component {
   return defineComponent({
     name: 'PropsWrapper',
     expose: [],
@@ -48,7 +48,7 @@ export function component<TComponent extends Component>(component: TComponent, p
   })
 }
 
-function asyncPropsWrapper<TComponent extends Component>(component: TComponent, props: Promise<ComponentProps<TComponent>>): Component {
+function asyncPropsWrapper<TComponent extends Component>(component: TComponent, props: Promise<Props<TComponent>>): Component {
   return defineComponent({
     name: 'AsyncPropsWrapper',
     expose: [],

--- a/src/services/component.ts
+++ b/src/services/component.ts
@@ -4,15 +4,15 @@ import { MaybePromise } from '@/types/utilities'
 
 type Constructor = new (...args: any) => any
 
-type Props<TComponent extends Component> = TComponent extends Constructor
+export type ComponentProps<TComponent extends Component> = TComponent extends Constructor
   ? InstanceType<TComponent>['$props']
   : TComponent extends AsyncComponentLoader<infer T extends Component>
-    ? Props<T>
+    ? ComponentProps<T>
     : TComponent extends FunctionalComponent<infer T>
       ? T
       : never
 
-type PropsGetter<TComponent extends Component> = () => MaybePromise<Props<TComponent>>
+type ComponentPropsGetter<TComponent extends Component> = () => MaybePromise<ComponentProps<TComponent>>
 
 /**
  * Creates a component wrapper which has no props itself but mounts another component within while binding its props
@@ -32,7 +32,7 @@ type PropsGetter<TComponent extends Component> = () => MaybePromise<Props<TCompo
  * })
  * ```
  */
-export function component<TComponent extends Component>(component: TComponent, props: PropsGetter<TComponent>): Component {
+export function component<TComponent extends Component>(component: TComponent, props: ComponentPropsGetter<TComponent>): Component {
   return defineComponent({
     name: 'PropsWrapper',
     expose: [],
@@ -48,7 +48,7 @@ export function component<TComponent extends Component>(component: TComponent, p
   })
 }
 
-function asyncPropsWrapper<TComponent extends Component>(component: TComponent, props: Promise<Props<TComponent>>): Component {
+function asyncPropsWrapper<TComponent extends Component>(component: TComponent, props: Promise<ComponentProps<TComponent>>): Component {
   return defineComponent({
     name: 'AsyncPropsWrapper',
     expose: [],

--- a/src/services/createExternalRoute.ts
+++ b/src/services/createExternalRoute.ts
@@ -2,25 +2,13 @@ import { markRaw } from 'vue'
 import { CombineKey } from '@/services/combineKey'
 import { CombinePath } from '@/services/combinePath'
 import { CombineQuery } from '@/services/combineQuery'
-import { combineRoutes, CreateRouteOptions, isWithParent, WithoutParent, WithParent } from '@/types/createRouteOptions'
+import { combineRoutes, CreateRouteOptions, isWithHost, isWithParent, WithHost, WithoutHost, WithoutParent, WithParent } from '@/types/createRouteOptions'
 import { Host, toHost, ToHost } from '@/types/host'
 import { ToKey, toKey } from '@/types/key'
 import { Path, toPath, ToPath } from '@/types/path'
 import { Query, toQuery, ToQuery } from '@/types/query'
 import { Route } from '@/types/route'
 import { checkDuplicateKeys } from '@/utilities/checkDuplicateKeys'
-
-type WithHost<THost extends string | Host> = {
-  host: THost,
-}
-
-function isWithHost(options: CreateRouteOptions): options is CreateRouteOptions & WithHost<string | Host> {
-  return 'host' in options && Boolean(options.host)
-}
-
-type WithoutHost = {
-  host?: never,
-}
 
 export function createExternalRoute<
   const THost extends string | Host,

--- a/src/services/createRoute.ts
+++ b/src/services/createRoute.ts
@@ -4,7 +4,7 @@ import { CombineKey } from '@/services/combineKey'
 import { CombinePath } from '@/services/combinePath'
 import { CombineQuery } from '@/services/combineQuery'
 import { host } from '@/services/host'
-import { CreateRouteOptions, WithComponent, WithComponents, WithParent, WithoutParent, combineRoutes, isWithComponent, isWithComponents, isWithParent } from '@/types/createRouteOptions'
+import { CreateRouteOptions, WithComponent, WithComponents, WithHooks, WithParent, WithoutParent, combineRoutes, isWithComponent, isWithComponents, isWithParent } from '@/types/createRouteOptions'
 import { Host } from '@/types/host'
 import { ToKey, toKey } from '@/types/key'
 import { ExtractParamTypes } from '@/types/params'
@@ -28,14 +28,14 @@ export function createRoute<
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
   TComponent extends Component | undefined = undefined
->(options: CreateRouteOptions<TName, TPath, TQuery> & WithComponent<TComponent, RouteDataParams<TPath, TQuery>> & WithoutParent): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>>
+>(options: CreateRouteOptions<TName, TPath, TQuery> & WithHooks & WithComponent<TComponent, RouteDataParams<TPath, TQuery>> & WithoutParent): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>>
 
 export function createRoute<
   const TName extends string | undefined = undefined,
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
   TComponents extends Record<string, Component> | undefined = undefined
->(options: CreateRouteOptions<TName, TPath, TQuery> & WithComponents<TComponents, RouteDataParams<TPath, TQuery>> & WithoutParent): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>>
+>(options: CreateRouteOptions<TName, TPath, TQuery> & WithHooks & WithComponents<TComponents, RouteDataParams<TPath, TQuery>> & WithoutParent): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>>
 
 export function createRoute<
   const TParent extends Route,
@@ -43,7 +43,7 @@ export function createRoute<
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
   TComponent extends Component | undefined = undefined
->(options: CreateRouteOptions<TName, TPath, TQuery> & WithComponent<TComponent, RouteDataParams<TPath, TQuery, TParent>> & WithParent<TParent>): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>>
+>(options: CreateRouteOptions<TName, TPath, TQuery> & WithHooks & WithComponent<TComponent, RouteDataParams<TPath, TQuery, TParent>> & WithParent<TParent>): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>>
 
 export function createRoute<
   const TParent extends Route,
@@ -51,7 +51,7 @@ export function createRoute<
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
   TComponents extends Record<string, Component> | undefined = undefined
->(options: CreateRouteOptions<TName, TPath, TQuery> & WithComponents<TComponents, RouteDataParams<TPath, TQuery, TParent>> & WithParent<TParent>): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>>
+>(options: CreateRouteOptions<TName, TPath, TQuery> & WithHooks & WithComponents<TComponents, RouteDataParams<TPath, TQuery, TParent>> & WithParent<TParent>): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>>
 
 export function createRoute(options: CreateRouteOptions): Route {
   const routeWithComponent = addRouterViewComponentIfWithoutComponent(options)

--- a/src/services/createRoute.ts
+++ b/src/services/createRoute.ts
@@ -1,31 +1,103 @@
-import { markRaw } from 'vue'
+import { Component, markRaw } from 'vue'
 import { RouterView } from '@/components'
 import { CombineKey } from '@/services/combineKey'
 import { CombinePath } from '@/services/combinePath'
 import { CombineQuery } from '@/services/combineQuery'
+import { ComponentProps } from '@/services/component'
 import { host } from '@/services/host'
-import { combineRoutes, CreateRouteOptions, isRouteWithParent, isRouteWithoutComponent, CreateRouteOptionsWithoutParent, CreateRouteOptionsWithParent } from '@/types/createRouteOptions'
+import { combineRoutes, isRouteWithoutComponent } from '@/types/createRouteOptions'
 import { Host } from '@/types/host'
 import { ToKey, toKey } from '@/types/key'
 import { Path, ToPath, toPath } from '@/types/path'
 import { Query, ToQuery, toQuery } from '@/types/query'
+import { RouteMeta } from '@/types/register'
 import { Route } from '@/types/route'
+import { MaybePromise } from '@/types/utilities'
 import { checkDuplicateKeys } from '@/utilities/checkDuplicateKeys'
+
+type CreateRouteOptions<
+  TName extends string | undefined = undefined,
+  TPath extends string | Path | undefined = undefined,
+  TQuery extends string | Query | undefined = undefined
+> = {
+  name?: TName,
+  path?: TPath,
+  query?: TQuery,
+  meta?: RouteMeta,
+}
+
+type RouteData<
+  TComponent extends Component | undefined,
+  TParams extends Record<string, unknown>
+> = (params: TParams) => MaybePromise<TComponent extends Component ? ComponentProps<TComponent> | void : void>
+
+type RouteDataRecord<
+  TComponents extends Record<string, Component>,
+  TParams extends Record<string, unknown>
+> = {
+  [TKey in keyof TComponents]: RouteData<TComponents[TKey], TParams>
+}
+
+type WithComponent<
+  TComponent extends Component | undefined,
+  TParams extends Record<string, unknown>
+> = {
+  component?: TComponent,
+  data?: RouteData<TComponent, TParams>,
+}
+
+type WithComponents<
+  TComponents extends Record<string, Component> | undefined,
+  TParams extends Record<string, unknown>
+> = {
+  components?: TComponents,
+  data?: TComponents extends Record<string, Component> ? RouteDataRecord<TComponents, TParams> : never,
+}
+
+type WithParent<TParent extends Route> = {
+  parent: TParent,
+}
+
+export function isCreateRouteOptionsWithParent(options: CreateRouteOptions): options is CreateRouteOptions & WithParent<Route> {
+  return 'parent' in options && Boolean(options.parent)
+}
+
+type WithoutParent = {
+  parent?: never,
+}
 
 export function createRoute<
   const TName extends string | undefined = undefined,
   const TPath extends string | Path | undefined = undefined,
-  const TQuery extends string | Query | undefined = undefined
->(options: CreateRouteOptionsWithoutParent<TName, TPath, TQuery>): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>>
+  const TQuery extends string | Query | undefined = undefined,
+  const TComponent extends Component | undefined = undefined
+>(options: CreateRouteOptions<TName, TPath, TQuery> & WithComponent<TComponent, {}> & WithoutParent): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>>
+
+export function createRoute<
+  const TName extends string | undefined = undefined,
+  const TPath extends string | Path | undefined = undefined,
+  const TQuery extends string | Query | undefined = undefined,
+  const TComponents extends Record<string, Component> | undefined = undefined
+>(options: CreateRouteOptions<TName, TPath, TQuery> & WithComponents<TComponents, {}> & WithoutParent): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>>
+
 
 export function createRoute<
   const TParent extends Route,
   const TName extends string | undefined = undefined,
   const TPath extends string | Path | undefined = undefined,
-  const TQuery extends string | Query | undefined = undefined
->(options: CreateRouteOptionsWithParent<TParent, TName, TPath, TQuery>): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>>
+  const TQuery extends string | Query | undefined = undefined,
+  const TComponent extends Component | undefined = undefined
+>(options: CreateRouteOptions<TName, TPath, TQuery> & WithComponent<TComponent, {}> & WithParent<TParent>): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>>
 
-export function createRoute(options: CreateRouteOptions | CreateRouteOptionsWithParent<Route>): Route {
+export function createRoute<
+  const TParent extends Route,
+  const TName extends string | undefined = undefined,
+  const TPath extends string | Path | undefined = undefined,
+  const TQuery extends string | Query | undefined = undefined,
+  const TComponents extends Record<string, Component> | undefined = undefined
+>(options: CreateRouteOptions<TName, TPath, TQuery> & WithComponents<TComponents, {}> & WithParent<TParent>): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>>
+
+export function createRoute(options: CreateRouteOptions): Route {
   const routeWithComponent = addRouterViewComponentIfWithoutComponent(options)
   const key = toKey(options.name)
   const path = toPath(options.path)
@@ -39,18 +111,18 @@ export function createRoute(options: CreateRouteOptions | CreateRouteOptionsWith
     path,
     query,
     depth: 1,
-    disabled: options.disabled ?? false,
+    disabled: false,
     host: host('', {}),
   }
 
-  const merged = isRouteWithParent(options) ? combineRoutes(options.parent, route) : route
+  const merged = isCreateRouteOptionsWithParent(options) ? combineRoutes(options.parent, route) : route
 
   checkDuplicateKeys(merged.path.params, merged.query.params)
 
   return merged
 }
 
-function addRouterViewComponentIfWithoutComponent(options: CreateRouteOptions): CreateRouteOptions {
+function addRouterViewComponentIfWithoutComponent(options: CreateRouteOptions): CreateRouteOptions & { component: Component } {
   if (isRouteWithoutComponent(options)) {
     return { ...options, component: RouterView }
   }

--- a/src/services/createRoute.ts
+++ b/src/services/createRoute.ts
@@ -3,99 +3,55 @@ import { RouterView } from '@/components'
 import { CombineKey } from '@/services/combineKey'
 import { CombinePath } from '@/services/combinePath'
 import { CombineQuery } from '@/services/combineQuery'
-import { ComponentProps } from '@/services/component'
 import { host } from '@/services/host'
-import { combineRoutes, isRouteWithoutComponent } from '@/types/createRouteOptions'
+import { CreateRouteOptions, WithComponent, WithComponents, WithParent, WithoutParent, combineRoutes, isWithComponent, isWithComponents, isWithParent } from '@/types/createRouteOptions'
 import { Host } from '@/types/host'
 import { ToKey, toKey } from '@/types/key'
+import { ExtractParamTypes } from '@/types/params'
 import { Path, ToPath, toPath } from '@/types/path'
 import { Query, ToQuery, toQuery } from '@/types/query'
-import { RouteMeta } from '@/types/register'
 import { Route } from '@/types/route'
-import { MaybePromise } from '@/types/utilities'
+import { Identity } from '@/types/utilities'
 import { checkDuplicateKeys } from '@/utilities/checkDuplicateKeys'
 
-type CreateRouteOptions<
-  TName extends string | undefined = undefined,
-  TPath extends string | Path | undefined = undefined,
-  TQuery extends string | Query | undefined = undefined
-> = {
-  name?: TName,
-  path?: TPath,
-  query?: TQuery,
-  meta?: RouteMeta,
-}
+type ParentPath<TParent extends Route | undefined> = TParent extends Route ? TParent['path'] : Path<'', {}>
+type ParentQuery<TParent extends Route | undefined> = TParent extends Route ? TParent['query'] : Query<'', {}>
 
-type RouteData<
-  TComponent extends Component | undefined,
-  TParams extends Record<string, unknown>
-> = (params: TParams) => MaybePromise<TComponent extends Component ? ComponentProps<TComponent> | void : void>
-
-type RouteDataRecord<
-  TComponents extends Record<string, Component>,
-  TParams extends Record<string, unknown>
-> = {
-  [TKey in keyof TComponents]: RouteData<TComponents[TKey], TParams>
-}
-
-type WithComponent<
-  TComponent extends Component | undefined,
-  TParams extends Record<string, unknown>
-> = {
-  component?: TComponent,
-  data?: RouteData<TComponent, TParams>,
-}
-
-type WithComponents<
-  TComponents extends Record<string, Component> | undefined,
-  TParams extends Record<string, unknown>
-> = {
-  components?: TComponents,
-  data?: TComponents extends Record<string, Component> ? RouteDataRecord<TComponents, TParams> : never,
-}
-
-type WithParent<TParent extends Route> = {
-  parent: TParent,
-}
-
-export function isCreateRouteOptionsWithParent(options: CreateRouteOptions): options is CreateRouteOptions & WithParent<Route> {
-  return 'parent' in options && Boolean(options.parent)
-}
-
-type WithoutParent = {
-  parent?: never,
-}
+type RouteDataParams<
+  TPath extends string | Path | undefined,
+  TQuery extends string | Query | undefined,
+  TParent extends Route | undefined = undefined
+> = ExtractParamTypes<Identity<CombinePath<ParentPath<TParent>, ToPath<TPath>>['params'] & CombineQuery<ParentQuery<TParent>, ToQuery<TQuery>>['params']>>
 
 export function createRoute<
   const TName extends string | undefined = undefined,
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
-  const TComponent extends Component | undefined = undefined
->(options: CreateRouteOptions<TName, TPath, TQuery> & WithComponent<TComponent, {}> & WithoutParent): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>>
+  TComponent extends Component | undefined = undefined
+>(options: CreateRouteOptions<TName, TPath, TQuery> & WithComponent<TComponent, RouteDataParams<TPath, TQuery>> & WithoutParent): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>>
 
 export function createRoute<
   const TName extends string | undefined = undefined,
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
-  const TComponents extends Record<string, Component> | undefined = undefined
->(options: CreateRouteOptions<TName, TPath, TQuery> & WithComponents<TComponents, {}> & WithoutParent): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>>
-
+  TComponents extends Record<string, Component> | undefined = undefined
+>(options: CreateRouteOptions<TName, TPath, TQuery> & WithComponents<TComponents, RouteDataParams<TPath, TQuery>> & WithoutParent): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>>
 
 export function createRoute<
   const TParent extends Route,
   const TName extends string | undefined = undefined,
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
-  const TComponent extends Component | undefined = undefined
->(options: CreateRouteOptions<TName, TPath, TQuery> & WithComponent<TComponent, {}> & WithParent<TParent>): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>>
+  TComponent extends Component | undefined = undefined
+>(options: CreateRouteOptions<TName, TPath, TQuery> & WithComponent<TComponent, RouteDataParams<TPath, TQuery, TParent>> & WithParent<TParent>): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>>
 
 export function createRoute<
   const TParent extends Route,
   const TName extends string | undefined = undefined,
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
-  const TComponents extends Record<string, Component> | undefined = undefined
->(options: CreateRouteOptions<TName, TPath, TQuery> & WithComponents<TComponents, {}> & WithParent<TParent>): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>>
+  TComponents extends Record<string, Component> | undefined = undefined
+>(options: CreateRouteOptions<TName, TPath, TQuery> & WithComponents<TComponents, RouteDataParams<TPath, TQuery, TParent>> & WithParent<TParent>): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>>
 
 export function createRoute(options: CreateRouteOptions): Route {
   const routeWithComponent = addRouterViewComponentIfWithoutComponent(options)
@@ -115,17 +71,21 @@ export function createRoute(options: CreateRouteOptions): Route {
     host: host('', {}),
   }
 
-  const merged = isCreateRouteOptionsWithParent(options) ? combineRoutes(options.parent, route) : route
+  const merged = isWithParent(options) ? combineRoutes(options.parent, route) : route
 
   checkDuplicateKeys(merged.path.params, merged.query.params)
 
   return merged
 }
 
-function addRouterViewComponentIfWithoutComponent(options: CreateRouteOptions): CreateRouteOptions & { component: Component } {
-  if (isRouteWithoutComponent(options)) {
-    return { ...options, component: RouterView }
+function addRouterViewComponentIfWithoutComponent(options: CreateRouteOptions): CreateRouteOptions & ({ component: Component } | { components: Record<string, Component> }) {
+  if (isWithComponents(options)) {
+    return options
   }
 
-  return options
+  if (isWithComponent(options)) {
+    return options
+  }
+
+  return { ...options, component: RouterView }
 }

--- a/src/services/createRoute.ts
+++ b/src/services/createRoute.ts
@@ -7,35 +7,24 @@ import { host } from '@/services/host'
 import { CreateRouteOptions, WithComponent, WithComponents, WithHooks, WithParent, WithoutParent, combineRoutes, isWithComponent, isWithComponents, isWithParent } from '@/types/createRouteOptions'
 import { Host } from '@/types/host'
 import { ToKey, toKey } from '@/types/key'
-import { ExtractParamTypes } from '@/types/params'
 import { Path, ToPath, toPath } from '@/types/path'
 import { Query, ToQuery, toQuery } from '@/types/query'
 import { Route } from '@/types/route'
-import { Identity } from '@/types/utilities'
 import { checkDuplicateKeys } from '@/utilities/checkDuplicateKeys'
 
-type ParentPath<TParent extends Route | undefined> = TParent extends Route ? TParent['path'] : Path<'', {}>
-type ParentQuery<TParent extends Route | undefined> = TParent extends Route ? TParent['query'] : Query<'', {}>
-
-type RouteDataParams<
-  TPath extends string | Path | undefined,
-  TQuery extends string | Query | undefined,
-  TParent extends Route | undefined = undefined
-> = ExtractParamTypes<Identity<CombinePath<ParentPath<TParent>, ToPath<TPath>>['params'] & CombineQuery<ParentQuery<TParent>, ToQuery<TQuery>>['params']>>
-
 export function createRoute<
   const TName extends string | undefined = undefined,
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
   TComponent extends Component | undefined = undefined
->(options: CreateRouteOptions<TName, TPath, TQuery> & WithHooks & WithComponent<TComponent, RouteDataParams<TPath, TQuery>> & WithoutParent): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>>
+>(options: CreateRouteOptions<TName, TPath, TQuery> & WithHooks & WithComponent<TComponent> & WithoutParent): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>>
 
 export function createRoute<
   const TName extends string | undefined = undefined,
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
   TComponents extends Record<string, Component> | undefined = undefined
->(options: CreateRouteOptions<TName, TPath, TQuery> & WithHooks & WithComponents<TComponents, RouteDataParams<TPath, TQuery>> & WithoutParent): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>>
+>(options: CreateRouteOptions<TName, TPath, TQuery> & WithHooks & WithComponents<TComponents> & WithoutParent): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>>
 
 export function createRoute<
   const TParent extends Route,
@@ -43,7 +32,7 @@ export function createRoute<
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
   TComponent extends Component | undefined = undefined
->(options: CreateRouteOptions<TName, TPath, TQuery> & WithHooks & WithComponent<TComponent, RouteDataParams<TPath, TQuery, TParent>> & WithParent<TParent>): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>>
+>(options: CreateRouteOptions<TName, TPath, TQuery> & WithHooks & WithComponent<TComponent> & WithParent<TParent>): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>>
 
 export function createRoute<
   const TParent extends Route,
@@ -51,7 +40,7 @@ export function createRoute<
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
   TComponents extends Record<string, Component> | undefined = undefined
->(options: CreateRouteOptions<TName, TPath, TQuery> & WithHooks & WithComponents<TComponents, RouteDataParams<TPath, TQuery, TParent>> & WithParent<TParent>): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>>
+>(options: CreateRouteOptions<TName, TPath, TQuery> & WithHooks & WithComponents<TComponents> & WithParent<TParent>): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>>
 
 export function createRoute(options: CreateRouteOptions): Route {
   const routeWithComponent = addRouterViewComponentIfWithoutComponent(options)

--- a/src/services/paramValidation.spec.ts
+++ b/src/services/paramValidation.spec.ts
@@ -145,7 +145,7 @@ test.each([
 })
 
 test.each([
-  { path: '/duplicate/[foo]', query: 'params=[?foo]' },
+  { path: '/duplicate/[foo]', host: 'https://router.kitbag.dev', query: 'params=[?foo]' },
   { path: '/duplicate/[foo]', host: 'https://[foo].kitbag.dev' },
   { path: '/', host: 'https://[?foo].kitbag.dev', query: 'params=[?foo]' },
   { path: '/duplicate/[foo]', host: 'https://[foo].kitbag.dev', query: 'params=[foo]' },
@@ -153,7 +153,6 @@ test.each([
   const action: () => void = () => createExternalRoute({
     name: 'different-cased-params',
     ...route,
-    component,
   })
 
   expect(action).toThrowError(DuplicateParamsError)

--- a/src/services/urlAssembly.spec.ts
+++ b/src/services/urlAssembly.spec.ts
@@ -274,7 +274,6 @@ describe('host params', () => {
       name: 'simple',
       path: '/',
       host,
-      component,
     })
 
     const url = assembleUrl(route)
@@ -291,7 +290,6 @@ describe('host params', () => {
       name: 'simple',
       path: '/',
       host,
-      component,
     })
 
     const url = assembleUrl(route)
@@ -307,7 +305,6 @@ describe('host params', () => {
       name: 'simple',
       path: '/',
       host,
-      component,
     })
 
     const url = assembleUrl(route, {
@@ -323,7 +320,6 @@ describe('host params', () => {
       name: 'simple',
       path: '/',
       host: host('[?subdomain]kitbag.dev', { subdomain: withDefault(String, 'abc.') }),
-      component,
     })
 
     const url = assembleUrl(route, {
@@ -341,7 +337,6 @@ describe('host params', () => {
       name: 'simple',
       path: '/',
       host,
-      component,
     })
 
     expect(() => assembleUrl(route)).toThrowError(InvalidRouteParamValueError)
@@ -355,7 +350,6 @@ describe('host params', () => {
       name: 'simple',
       path: '/',
       host,
-      component,
     })
 
     const url = assembleUrl(route, {

--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -22,14 +22,14 @@ export type WithHooks = {
   onAfterRouteLeave?: MaybeArray<AfterRouteHook>,
 }
 
-export type WithHost<THost extends string | Host> = {
+export type WithHost<THost extends string | Host = string | Host> = {
   /**
    * Host part of URL.
    */
   host: THost,
 }
 
-export function isWithHost(options: CreateRouteOptions): options is CreateRouteOptions & WithHost<string | Host> {
+export function isWithHost(options: CreateRouteOptions): options is CreateRouteOptions & WithHost {
   return 'host' in options && Boolean(options.host)
 }
 

--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -2,13 +2,12 @@ import { Component } from 'vue'
 import { combineKey } from '@/services/combineKey'
 import { combinePath } from '@/services/combinePath'
 import { combineQuery } from '@/services/combineQuery'
-import { ComponentProps } from '@/services/component'
 import { AfterRouteHook, BeforeRouteHook } from '@/types/hooks'
 import { Path } from '@/types/path'
 import { Query } from '@/types/query'
 import { RouteMeta } from '@/types/register'
 import { Route } from '@/types/route'
-import { Identity, MaybeArray, MaybePromise } from '@/types/utilities'
+import { MaybeArray } from '@/types/utilities'
 
 /**
  * Defines route hooks that can be applied before entering, updating, or leaving a route, as well as after these events.
@@ -34,19 +33,10 @@ export type WithoutParent = {
   parent?: never,
 }
 
-type RouteDataRecord<
-  TComponents extends Record<string, Component> | undefined,
-  TParams extends Record<string, unknown>
-> = Identity<{
-  [TKey in keyof TComponents]?: TComponents[TKey] extends Component ? (params: TParams) => MaybePromise<ComponentProps<TComponents[TKey]> | void> : void
-}>
-
 export type WithComponent<
-  TComponent extends Component | undefined = Component | undefined,
-  TParams extends Record<string, unknown> = Record<string, unknown>
+  TComponent extends Component | undefined = Component | undefined
 > = {
   component?: TComponent,
-  data?: (params: TParams) => TComponent extends Component ? ComponentProps<TComponent> | void : void,
 }
 
 export function isWithComponent(options: CreateRouteOptions): options is CreateRouteOptions & { component: Component } {
@@ -54,11 +44,9 @@ export function isWithComponent(options: CreateRouteOptions): options is CreateR
 }
 
 export type WithComponents<
-  TComponents extends Record<string, Component> | undefined = Record<string, Component> | undefined,
-  TParams extends Record<string, unknown> = Record<string, unknown>
+  TComponents extends Record<string, Component> | undefined = Record<string, Component> | undefined
 > = {
   components?: TComponents,
-  data?: RouteDataRecord<TComponents, TParams>,
 }
 
 export function isWithComponents(options: CreateRouteOptions): options is CreateRouteOptions & { components: Record<string, Component> } {

--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -22,11 +22,11 @@ export type WithHooks = {
   onAfterRouteLeave?: MaybeArray<AfterRouteHook>,
 }
 
-export type WithParent<TParent extends Route> = {
+export type WithParent<TParent extends Route = Route> = {
   parent: TParent,
 }
 
-export function isWithParent<T extends Record<string, unknown>>(options: T): options is T & WithParent<Route> {
+export function isWithParent<T extends Record<string, unknown>>(options: T): options is T & WithParent {
   return 'parent' in options && Boolean(options.parent)
 }
 
@@ -42,8 +42,8 @@ type RouteDataRecord<
 }>
 
 export type WithComponent<
-  TComponent extends Component | undefined,
-  TParams extends Record<string, unknown>
+  TComponent extends Component | undefined = Component | undefined,
+  TParams extends Record<string, unknown> = Record<string, unknown>
 > = {
   component?: TComponent,
   data?: (params: TParams) => TComponent extends Component ? ComponentProps<TComponent> | void : void,
@@ -54,8 +54,8 @@ export function isWithComponent(options: CreateRouteOptions): options is CreateR
 }
 
 export type WithComponents<
-  TComponents extends Record<string, Component> | undefined,
-  TParams extends Record<string, unknown>
+  TComponents extends Record<string, Component> | undefined = Record<string, Component> | undefined,
+  TParams extends Record<string, unknown> = Record<string, unknown>
 > = {
   components?: TComponents,
   data?: RouteDataRecord<TComponents, TParams>,
@@ -66,9 +66,9 @@ export function isWithComponents(options: CreateRouteOptions): options is Create
 }
 
 export type CreateRouteOptions<
-  TName extends string | undefined = undefined,
-  TPath extends string | Path | undefined = undefined,
-  TQuery extends string | Query | undefined = undefined
+  TName extends string | undefined = string | undefined,
+  TPath extends string | Path | undefined = string | Path | undefined,
+  TQuery extends string | Query | undefined = string | Query | undefined
 > = {
   name?: TName,
   path?: TPath,

--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -3,6 +3,7 @@ import { combineKey } from '@/services/combineKey'
 import { combinePath } from '@/services/combinePath'
 import { combineQuery } from '@/services/combineQuery'
 import { AfterRouteHook, BeforeRouteHook } from '@/types/hooks'
+import { Host } from '@/types/host'
 import { Path } from '@/types/path'
 import { Query } from '@/types/query'
 import { RouteMeta } from '@/types/register'
@@ -21,6 +22,21 @@ export type WithHooks = {
   onAfterRouteLeave?: MaybeArray<AfterRouteHook>,
 }
 
+export type WithHost<THost extends string | Host> = {
+  /**
+   * Host part of URL.
+   */
+  host: THost,
+}
+
+export function isWithHost(options: CreateRouteOptions): options is CreateRouteOptions & WithHost<string | Host> {
+  return 'host' in options && Boolean(options.host)
+}
+
+export type WithoutHost = {
+  host?: never,
+}
+
 export type WithParent<TParent extends Route = Route> = {
   parent: TParent,
 }
@@ -36,6 +52,9 @@ export type WithoutParent = {
 export type WithComponent<
   TComponent extends Component | undefined = Component | undefined
 > = {
+  /**
+   * A Vue component, which can be either synchronous or asynchronous components.
+   */
   component?: TComponent,
 }
 
@@ -46,6 +65,9 @@ export function isWithComponent(options: CreateRouteOptions): options is CreateR
 export type WithComponents<
   TComponents extends Record<string, Component> | undefined = Record<string, Component> | undefined
 > = {
+  /**
+   * Multiple components for named views, which can be either synchronous or asynchronous components.
+   */
   components?: TComponents,
 }
 
@@ -58,9 +80,21 @@ export type CreateRouteOptions<
   TPath extends string | Path | undefined = string | Path | undefined,
   TQuery extends string | Query | undefined = string | Query | undefined
 > = {
+  /**
+   * Name for route, used to create route keys and in navigation.
+   */
   name?: TName,
+  /**
+   * Path part of URL.
+   */
   path?: TPath,
+  /**
+   * Query (aka search) part of URL.
+   */
   query?: TQuery,
+  /**
+   * Represents additional metadata associated with a route, customizable via declaration merging.
+   */
   meta?: RouteMeta,
 }
 

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -1,4 +1,4 @@
-import { CreateRouteOptions, WithComponent, WithComponents, WithHooks, WithParent, WithoutParent } from '@/types/createRouteOptions'
+import { CreateRouteOptions, WithComponent, WithComponents, WithHooks, WithHost, WithParent, WithoutHost, WithoutParent } from '@/types/createRouteOptions'
 import { Host } from '@/types/host'
 import { Path } from '@/types/path'
 import { Query } from '@/types/query'
@@ -12,7 +12,7 @@ export type Routes = Readonly<Route[]>
 /**
  * The Route properties originally provided to `createRoute`. The only change is normalizing meta to always default to an empty object.
  */
-export type CreateRouteOptionsWithMeta = CreateRouteOptions & WithHooks & (WithComponent | WithComponents) & (WithParent | WithoutParent) & { meta: RouteMeta }
+export type CreateRouteOptionsWithMeta = CreateRouteOptions & WithHooks & (WithHost | WithoutHost) & (WithComponent | WithComponents) & (WithParent | WithoutParent) & { meta: RouteMeta }
 
 /**
  * Represents the structure of a route within the application. Return value of `createRoute`

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -1,4 +1,4 @@
-import { CreateRouteOptions } from '@/types/createRouteOptions'
+import { CreateRouteOptions, WithComponent, WithComponents, WithHooks, WithParent, WithoutParent } from '@/types/createRouteOptions'
 import { Host } from '@/types/host'
 import { Path } from '@/types/path'
 import { Query } from '@/types/query'
@@ -12,7 +12,7 @@ export type Routes = Readonly<Route[]>
 /**
  * The Route properties originally provided to `createRoute`. The only change is normalizing meta to always default to an empty object.
  */
-export type CreateRouteOptionsWithMeta = CreateRouteOptions & { meta: RouteMeta }
+export type CreateRouteOptionsWithMeta = CreateRouteOptions & WithHooks & (WithComponent | WithComponents) & (WithParent | WithoutParent) & { meta: RouteMeta }
 
 /**
  * Represents the structure of a route within the application. Return value of `createRoute`


### PR DESCRIPTION
# Description
To make the types for `createRoute` and `createExternalRoute` more intuitive I'm breaking apart `CreateRouteOptions` into more pieces and using those pieces directly within the overload declarations. This contrasts the current implementation where there are two type `CreateRouteOptionsWithoutParent` and `CreateRouteOptionsWithParent`.

We can now express options like `CreateRouteOptions & WithParent & WithComponent & ...` which makes each overload more intuitive and prevents some of the overlap between `createRoute` and `createExternalRoute`. For example, `host` is not an option when using `createRoute` and `component` is not an option when using `createExternalRoute`.

This also adds overloads and generics to `createRoute` specifically for component(s). 