### PR TITLE
Fix declaration merging of GlobalComponents

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -3,7 +3,7 @@ import RouterView from '@/components/routerView.vue'
 
 export { RouterView, RouterLink }
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   export interface GlobalComponents {
     RouterView: typeof RouterView,
     RouterLink: typeof RouterLink,


### PR DESCRIPTION
using "vue" instead of "@vue/runtime-core"

as described in vue docs
https://vuejs.org/guide/extras/web-components.html#web-components-and-typescript

not sure when this changed, but the language tools looks like it updated to support TS5.5
https://github.com/vuejs/language-tools/issues/4501#issuecomment-2190384987