### PR TITLE
Minor fixes or rejection route type guard and types in hook runner methods

### DIFF
--- a/src/services/createCurrentRoute.ts
+++ b/src/services/createCurrentRoute.ts
@@ -19,7 +19,10 @@ export function createCurrentRoute(fallbackRoute: ResolvedRoute, push: RouterPus
   const route = reactive({ ...fallbackRoute })
 
   const updateRoute: ResolvedRouteUpdate = (newRoute) => {
-    Object.assign(route, { [isRejectionRouteSymbol]: false, ...newRoute })
+    Object.assign(route, { 
+      [isRejectionRouteSymbol]: false,
+      ...newRoute 
+    })
   }
 
   const currentRoute = route

--- a/src/services/createCurrentRoute.ts
+++ b/src/services/createCurrentRoute.ts
@@ -1,5 +1,6 @@
 import { reactive } from 'vue'
 import { createRouterRoute } from '@/services/createRouterRoute'
+import { isRejectionRouteSymbol } from '@/services/isRejectionRoute'
 import { RouterRoutes } from '@/types'
 import { ResolvedRoute } from '@/types/resolved'
 import { Routes } from '@/types/route'
@@ -18,7 +19,7 @@ export function createCurrentRoute(fallbackRoute: ResolvedRoute, push: RouterPus
   const route = reactive({ ...fallbackRoute })
 
   const updateRoute: ResolvedRouteUpdate = (newRoute) => {
-    Object.assign(route, { ...newRoute })
+    Object.assign(route, { [isRejectionRouteSymbol]: false, ...newRoute })
   }
 
   const currentRoute = route

--- a/src/services/createRouterReject.ts
+++ b/src/services/createRouterReject.ts
@@ -1,6 +1,7 @@
 import { Ref, markRaw, ref, Component } from 'vue'
 import { genericRejection } from '@/components/rejection'
 import { createResolvedRouteQuery } from '@/services/createResolvedRouteQuery'
+import { isRejectionRouteSymbol } from '@/services/isRejectionRoute'
 import { RegisteredRejectionType } from '@/types/register'
 import { ResolvedRoute } from '@/types/resolved'
 
@@ -10,7 +11,6 @@ export type BuiltInRejectionType = typeof builtInRejections[number]
 export type RouterSetReject = (type: RegisteredRejectionType | null) => void
 
 type GetRejectionRoute = (type: RegisteredRejectionType) => ResolvedRoute
-type IsRejectionRoute = (route: ResolvedRoute) => boolean
 
 export type RouterRejection = Ref<null | { type: RegisteredRejectionType, component: Component }>
 
@@ -18,13 +18,11 @@ type CreateRouterRejectContext = {
   rejections?: Partial<Record<string, Component>>,
 }
 
-const isRejectionRouteSymbol = Symbol()
 
 export type CreateRouterReject = {
   setRejection: RouterSetReject,
   rejection: RouterRejection,
   getRejectionRoute: GetRejectionRoute,
-  isRejectionRoute: IsRejectionRoute,
 }
 
 export function createRouterReject({
@@ -62,10 +60,6 @@ export function createRouterReject({
     return resolved
   }
 
-  const isRejectionRoute: IsRejectionRoute = (route) => {
-    return isRejectionRouteSymbol in route
-  }
-
   const setRejection: RouterSetReject = (type) => {
     if (!type) {
       rejection.value = null
@@ -83,6 +77,5 @@ export function createRouterReject({
     setRejection,
     rejection,
     getRejectionRoute,
-    isRejectionRoute,
   }
 }

--- a/src/services/hooks.ts
+++ b/src/services/hooks.ts
@@ -57,7 +57,7 @@ export function createRouteHookRunners<const T extends Routes>(): RouteHookRunne
     throw new NavigationAbortError()
   }
 
-  async function runBeforeRouteHooks<const T extends Routes>({ to, from, hooks }: BeforeContext): Promise<BeforeRouteHookResponse<T>> {
+  async function runBeforeRouteHooks({ to, from, hooks }: BeforeContext): Promise<BeforeRouteHookResponse<T>> {
     const { global, component } = hooks
     const route = getBeforeRouteHooksFromRoutes(to, from)
 
@@ -112,7 +112,7 @@ export function createRouteHookRunners<const T extends Routes>(): RouteHookRunne
     }
   }
 
-  async function runAfterRouteHooks<const T extends Routes>({ to, from, hooks }: AfterContext): Promise<AfterRouteHookResponse<T>> {
+  async function runAfterRouteHooks({ to, from, hooks }: AfterContext): Promise<AfterRouteHookResponse<T>> {
     const { global, component } = hooks
     const route = getAfterRouteHooksFromRoutes(to, from)
 

--- a/src/services/isRejectionRoute.ts
+++ b/src/services/isRejectionRoute.ts
@@ -1,0 +1,7 @@
+import { ResolvedRoute } from '@/types/resolved'
+
+export const isRejectionRouteSymbol = Symbol()
+
+export function isRejectionRoute(route: ResolvedRoute): boolean {
+  return isRejectionRouteSymbol in route && !!route[isRejectionRouteSymbol]
+}


### PR DESCRIPTION
while exploring the idea of "system" or "default" hooks to [handle scroll position](https://github.com/kitbagjs/router/issues/193) I found a couple bugs. 

- move `isRejectionRoute` out of createRouterReject, not used anyways
- ensure that `isRejectionRouteSymbol` defaults to `false` when updating current route. We use `Object.assign` to update current route. All non-rejection routes do not have this property. The initial current route is a rejection route (not found). So the property is there when we create the router and never gets unset. So every route appeared to be a rejection route
- we were taking `T extends Routes` on the hook runner methods but T was available from the parent function and wasn't being overridden.