### PR TITLE
store rejections type in router

### DIFF
--- a/src/errors/routerRejectionError.ts
+++ b/src/errors/routerRejectionError.ts
@@ -1,9 +1,9 @@
-import { RouterRejectionType } from '@/services/createRouterReject'
+import { RegisteredRejectionType } from '@/types/register'
 
 export class RouterRejectionError extends Error {
-  public type: RouterRejectionType
+  public type: RegisteredRejectionType
 
-  public constructor(type: RouterRejectionType) {
+  public constructor(type: RegisteredRejectionType) {
     super(`Routing action rejected: ${type}`)
 
     this.type = type

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -53,9 +53,9 @@ type RouterUpdateOptions = {
  * const router = createRouter(routes)
  * ```
  */
-export function createRouter<const TRoutes extends Routes, TOptions extends RouterOptions>(routes: TRoutes, options?: TOptions): Router<TRoutes, TOptions>
-export function createRouter<const TRoutes extends Routes, TOptions extends RouterOptions>(arrayOfRoutes: TRoutes[], options?: TOptions): Router<TRoutes, TOptions>
-export function createRouter<const TRoutes extends Routes, TOptions extends RouterOptions>(routesOrArrayOfRoutes: TRoutes | TRoutes[], options: TOptions): Router<TRoutes, TOptions> {
+export function createRouter<const TRoutes extends Routes, const TOptions extends RouterOptions>(routes: TRoutes, options?: TOptions): Router<TRoutes, TOptions>
+export function createRouter<const TRoutes extends Routes, const TOptions extends RouterOptions>(arrayOfRoutes: TRoutes[], options?: TOptions): Router<TRoutes, TOptions>
+export function createRouter<const TRoutes extends Routes, const TOptions extends RouterOptions>(routesOrArrayOfRoutes: TRoutes | TRoutes[], options: TOptions): Router<TRoutes, TOptions> {
   const flattenedRoutes = isNestedArray(routesOrArrayOfRoutes) ? routesOrArrayOfRoutes.flat() : routesOrArrayOfRoutes
   const routes = insertBaseRoute(flattenedRoutes, options.base)
 

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -53,9 +53,9 @@ type RouterUpdateOptions = {
  * const router = createRouter(routes)
  * ```
  */
-export function createRouter<const T extends Routes>(routes: T, options?: RouterOptions): Router<T>
-export function createRouter<const T extends Routes>(arrayOfRoutes: T[], options?: RouterOptions): Router<T>
-export function createRouter<const T extends Routes>(routesOrArrayOfRoutes: T | T[], options: RouterOptions = {}): Router<T> {
+export function createRouter<const TRoutes extends Routes, TOptions extends RouterOptions>(routes: TRoutes, options?: TOptions): Router<TRoutes, TOptions>
+export function createRouter<const TRoutes extends Routes, TOptions extends RouterOptions>(arrayOfRoutes: TRoutes[], options?: TOptions): Router<TRoutes, TOptions>
+export function createRouter<const TRoutes extends Routes, TOptions extends RouterOptions>(routesOrArrayOfRoutes: TRoutes | TRoutes[], options: TOptions): Router<TRoutes, TOptions> {
   const flattenedRoutes = isNestedArray(routesOrArrayOfRoutes) ? routesOrArrayOfRoutes.flat() : routesOrArrayOfRoutes
   const routes = insertBaseRoute(flattenedRoutes, options.base)
 
@@ -71,7 +71,7 @@ export function createRouter<const T extends Routes>(routesOrArrayOfRoutes: T | 
     },
   })
 
-  const { runBeforeRouteHooks, runAfterRouteHooks } = createRouteHookRunners<T>()
+  const { runBeforeRouteHooks, runAfterRouteHooks } = createRouteHookRunners<TRoutes>()
   const {
     hooks,
     onBeforeRouteEnter,
@@ -145,7 +145,7 @@ export function createRouter<const T extends Routes>(routesOrArrayOfRoutes: T | 
     history.startListening()
   }
 
-  const push: RouterPush<T> = (source: Url | RoutesName<T>, paramsOrOptions?: Record<string, unknown> | RouterPushOptions, maybeOptions?: RouterPushOptions) => {
+  const push: RouterPush<TRoutes> = (source: Url | RoutesName<TRoutes>, paramsOrOptions?: Record<string, unknown> | RouterPushOptions, maybeOptions?: RouterPushOptions) => {
     if (isUrl(source)) {
       const options: RouterPushOptions = { ...paramsOrOptions }
       const url = resolve(source, options)
@@ -162,7 +162,7 @@ export function createRouter<const T extends Routes>(routesOrArrayOfRoutes: T | 
     return set(url, { ...options, state })
   }
 
-  const replace: RouterReplace<T> = (source: Url | RoutesName<T>, paramsOrOptions?: Record<string, unknown> | RouterReplaceOptions, maybeOptions?: RouterReplaceOptions) => {
+  const replace: RouterReplace<TRoutes> = (source: Url | RoutesName<TRoutes>, paramsOrOptions?: Record<string, unknown> | RouterReplaceOptions, maybeOptions?: RouterReplaceOptions) => {
     if (isUrl(source)) {
       const options: RouterPushOptions = { ...paramsOrOptions, replace: true }
       const url = resolve(source, options)
@@ -183,7 +183,7 @@ export function createRouter<const T extends Routes>(routesOrArrayOfRoutes: T | 
     return setRejection(type)
   }
 
-  const find = <TSource extends RoutesName<T>>(
+  const find = <TSource extends RoutesName<TRoutes>>(
     source: Url | TSource,
     params: Record<PropertyKey, unknown> = {},
   ): ResolvedRoute | undefined => {
@@ -202,7 +202,7 @@ export function createRouter<const T extends Routes>(routesOrArrayOfRoutes: T | 
 
   const { setRejection, rejection, getRejectionRoute } = createRouterReject(options)
   const notFoundRoute = getRejectionRoute('NotFound')
-  const { currentRoute, routerRoute, updateRoute } = createCurrentRoute<T>(notFoundRoute, push)
+  const { currentRoute, routerRoute, updateRoute } = createCurrentRoute<TRoutes>(notFoundRoute, push)
 
   history.startListening()
 
@@ -227,7 +227,7 @@ export function createRouter<const T extends Routes>(routesOrArrayOfRoutes: T | 
     app.provide(routerInjectionKey, router as any)
   }
 
-  const router: Router<T> = {
+  const router: Router<TRoutes> = {
     route: routerRoute,
     resolve,
     push,

--- a/src/services/createRouterReject.ts
+++ b/src/services/createRouterReject.ts
@@ -3,23 +3,22 @@ import { genericRejection } from '@/components/rejection'
 import { createResolvedRouteQuery } from '@/services/createResolvedRouteQuery'
 import { RegisteredRejectionType } from '@/types/register'
 import { ResolvedRoute } from '@/types/resolved'
+import { RouterOptions } from '@/types/router'
 
 export const builtInRejections: ['NotFound'] = ['NotFound']
 export type BuiltInRejectionType = typeof builtInRejections[number]
 
-export type RouterRejectionType = BuiltInRejectionType | RegisteredRejectionType
+export type RouterSetReject = (type: RegisteredRejectionType | null) => void
 
-export type RouterRejectionComponents = { rejections?: Partial<Record<RouterRejectionType, Component>> }
+export type RejectionType<TOptions extends RouterOptions> = keyof TOptions['rejections'] | BuiltInRejectionType
 
-export type RouterSetReject = (type: RouterRejectionType | null) => void
-
-type GetRejectionRoute = (type: RouterRejectionType) => ResolvedRoute
+type GetRejectionRoute = (type: RegisteredRejectionType) => ResolvedRoute
 type IsRejectionRoute = (route: ResolvedRoute) => boolean
 
-export type RouterRejection = Ref<null | { type: RouterRejectionType, component: Component }>
+export type RouterRejection = Ref<null | { type: RegisteredRejectionType, component: Component }>
 
 type CreateRouterRejectContext = {
-  rejections?: RouterRejectionComponents['rejections'],
+  rejections?: Partial<Record<string, Component>>,
 }
 
 const isRejectionRouteSymbol = Symbol()
@@ -35,7 +34,7 @@ export function createRouterReject({
   rejections: customRejectionComponents,
 }: CreateRouterRejectContext): CreateRouterReject {
 
-  const getRejectionComponent = (type: RouterRejectionType): Component => {
+  const getRejectionComponent = (type: RegisteredRejectionType): Component => {
     const components = {
       ...customRejectionComponents,
     }

--- a/src/services/createRouterReject.ts
+++ b/src/services/createRouterReject.ts
@@ -3,14 +3,11 @@ import { genericRejection } from '@/components/rejection'
 import { createResolvedRouteQuery } from '@/services/createResolvedRouteQuery'
 import { RegisteredRejectionType } from '@/types/register'
 import { ResolvedRoute } from '@/types/resolved'
-import { RouterOptions } from '@/types/router'
 
 export const builtInRejections: ['NotFound'] = ['NotFound']
 export type BuiltInRejectionType = typeof builtInRejections[number]
 
 export type RouterSetReject = (type: RegisteredRejectionType | null) => void
-
-export type RejectionType<TOptions extends RouterOptions> = keyof TOptions['rejections'] | BuiltInRejectionType
 
 type GetRejectionRoute = (type: RegisteredRejectionType) => ResolvedRoute
 type IsRejectionRoute = (route: ResolvedRoute) => boolean

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,8 +1,7 @@
-import { RouterRejectionType } from '@/services/createRouterReject'
-import { RegisteredRouterPush, RegisteredRouterReplace } from '@/types/register'
+import { RegisteredRejectionType, RegisteredRouterPush, RegisteredRouterReplace } from '@/types/register'
 import { ResolvedRoute } from '@/types/resolved'
 import { Routes } from '@/types/route'
-import { RouterReject } from '@/types/router'
+import { RouterOptions, RouterReject } from '@/types/router'
 import { RouterPush } from '@/types/routerPush'
 import { MaybePromise } from '@/types/utilities'
 
@@ -11,14 +10,14 @@ import { MaybePromise } from '@/types/utilities'
  * @param hook - {@link BeforeRouteHook} The hook function to add.
  * @returns {RouteHookRemove} A function that removes the added hook.
  */
-export type AddBeforeRouteHook = (hook: BeforeRouteHook) => RouteHookRemove
+export type AddBeforeRouteHook<TOptions extends RouterOptions = RouterOptions> = (hook: BeforeRouteHook<TOptions>) => RouteHookRemove
 
 /**
  * Adds a hook that is called after a route change. Returns a function to remove the hook.
  * @param hook - {@link AfterRouteHook} The hook function to add.
  * @returns {RouteHookRemove} A function that removes the added hook.
  */
-export type AddAfterRouteHook = (hook: AfterRouteHook) => RouteHookRemove
+export type AddAfterRouteHook<TOptions extends RouterOptions = RouterOptions> = (hook: AfterRouteHook<TOptions>) => RouteHookRemove
 
 /**
  * A function that can be called to abort a routing operation.
@@ -28,9 +27,9 @@ export type RouteHookAbort = () => void
 /**
  * Context provided to route hooks, containing context of previous route and functions for triggering rejections and push/replace to another route.
  */
-type RouteHookContext = {
+type RouteHookContext<TOptions extends RouterOptions = RouterOptions> = {
   from: ResolvedRoute | null,
-  reject: RouterReject,
+  reject: RouterReject<TOptions>,
   push: RegisteredRouterPush,
   replace: RegisteredRouterReplace,
 }
@@ -39,14 +38,14 @@ type RouteHookContext = {
  * Context provided to route hooks, containing context of previous route and functions for triggering rejections, push/replace to another route,
  * as well as aborting current route change.
  */
-type BeforeRouteHookContext = RouteHookContext & {
+type BeforeRouteHookContext<TOptions extends RouterOptions = RouterOptions> = RouteHookContext<TOptions> & {
   abort: RouteHookAbort,
 }
 
 /**
  * Context provided to route hooks, containing context of previous route and functions for triggering rejections and push/replace to another route.
  */
-type AfterRouteHookContext = RouteHookContext
+type AfterRouteHookContext<TOptions extends RouterOptions = RouterOptions> = RouteHookContext<TOptions>
 
 /**
  * Represents a function called before a route change, potentially altering the routing operation.
@@ -54,7 +53,7 @@ type AfterRouteHookContext = RouteHookContext
  * @param context - {@link BeforeRouteHookContext} The context providing functions and state for the routing operation.
  * @returns Possibly a promise that resolves when the hook's logic has completed.
  */
-export type BeforeRouteHook = (to: ResolvedRoute, context: BeforeRouteHookContext) => MaybePromise<void>
+export type BeforeRouteHook<TOptions extends RouterOptions = RouterOptions> = (to: ResolvedRoute, context: BeforeRouteHookContext<TOptions>) => MaybePromise<void>
 
 /**
  * Represents a function called after a route change has occurred.
@@ -62,7 +61,7 @@ export type BeforeRouteHook = (to: ResolvedRoute, context: BeforeRouteHookContex
  * @param context - {@link AfterRouteHookContext} The context providing functions and state for the routing operation.
  * @returns Possibly a promise that resolves when the hook's logic has completed.
  */
-export type AfterRouteHook = (to: ResolvedRoute, context: AfterRouteHookContext) => MaybePromise<void>
+export type AfterRouteHook<TOptions extends RouterOptions = RouterOptions> = (to: ResolvedRoute, context: AfterRouteHookContext<TOptions>) => MaybePromise<void>
 
 /**
  * Generic type representing a route hook, which can be either before or after a route change.
@@ -117,7 +116,7 @@ type RouteHookPushResponse<T extends Routes> = {
  */
 type RouteHookRejectResponse = {
   status: 'REJECT',
-  type: RouterRejectionType,
+  type: RegisteredRejectionType,
 }
 
 /**

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,7 +1,7 @@
 import { RegisteredRejectionType, RegisteredRouterPush, RegisteredRouterReplace } from '@/types/register'
 import { ResolvedRoute } from '@/types/resolved'
 import { Routes } from '@/types/route'
-import { RouterOptions, RouterReject } from '@/types/router'
+import { RouterReject } from '@/types/router'
 import { RouterPush } from '@/types/routerPush'
 import { MaybePromise } from '@/types/utilities'
 
@@ -10,14 +10,14 @@ import { MaybePromise } from '@/types/utilities'
  * @param hook - {@link BeforeRouteHook} The hook function to add.
  * @returns {RouteHookRemove} A function that removes the added hook.
  */
-export type AddBeforeRouteHook<TOptions extends RouterOptions = RouterOptions> = (hook: BeforeRouteHook<TOptions>) => RouteHookRemove
+export type AddBeforeRouteHook = (hook: BeforeRouteHook) => RouteHookRemove
 
 /**
  * Adds a hook that is called after a route change. Returns a function to remove the hook.
  * @param hook - {@link AfterRouteHook} The hook function to add.
  * @returns {RouteHookRemove} A function that removes the added hook.
  */
-export type AddAfterRouteHook<TOptions extends RouterOptions = RouterOptions> = (hook: AfterRouteHook<TOptions>) => RouteHookRemove
+export type AddAfterRouteHook = (hook: AfterRouteHook) => RouteHookRemove
 
 /**
  * A function that can be called to abort a routing operation.
@@ -27,9 +27,9 @@ export type RouteHookAbort = () => void
 /**
  * Context provided to route hooks, containing context of previous route and functions for triggering rejections and push/replace to another route.
  */
-type RouteHookContext<TOptions extends RouterOptions = RouterOptions> = {
+type RouteHookContext = {
   from: ResolvedRoute | null,
-  reject: RouterReject<TOptions>,
+  reject: RouterReject,
   push: RegisteredRouterPush,
   replace: RegisteredRouterReplace,
 }
@@ -38,14 +38,14 @@ type RouteHookContext<TOptions extends RouterOptions = RouterOptions> = {
  * Context provided to route hooks, containing context of previous route and functions for triggering rejections, push/replace to another route,
  * as well as aborting current route change.
  */
-type BeforeRouteHookContext<TOptions extends RouterOptions = RouterOptions> = RouteHookContext<TOptions> & {
+type BeforeRouteHookContext = RouteHookContext & {
   abort: RouteHookAbort,
 }
 
 /**
  * Context provided to route hooks, containing context of previous route and functions for triggering rejections and push/replace to another route.
  */
-type AfterRouteHookContext<TOptions extends RouterOptions = RouterOptions> = RouteHookContext<TOptions>
+type AfterRouteHookContext = RouteHookContext
 
 /**
  * Represents a function called before a route change, potentially altering the routing operation.
@@ -53,7 +53,7 @@ type AfterRouteHookContext<TOptions extends RouterOptions = RouterOptions> = Rou
  * @param context - {@link BeforeRouteHookContext} The context providing functions and state for the routing operation.
  * @returns Possibly a promise that resolves when the hook's logic has completed.
  */
-export type BeforeRouteHook<TOptions extends RouterOptions = RouterOptions> = (to: ResolvedRoute, context: BeforeRouteHookContext<TOptions>) => MaybePromise<void>
+export type BeforeRouteHook = (to: ResolvedRoute, context: BeforeRouteHookContext) => MaybePromise<void>
 
 /**
  * Represents a function called after a route change has occurred.
@@ -61,7 +61,7 @@ export type BeforeRouteHook<TOptions extends RouterOptions = RouterOptions> = (t
  * @param context - {@link AfterRouteHookContext} The context providing functions and state for the routing operation.
  * @returns Possibly a promise that resolves when the hook's logic has completed.
  */
-export type AfterRouteHook<TOptions extends RouterOptions = RouterOptions> = (to: ResolvedRoute, context: AfterRouteHookContext<TOptions>) => MaybePromise<void>
+export type AfterRouteHook = (to: ResolvedRoute, context: AfterRouteHookContext) => MaybePromise<void>
 
 /**
  * Generic type representing a route hook, which can be either before or after a route change.

--- a/src/types/register.ts
+++ b/src/types/register.ts
@@ -1,4 +1,4 @@
-import { BuiltInRejectionType, RejectionType } from '@/services/createRouterReject'
+import { BuiltInRejectionType } from '@/services/createRouterReject'
 import { Route, Routes } from '@/types/route'
 import { Router, RouterOptions } from '@/types/router'
 import { RouterPush } from '@/types/routerPush'
@@ -6,7 +6,7 @@ import { RouterReplace } from '@/types/routerReplace'
 import { RoutesName, RoutesMap } from '@/types/routesMap'
 
 /**
- * Represents the state of currently registered router, rejections, and route meta. Used to provide correct type context for
+ * Represents the state of currently registered router, and route meta. Used to provide correct type context for
  * components like `RouterLink`, as well as for composables like `useRouter`, `useRoute`, and hooks.
  *
  * @example
@@ -39,7 +39,7 @@ export type RegisteredRoutes = Register extends { router: Router<infer TRoutes e
  * Represents the possible Rejections registered within {@link Register}
  */
 export type RegisteredRejectionType = Register extends { router: Router<Routes, infer TOptions extends RouterOptions> }
-  ? RejectionType<TOptions>
+  ? keyof TOptions['rejections'] | BuiltInRejectionType
   : BuiltInRejectionType
 
 /**

--- a/src/types/register.ts
+++ b/src/types/register.ts
@@ -1,5 +1,6 @@
+import { BuiltInRejectionType, RejectionType } from '@/services/createRouterReject'
 import { Route, Routes } from '@/types/route'
-import { Router } from '@/types/router'
+import { Router, RouterOptions } from '@/types/router'
 import { RouterPush } from '@/types/routerPush'
 import { RouterReplace } from '@/types/routerReplace'
 import { RoutesName, RoutesMap } from '@/types/routesMap'
@@ -13,7 +14,6 @@ import { RoutesName, RoutesMap } from '@/types/routesMap'
  * declare module '@kitbag/router' {
  *   interface Register {
  *     router: typeof router
- *     rejections: ["NotAuthorized"],
  *     routeMeta: { public?: boolean }
  *   }
  * }
@@ -38,9 +38,9 @@ export type RegisteredRoutes = Register extends { router: Router<infer TRoutes e
 /**
  * Represents the possible Rejections registered within {@link Register}
  */
-export type RegisteredRejectionType = Register extends { rejections: infer TRejections extends string[] }
-  ? TRejections[number]
-  : never
+export type RegisteredRejectionType = Register extends { router: Router<Routes, infer TOptions extends RouterOptions> }
+  ? RejectionType<TOptions>
+  : BuiltInRejectionType
 
 /**
  * Represents additional metadata associated with a route, customizable via declaration merging.

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -1,6 +1,5 @@
 import { Component, Plugin } from 'vue'
 import { RouterHistoryMode } from '@/services/createRouterHistory'
-import { RejectionType } from '@/services/createRouterReject'
 import { RouterResolve } from '@/services/createRouterResolve'
 import { RouterRoute } from '@/services/createRouterRoute'
 import { AddAfterRouteHook, AddBeforeRouteHook } from '@/types/hooks'
@@ -12,7 +11,7 @@ import { RouterFind } from '@/types/routerFind'
 import { RouterPush } from '@/types/routerPush'
 import { RouterReplace } from '@/types/routerReplace'
 
-export type RouterReject<TOptions extends RouterOptions = RouterOptions> = (type: RouterOptions extends TOptions ? RegisteredRejectionType : RejectionType<TOptions>) => void
+export type RouterReject = (type: RegisteredRejectionType) => void
 
 /**
  * Options to initialize a {@link Router} instance.
@@ -47,7 +46,8 @@ export type RouterOptions = {
 
 export type Router<
   TRoutes extends Routes = any,
-  TOptions extends RouterOptions = any
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  __TOptions extends RouterOptions = any
 > = Plugin & {
   /**
    * Manages the current route state.
@@ -72,7 +72,7 @@ export type Router<
   /**
    * Handles route rejection based on a specified rejection type.
    */
-  reject: RouterReject<TOptions>,
+  reject: RouterReject,
   /**
    * Forces the router to re-evaluate the current route.
    */
@@ -92,27 +92,27 @@ export type Router<
   /**
    * Registers a hook to be called before a route is entered.
    */
-  onBeforeRouteEnter: AddBeforeRouteHook<TOptions>,
+  onBeforeRouteEnter: AddBeforeRouteHook,
   /**
    * Registers a hook to be called before a route is left.
    */
-  onBeforeRouteLeave: AddBeforeRouteHook<TOptions>,
+  onBeforeRouteLeave: AddBeforeRouteHook,
   /**
    * Registers a hook to be called before a route is updated.
    */
-  onBeforeRouteUpdate: AddBeforeRouteHook<TOptions>,
+  onBeforeRouteUpdate: AddBeforeRouteHook,
   /**
    * Registers a hook to be called after a route is entered.
    */
-  onAfterRouteEnter: AddAfterRouteHook<TOptions>,
+  onAfterRouteEnter: AddAfterRouteHook,
   /**
    * Registers a hook to be called after a route is left.
    */
-  onAfterRouteLeave: AddAfterRouteHook<TOptions>,
+  onAfterRouteLeave: AddAfterRouteHook,
   /**
    * Registers a hook to be called after a route is updated.
    */
-  onAfterRouteUpdate: AddAfterRouteHook<TOptions>,
+  onAfterRouteUpdate: AddAfterRouteHook,
   /**
    * A promise that resolves when the router is fully initialized.
    */

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -1,17 +1,18 @@
-import { Plugin } from 'vue'
+import { Component, Plugin } from 'vue'
 import { RouterHistoryMode } from '@/services/createRouterHistory'
-import { RouterRejectionComponents, RouterRejectionType } from '@/services/createRouterReject'
+import { RejectionType } from '@/services/createRouterReject'
 import { RouterResolve } from '@/services/createRouterResolve'
 import { RouterRoute } from '@/services/createRouterRoute'
 import { AddAfterRouteHook, AddBeforeRouteHook } from '@/types/hooks'
 import { PrefetchConfig } from '@/types/prefetch'
+import { RegisteredRejectionType } from '@/types/register'
 import { ResolvedRoute } from '@/types/resolved'
 import { Routes } from '@/types/route'
 import { RouterFind } from '@/types/routerFind'
 import { RouterPush } from '@/types/routerPush'
 import { RouterReplace } from '@/types/routerReplace'
 
-export type RouterReject = (type: RouterRejectionType) => void
+export type RouterReject<TOptions extends RouterOptions = RouterOptions> = (type: RouterOptions extends TOptions ? RegisteredRejectionType : RejectionType<TOptions>) => void
 
 /**
  * Options to initialize a {@link Router} instance.
@@ -38,10 +39,15 @@ export type RouterOptions = {
    * Determines what assets are prefetched when router-link is rendered for a specific route
    */
   prefetch?: PrefetchConfig,
-} & RouterRejectionComponents
+  /**
+   * Components assigned to each type of rejection your router supports.
+   */
+  rejections?: Partial<Record<string, Component>>,
+}
 
 export type Router<
-  TRoutes extends Routes = any
+  TRoutes extends Routes = any,
+  TOptions extends RouterOptions = any
 > = Plugin & {
   /**
    * Manages the current route state.
@@ -66,7 +72,7 @@ export type Router<
   /**
    * Handles route rejection based on a specified rejection type.
    */
-  reject: RouterReject,
+  reject: RouterReject<TOptions>,
   /**
    * Forces the router to re-evaluate the current route.
    */
@@ -86,27 +92,27 @@ export type Router<
   /**
    * Registers a hook to be called before a route is entered.
    */
-  onBeforeRouteEnter: AddBeforeRouteHook,
+  onBeforeRouteEnter: AddBeforeRouteHook<TOptions>,
   /**
    * Registers a hook to be called before a route is left.
    */
-  onBeforeRouteLeave: AddBeforeRouteHook,
+  onBeforeRouteLeave: AddBeforeRouteHook<TOptions>,
   /**
    * Registers a hook to be called before a route is updated.
    */
-  onBeforeRouteUpdate: AddBeforeRouteHook,
+  onBeforeRouteUpdate: AddBeforeRouteHook<TOptions>,
   /**
    * Registers a hook to be called after a route is entered.
    */
-  onAfterRouteEnter: AddAfterRouteHook,
+  onAfterRouteEnter: AddAfterRouteHook<TOptions>,
   /**
    * Registers a hook to be called after a route is left.
    */
-  onAfterRouteLeave: AddAfterRouteHook,
+  onAfterRouteLeave: AddAfterRouteHook<TOptions>,
   /**
    * Registers a hook to be called after a route is updated.
    */
-  onAfterRouteUpdate: AddAfterRouteHook,
+  onAfterRouteUpdate: AddAfterRouteHook<TOptions>,
   /**
    * A promise that resolves when the router is fully initialized.
    */


### PR DESCRIPTION
This PR should have no impact on the router at runtime. All it does is move the responsibility of defining rejection types from being part of the register interface

```ts
declare module '@kitbag/router' {
  interface Register {
    // router: typeof router
    rejections: ['AuthNeeded']
  }
}
```

into a generic captured by `createRouter`

```ts
const router = createRouter(routes, {
  rejections: {
    AuthNeeded: MyLoginComponent
  }
})
```

If approved, will need a docs change before merging