### PR TITLE
Fix route props not being reactive when changing props on the current route

### DIFF
--- a/src/components/routerView.vue
+++ b/src/components/routerView.vue
@@ -55,6 +55,10 @@
     }
 
     if (props) {
+      // So that the props are reactive we need to actually access the route params in this computed
+      // eslint-disable-next-line @typescript-eslint/no-unused-expressions, no-unused-expressions
+      route.params
+
       return componentUtil(component, () => props(route.params))
     }
 


### PR DESCRIPTION
# Description
Because `route.params` wasn't actually accessed within the `component` computed property within `RouterView` so the effect wasn't tracked. 