### PR TITLE
merge parent route meta with children route meta

### DIFF
--- a/src/errors/metaPropertyConflict.ts
+++ b/src/errors/metaPropertyConflict.ts
@@ -1,0 +1,9 @@
+/**
+ * An error thrown when a parent's meta has the same key as a child and the types are not compatible.
+ * A child's meta can override properties of the parent, however the types must match!
+ */
+export class MetaPropertyConflict extends Error {
+  public constructor(property?: string) {
+    super(`Child property on meta for ${property} conflicts with the parent meta.`)
+  }
+}

--- a/src/services/combineMeta.spec.ts
+++ b/src/services/combineMeta.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from 'vitest'
+import { MetaPropertyConflict } from '@/errors/metaPropertyConflict'
+import { combineMeta } from '@/services/combineMeta'
+
+test('given 2 meta objects, returns new meta joined together', () => {
+  const aMeta = { foz: 123 }
+  const bMeta = { baz: 'baz' }
+
+  const response = combineMeta(aMeta, bMeta)
+
+  expect(response).toMatchObject({
+    foz: 123,
+    baz: 'baz',
+  })
+})
+
+test('given 2 meta objects with duplicate properties but same type, overrides parent value with child', () => {
+  const aMeta = { foz: 123 }
+  const bMeta = { foz: 456 }
+
+  const response = combineMeta(aMeta, bMeta)
+
+  expect(response).toMatchObject({
+    foz: 456,
+  })
+})
+
+test('given 2 meta objects with duplicate properties with DIFFERENT types, throws MetaPropertyConflict error', () => {
+  const aMeta = { foz: 123 }
+  const bMeta = { foz: 'baz' }
+
+  const action: () => void = () => combineMeta(aMeta, bMeta)
+
+  expect(action).toThrow(MetaPropertyConflict)
+})

--- a/src/services/combineMeta.ts
+++ b/src/services/combineMeta.ts
@@ -1,0 +1,23 @@
+import { MetaPropertyConflict } from '@/errors/metaPropertyConflict'
+
+export type CombineMeta<
+  TParent extends Record<string, unknown>,
+  TChild extends Record<string, unknown>
+> = TParent & TChild
+
+export function combineMeta<TParentMeta extends Record<string, unknown>, TChildMeta extends Record<string, unknown>>(parentMeta: TParentMeta, childMeta: TChildMeta): CombineMeta<TParentMeta, TChildMeta>
+export function combineMeta(parentMeta: Record<string, unknown>, childMeta: Record<string, unknown>): Record<string, unknown> {
+  checkForConflicts(parentMeta, childMeta)
+
+  return { ...parentMeta, ...childMeta }
+}
+
+function checkForConflicts(parentMeta: Record<string, unknown>, childMeta: Record<string, unknown>): void {
+  const conflict = Object.keys(parentMeta).find(key => {
+    return key in childMeta && typeof childMeta[key] !== typeof parentMeta[key]
+  })
+
+  if (conflict) {
+    throw new MetaPropertyConflict(conflict)
+  }
+}

--- a/src/services/createExternalRoute.ts
+++ b/src/services/createExternalRoute.ts
@@ -28,6 +28,7 @@ export function createExternalRoute(options: CreateRouteOptions): Route {
   const key = toKey(options.name)
   const path = toPath(options.path)
   const query = toQuery(options.query)
+  const meta = options.meta ?? {}
   const host = isWithHost(options) ? toHost(options.host) : toHost('')
   const rawRoute = markRaw({ meta: {}, state: {}, ...options })
 
@@ -38,6 +39,7 @@ export function createExternalRoute(options: CreateRouteOptions): Route {
     host,
     path,
     query,
+    meta,
     depth: 1,
     stateParams: {},
   }

--- a/src/services/createExternalRoute.ts
+++ b/src/services/createExternalRoute.ts
@@ -41,7 +41,7 @@ export function createExternalRoute(options: CreateRouteOptions): Route {
     query,
     meta,
     depth: 1,
-    stateParams: {},
+    state: {},
   }
 
   const merged = isWithParent(options) ? combineRoutes(options.parent, route) : route

--- a/src/services/createRoute.spec.ts
+++ b/src/services/createRoute.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test } from 'vitest'
+import { createRoute } from '@/services/createRoute'
+import { path } from '@/services/path'
+import { query } from '@/services/query'
+
+test('given parent, key is combined', () => {
+  const parent = createRoute({
+    name: 'parent',
+  })
+
+  const child = createRoute({
+    parent: parent,
+    name: 'child',
+  })
+
+  expect(child.key).toBe('parent.child')
+})
+
+test('given parent, path is combined', () => {
+  const parent = createRoute({
+    path: '/parent',
+  })
+
+  const child = createRoute({
+    parent: parent,
+    path: path('/child/[id]', { id: Number }),
+  })
+
+  expect(child.path).toMatchObject({
+    path: '/parent/child/[id]',
+    params: {
+      id: Number,
+    },
+  })
+})
+
+test('given parent, query is combined', () => {
+  const parent = createRoute({
+    query: 'static=123',
+  })
+
+  const child = createRoute({
+    parent: parent,
+    query: query('sort=[sort]', { sort: Boolean }),
+  })
+
+  expect(child.query).toMatchObject({
+    query: 'static=123&sort=[sort]',
+    params: {
+      sort: Boolean,
+    },
+  })
+})
+
+test('given parent, state is combined into stateParams', () => {
+  const parent = createRoute({
+    state: {
+      foo: Number,
+    },
+  })
+
+  const child = createRoute({
+    parent: parent,
+    state: {
+      bar: String,
+    },
+  })
+
+  expect(child.stateParams).toMatchObject({
+    foo: Number,
+    bar: String,
+  })
+})
+
+test('given parent and child without state, state matches parent', () => {
+  const parent = createRoute({
+    state: {
+      foo: Number,
+    },
+  })
+
+  const child = createRoute({
+    parent: parent,
+  })
+
+  expect(child.stateParams).toMatchObject({
+    foo: Number,
+  })
+})
+
+test('given parent, meta is combined', () => {
+  const parent = createRoute({
+    meta: {
+      foo: 123,
+    },
+  })
+
+  const child = createRoute({
+    parent: parent,
+    meta: {
+      bar: 'zoo',
+    },
+  })
+
+  expect(child.meta).toMatchObject({
+    foo: 123,
+    bar: 'zoo',
+  })
+})
+
+test('given parent and child without meta, meta matches parent', () => {
+  const parent = createRoute({
+    meta: {
+      foo: 123,
+    },
+  })
+
+  const child = createRoute({
+    parent: parent,
+  })
+
+  expect(child.meta).toMatchObject({
+    foo: 123,
+  })
+})

--- a/src/services/createRoute.spec.ts
+++ b/src/services/createRoute.spec.ts
@@ -52,7 +52,7 @@ test('given parent, query is combined', () => {
   })
 })
 
-test('given parent, state is combined into stateParams', () => {
+test('given parent, state is combined into state', () => {
   const parent = createRoute({
     state: {
       foo: Number,
@@ -66,7 +66,7 @@ test('given parent, state is combined into stateParams', () => {
     },
   })
 
-  expect(child.stateParams).toMatchObject({
+  expect(child.state).toMatchObject({
     foo: Number,
     bar: String,
   })
@@ -83,7 +83,7 @@ test('given parent and child without state, state matches parent', () => {
     parent: parent,
   })
 
-  expect(child.stateParams).toMatchObject({
+  expect(child.state).toMatchObject({
     foo: Number,
   })
 })

--- a/src/services/createRoute.ts
+++ b/src/services/createRoute.ts
@@ -41,7 +41,7 @@ export function createRoute<
   const TQuery extends string | Query | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
   const TState extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithoutComponents & WithParent<TParent> & (WithState<TState> | WithoutState)): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TState, TParent['stateParams']>>
+>(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithoutComponents & WithParent<TParent> & (WithState<TState> | WithoutState)): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TState, TParent['state']>>
 
 export function createRoute<
   TComponent extends Component,
@@ -60,7 +60,7 @@ export function createRoute<
   const TQuery extends string | Query | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
   const TState extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponent<TComponent, RouteParams<TPath, TQuery, TParent>> & WithParent<TParent> & (WithState<TState> | WithoutState)): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TState, TParent['stateParams']>>
+>(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponent<TComponent, RouteParams<TPath, TQuery, TParent>> & WithParent<TParent> & (WithState<TState> | WithoutState)): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TState, TParent['state']>>
 
 export function createRoute<
   TComponents extends Record<string, Component>,
@@ -79,14 +79,14 @@ export function createRoute<
   const TQuery extends string | Query | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
   const TState extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponents<TComponents, RouteParams<TPath, TQuery, TParent>> & WithParent<TParent> & (WithState<TState> | WithoutState)): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TState, TParent['stateParams']>>
+>(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponents<TComponents, RouteParams<TPath, TQuery, TParent>> & WithParent<TParent> & (WithState<TState> | WithoutState)): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TState, TParent['state']>>
 
 export function createRoute(options: CreateRouteOptions): Route {
   const key = toKey(options.name)
   const path = toPath(options.path)
   const query = toQuery(options.query)
   const meta = options.meta ?? {}
-  const stateParams = isWithState(options) ? options.state : {}
+  const state = isWithState(options) ? options.state : {}
   const rawRoute = markRaw({ meta: {}, state: {}, ...options })
 
   const route = {
@@ -96,7 +96,7 @@ export function createRoute(options: CreateRouteOptions): Route {
     path,
     query,
     meta,
-    stateParams,
+    state,
     depth: 1,
     host: host('', {}),
   }

--- a/src/services/createRoute.ts
+++ b/src/services/createRoute.ts
@@ -31,8 +31,8 @@ export function createRoute<
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
-  const TStateParams extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithoutComponents & WithoutParent & (WithState<TStateParams> | WithoutState)): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, TMeta, TStateParams>
+  const TState extends Record<string, Param> = Record<string, Param>
+>(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithoutComponents & WithoutParent & (WithState<TState> | WithoutState)): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, TMeta, TState>
 
 export function createRoute<
   const TParent extends Route,
@@ -40,8 +40,8 @@ export function createRoute<
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
-  const TStateParams extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithoutComponents & WithParent<TParent> & (WithState<TStateParams> | WithoutState)): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TStateParams, TParent['stateParams']>>
+  const TState extends Record<string, Param> = Record<string, Param>
+>(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithoutComponents & WithParent<TParent> & (WithState<TState> | WithoutState)): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TState, TParent['stateParams']>>
 
 export function createRoute<
   TComponent extends Component,
@@ -49,8 +49,8 @@ export function createRoute<
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
-  const TStateParams extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponent<TComponent, RouteParams<TPath, TQuery>> & WithoutParent & (WithState<TStateParams> | WithoutState)): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, TMeta, TStateParams>
+  const TState extends Record<string, Param> = Record<string, Param>
+>(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponent<TComponent, RouteParams<TPath, TQuery>> & WithoutParent & (WithState<TState> | WithoutState)): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, TMeta, TState>
 
 export function createRoute<
   TComponent extends Component,
@@ -59,8 +59,8 @@ export function createRoute<
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
-  const TStateParams extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponent<TComponent, RouteParams<TPath, TQuery, TParent>> & WithParent<TParent> & (WithState<TStateParams> | WithoutState)): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TStateParams, TParent['stateParams']>>
+  const TState extends Record<string, Param> = Record<string, Param>
+>(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponent<TComponent, RouteParams<TPath, TQuery, TParent>> & WithParent<TParent> & (WithState<TState> | WithoutState)): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TState, TParent['stateParams']>>
 
 export function createRoute<
   TComponents extends Record<string, Component>,
@@ -68,8 +68,8 @@ export function createRoute<
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
-  const TStateParams extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponents<TComponents, RouteParams<TPath, TQuery>> & WithoutParent & (WithState<TStateParams> | WithoutState)): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, TMeta, TStateParams>
+  const TState extends Record<string, Param> = Record<string, Param>
+>(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponents<TComponents, RouteParams<TPath, TQuery>> & WithoutParent & (WithState<TState> | WithoutState)): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, TMeta, TState>
 
 export function createRoute<
   TComponents extends Record<string, Component>,
@@ -78,8 +78,8 @@ export function createRoute<
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
-  const TStateParams extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponents<TComponents, RouteParams<TPath, TQuery, TParent>> & WithParent<TParent> & (WithState<TStateParams> | WithoutState)): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TStateParams, TParent['stateParams']>>
+  const TState extends Record<string, Param> = Record<string, Param>
+>(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponents<TComponents, RouteParams<TPath, TQuery, TParent>> & WithParent<TParent> & (WithState<TState> | WithoutState)): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TState, TParent['stateParams']>>
 
 export function createRoute(options: CreateRouteOptions): Route {
   const key = toKey(options.name)

--- a/src/services/createRoute.ts
+++ b/src/services/createRoute.ts
@@ -1,5 +1,6 @@
 import { Component, markRaw } from 'vue'
 import { CombineKey } from '@/services/combineKey'
+import { CombineMeta } from '@/services/combineMeta'
 import { CombinePath } from '@/services/combinePath'
 import { CombineQuery } from '@/services/combineQuery'
 import { CombineState } from '@/services/combineState'
@@ -31,7 +32,7 @@ export function createRoute<
   const TQuery extends string | Query | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
   const TStateParams extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithoutComponents & WithoutParent & (WithState<TStateParams> | WithoutState)): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, TStateParams>
+>(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithoutComponents & WithoutParent & (WithState<TStateParams> | WithoutState)): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, TMeta, TStateParams>
 
 export function createRoute<
   const TParent extends Route,
@@ -40,7 +41,7 @@ export function createRoute<
   const TQuery extends string | Query | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
   const TStateParams extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithoutComponents & WithParent<TParent> & (WithState<TStateParams> | WithoutState)): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineState<TStateParams, TParent['stateParams']>>
+>(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithoutComponents & WithParent<TParent> & (WithState<TStateParams> | WithoutState)): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TStateParams, TParent['stateParams']>>
 
 export function createRoute<
   TComponent extends Component,
@@ -49,7 +50,7 @@ export function createRoute<
   const TQuery extends string | Query | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
   const TStateParams extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponent<TComponent, RouteParams<TPath, TQuery>> & WithoutParent & (WithState<TStateParams> | WithoutState)): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, TStateParams>
+>(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponent<TComponent, RouteParams<TPath, TQuery>> & WithoutParent & (WithState<TStateParams> | WithoutState)): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, TMeta, TStateParams>
 
 export function createRoute<
   TComponent extends Component,
@@ -59,7 +60,7 @@ export function createRoute<
   const TQuery extends string | Query | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
   const TStateParams extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponent<TComponent, RouteParams<TPath, TQuery, TParent>> & WithParent<TParent> & (WithState<TStateParams> | WithoutState)): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineState<TStateParams, TParent['stateParams']>>
+>(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponent<TComponent, RouteParams<TPath, TQuery, TParent>> & WithParent<TParent> & (WithState<TStateParams> | WithoutState)): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TStateParams, TParent['stateParams']>>
 
 export function createRoute<
   TComponents extends Record<string, Component>,
@@ -68,7 +69,7 @@ export function createRoute<
   const TQuery extends string | Query | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
   const TStateParams extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponents<TComponents, RouteParams<TPath, TQuery>> & WithoutParent & (WithState<TStateParams> | WithoutState)): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, TStateParams>
+>(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponents<TComponents, RouteParams<TPath, TQuery>> & WithoutParent & (WithState<TStateParams> | WithoutState)): Route<ToKey<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, TMeta, TStateParams>
 
 export function createRoute<
   TComponents extends Record<string, Component>,
@@ -78,12 +79,13 @@ export function createRoute<
   const TQuery extends string | Query | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
   const TStateParams extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponents<TComponents, RouteParams<TPath, TQuery, TParent>> & WithParent<TParent> & (WithState<TStateParams> | WithoutState)): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineState<TStateParams, TParent['stateParams']>>
+>(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponents<TComponents, RouteParams<TPath, TQuery, TParent>> & WithParent<TParent> & (WithState<TStateParams> | WithoutState)): Route<CombineKey<TParent['key'], ToKey<TName>>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TStateParams, TParent['stateParams']>>
 
 export function createRoute(options: CreateRouteOptions): Route {
   const key = toKey(options.name)
   const path = toPath(options.path)
   const query = toQuery(options.query)
+  const meta = options.meta ?? {}
   const stateParams = isWithState(options) ? options.state : {}
   const rawRoute = markRaw({ meta: {}, state: {}, ...options })
 
@@ -93,6 +95,7 @@ export function createRoute(options: CreateRouteOptions): Route {
     key,
     path,
     query,
+    meta,
     stateParams,
     depth: 1,
     host: host('', {}),

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -150,7 +150,7 @@ export function createRouter<const T extends Routes>(routesOrArrayOfRoutes: T | 
     const params: any = paramsOrOptions ?? {}
     const url = resolve(source, params, options)
     const route = getRoute(source)
-    const state = setStateValues(route?.stateParams ?? {}, options.state)
+    const state = setStateValues(route?.state ?? {}, options.state)
 
     return set(url, { ...options, state })
   }
@@ -167,7 +167,7 @@ export function createRouter<const T extends Routes>(routesOrArrayOfRoutes: T | 
     const params: any = paramsOrOptions ?? {}
     const url = resolve(source, params, options)
     const route = getRoute(source)
-    const state = setStateValues(route?.stateParams ?? {}, options.state)
+    const state = setStateValues(route?.state ?? {}, options.state)
 
     return set(url, { ...options, state })
   }

--- a/src/services/createRouterReject.ts
+++ b/src/services/createRouterReject.ts
@@ -60,7 +60,6 @@ export function createRouterReject({
       query: createResolvedRouteQuery(''),
       params: {},
       state: {},
-      stateParams: {},
       [isRejectionRouteSymbol]: true,
     }
 

--- a/src/services/getResolvedRouteForUrl.ts
+++ b/src/services/getResolvedRouteForUrl.ts
@@ -33,9 +33,8 @@ export function getResolvedRouteForUrl(routes: Routes, url: string, state?: unkn
     matched: route.matched,
     matches: route.matches,
     key: route.key,
-    stateParams: route.stateParams,
     query: createResolvedRouteQuery(search),
     params: getRouteParamValues(route, url),
-    state: getStateValues(route.stateParams, state),
+    state: getStateValues(route.state, state),
   }
 }

--- a/src/services/hooks.spec.ts
+++ b/src/services/hooks.spec.ts
@@ -26,7 +26,6 @@ test('calls hook with correct routes', () => {
     query: createResolvedRouteQuery(),
     params: {},
     state: {},
-    stateParams: {},
   }
 
   const fromOptions = {
@@ -43,7 +42,6 @@ test('calls hook with correct routes', () => {
     query: createResolvedRouteQuery(),
     params: {},
     state: {},
-    stateParams: {},
   }
 
   runBeforeRouteHooks({
@@ -82,7 +80,6 @@ test.each<{ type: string, status: string, hook: BeforeRouteHook }>([
     query: createResolvedRouteQuery(),
     params: {},
     state: {},
-    stateParams: {},
   }
 
   const fromOptions = {
@@ -99,7 +96,6 @@ test.each<{ type: string, status: string, hook: BeforeRouteHook }>([
     query: createResolvedRouteQuery(),
     params: {},
     state: {},
-    stateParams: {},
   }
 
   const response = await runBeforeRouteHooks({
@@ -133,7 +129,6 @@ test('hook is called in order', async () => {
     query: createResolvedRouteQuery(),
     params: {},
     state: {},
-    stateParams: {},
   }
 
   const fromOptions = {
@@ -150,7 +145,6 @@ test('hook is called in order', async () => {
     query: createResolvedRouteQuery(),
     params: {},
     state: {},
-    stateParams: {},
   }
 
   await runBeforeRouteHooks({

--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -137,7 +137,7 @@ export function combineRoutes(parent: Route, child: Route): Route {
     path: combinePath(parent.path, child.path),
     query: combineQuery(parent.query, child.query),
     meta: combineMeta(parent.meta, child.meta),
-    stateParams: combineState(parent.stateParams, child.stateParams),
+    state: combineState(parent.state, child.state),
     matches: [...parent.matches, child.matched],
     host: parent.host,
     depth: parent.depth + 1,

--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -1,5 +1,6 @@
 import { Component } from 'vue'
 import { combineKey } from '@/services/combineKey'
+import { combineMeta } from '@/services/combineMeta'
 import { combinePath } from '@/services/combinePath'
 import { combineQuery } from '@/services/combineQuery'
 import { combineState } from '@/services/combineState'
@@ -135,6 +136,7 @@ export function combineRoutes(parent: Route, child: Route): Route {
     key: combineKey(parent.key, child.key),
     path: combinePath(parent.path, child.path),
     query: combineQuery(parent.query, child.query),
+    meta: combineMeta(parent.meta, child.meta),
     stateParams: combineState(parent.stateParams, child.stateParams),
     matches: [...parent.matches, child.matched],
     host: parent.host,

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -30,11 +30,7 @@ export type ResolvedRoute<TRoute extends Route = Route> = Readonly<{
   */
   params: ExtractRouteParamTypes<TRoute>,
   /**
-   * Represents the schema of the route state, combined with any parents.
-   */
-  stateParams: TRoute['stateParams'],
-  /**
    * Type for additional data intended to be stored in history state.
    */
-  state: ExtractRouteStateParamsAsOptional<TRoute['stateParams']>,
+  state: ExtractRouteStateParamsAsOptional<TRoute['state']>,
 }>

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -27,7 +27,7 @@ export type Route<
   TPath extends Path = Path,
   TQuery extends Query = Query,
   TMeta extends RouteMeta = RouteMeta,
-  TStateParams extends Record<string, Param> = Record<string, Param>
+  TState extends Record<string, Param> = Record<string, Param>
 > = {
   /**
    * The specific route properties that were matched in the current route.
@@ -61,6 +61,6 @@ export type Route<
   /**
    * Represents the schema of the route state, combined with any parents.
   */
-  stateParams: TStateParams,
+  state: TState,
   depth: number,
 }

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -26,6 +26,7 @@ export type Route<
   THost extends Host = Host,
   TPath extends Path = Path,
   TQuery extends Query = Query,
+  TMeta extends RouteMeta = RouteMeta,
   TStateParams extends Record<string, Param> = Record<string, Param>
 > = {
   /**
@@ -53,6 +54,10 @@ export type Route<
    * Represents the structured query of the route, including query params.
   */
   query: TQuery,
+  /**
+   * Represents additional metadata associated with a route, combined with any parents.
+  */
+  meta: TMeta,
   /**
    * Represents the schema of the route state, combined with any parents.
   */

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -13,7 +13,7 @@ export type RouteStateByKey<
 > = ExtractStateParams<RouteGetByKey<TRoutes, TKey>>
 
 type ExtractStateParams<TRoute> = TRoute extends {
-  stateParams: infer TState extends Record<string, Param>,
+  state: infer TState extends Record<string, Param>,
 }
   ? ExtractParamTypes<TState>
   : Record<string, unknown>

--- a/src/utilities/testHelpers.ts
+++ b/src/utilities/testHelpers.ts
@@ -88,6 +88,5 @@ export function mockResolvedRoute(matched: ResolvedRoute['matched'], matches: Re
     query: createResolvedRouteQuery(),
     params: {},
     state: {},
-    stateParams: {},
   }
 }


### PR DESCRIPTION
This PR updates `createRoute` utility to use a new `combineMeta` to merge child meta with parent (if parent exists). This follows the pattern used for state (and others).  Merging meta is just a bit unique in that duplicate keys are allowed as long as the child's property of the same name matches `typeof` for the parent. The thinking here being that the child can override the meta property of a parent.

This PR also adds a new test suite for `createRoute`, with tests for new meta functionality as well as combine logic for other parts of the route.