### PR TITLE
push/replace accepts option for hash, assembles on url

### DIFF
--- a/docs/api/types/ResolvedRoute.md
+++ b/docs/api/types/ResolvedRoute.md
@@ -43,6 +43,14 @@ query: ResolvedRouteQuery;
 
 Accessor for query string values from user in the current browser location. [ResolvedRouteQuery](/api/types/ResolvedRouteQuery)
 
+### hash
+
+```ts
+hash?: string;
+```
+
+Accessor for hash string value (or undefined) from user in the current browser location.
+
 ### params
 
 ```ts

--- a/docs/api/types/RouterPush.md
+++ b/docs/api/types/RouterPush.md
@@ -21,6 +21,7 @@ Push will update the URL for the browser and also add the URL into the history s
 {
   query?: Record<string, string>,
   replace?: boolean,
+  hash?: string,
 }
 ```
 

--- a/docs/api/types/RouterReplace.md
+++ b/docs/api/types/RouterReplace.md
@@ -20,6 +20,7 @@ Replace has the same effect as [`RouterPush`](/api/types/RouterPush) but without
 ```ts
 {
   query?: Record<string, string>,
+  hash?: string,
 }
 ```
 

--- a/docs/api/types/RouterResolve.md
+++ b/docs/api/types/RouterResolve.md
@@ -34,6 +34,7 @@ If source is `Url`, expected type for params is `never`. Else when source is `TS
 ```ts
 {
   query?: Record<string, string>,
+  hash?: string,
 }
 ```
 

--- a/src/services/createRouterResolve.spec.ts
+++ b/src/services/createRouterResolve.spec.ts
@@ -84,3 +84,9 @@ test('when given an external route with params in host, interpolates param value
 
   expect(url).toBe('https://router.kitbag.dev/')
 })
+
+test('given a route with hash, interpolates hash value', () => {
+  const resolve = createRouterResolve(routes)
+
+  expect(resolve('parentA', { paramA: 'bar' }, { hash: 'foo' })).toBe('/parentA/bar#foo')
+})

--- a/src/services/createRouterResolve.ts
+++ b/src/services/createRouterResolve.ts
@@ -10,6 +10,7 @@ import { AllPropertiesAreOptional } from '@/types/utilities'
 
 export type RouterResolveOptions = {
   query?: Record<string, string>,
+  hash?: string,
 }
 
 type RouterResolveArgs<
@@ -51,6 +52,7 @@ export function createRouterResolve<const TRoutes extends Routes>(routes: TRoute
     const url = assembleUrl(match, {
       params,
       query: options.query,
+      hash: options.hash,
     })
 
     return url

--- a/src/services/createRouterRoute.ts
+++ b/src/services/createRouterRoute.ts
@@ -13,7 +13,6 @@ export type RouterRoute<TRoute extends ResolvedRoute = ResolvedRoute> = Readonly
   matches: TRoute['matches'],
   state: TRoute['state'],
   query: ResolvedRouteQuery,
-  hash: TRoute['hash'],
   params: Writable<TRoute['params']>,
   update: RouteUpdate<TRoute>,
 }>

--- a/src/services/createRouterRoute.ts
+++ b/src/services/createRouterRoute.ts
@@ -13,6 +13,7 @@ export type RouterRoute<TRoute extends ResolvedRoute = ResolvedRoute> = Readonly
   matches: TRoute['matches'],
   state: TRoute['state'],
   query: ResolvedRouteQuery,
+  hash: TRoute['hash'],
   params: Writable<TRoute['params']>,
   update: RouteUpdate<TRoute>,
 }>
@@ -40,13 +41,14 @@ export function createRouterRoute<TRoute extends ResolvedRoute>(route: TRoute, p
     return push(route.name, params, maybeOptions)
   }
 
-  const { matched, matches, name, query, params, state } = toRefs(route)
+  const { matched, matches, name, query, params, state, hash } = toRefs(route)
 
   const routerRoute: RouterRoute<TRoute> = reactive({
     matched,
     matches,
     state,
     query,
+    hash,
     params,
     name,
     update,

--- a/src/services/createRouterRoute.ts
+++ b/src/services/createRouterRoute.ts
@@ -13,6 +13,7 @@ export type RouterRoute<TRoute extends ResolvedRoute = ResolvedRoute> = Readonly
   matches: TRoute['matches'],
   state: TRoute['state'],
   query: ResolvedRouteQuery,
+  hash: TRoute['hash'],
   params: Writable<TRoute['params']>,
   update: RouteUpdate<TRoute>,
 }>

--- a/src/services/getResolvedRouteForUrl.browser.spec.ts
+++ b/src/services/getResolvedRouteForUrl.browser.spec.ts
@@ -215,3 +215,14 @@ test('given state that matches state params, returns state', () => {
 
   expect(response?.state).toMatchObject({ foo: true, bar: 'abc' })
 })
+
+test('given a route with hash returns hash property', () => {
+  const route = createRoute({
+    name: 'route',
+    path: '/foo',
+    component,
+  })
+  const response = getResolvedRouteForUrl([route], '/foo#bar')
+
+  expect(response?.hash).toBe('#bar')
+})

--- a/src/services/getResolvedRouteForUrl.ts
+++ b/src/services/getResolvedRouteForUrl.ts
@@ -27,7 +27,7 @@ export function getResolvedRouteForUrl(routes: Routes, url: string, state?: unkn
   }
 
   const [route] = matches
-  const { search } = createMaybeRelativeUrl(url)
+  const { search, hash } = createMaybeRelativeUrl(url)
 
   return {
     matched: route.matched,
@@ -36,5 +36,6 @@ export function getResolvedRouteForUrl(routes: Routes, url: string, state?: unkn
     query: createResolvedRouteQuery(search),
     params: getRouteParamValues(route, url),
     state: getStateValues(route.state, state),
+    hash,
   }
 }

--- a/src/services/urlAssembly.spec.ts
+++ b/src/services/urlAssembly.spec.ts
@@ -359,3 +359,14 @@ describe('host params', () => {
     expect(url).toBe('ABC.kitbag.dev/')
   })
 })
+
+test('given route with hash, returns url with hash value interpolated', () => {
+  const route = createRoute({
+    name: 'simple',
+    path: '/',
+  })
+
+  const url = assembleUrl(route, { hash: 'foo' })
+
+  expect(url).toBe('/#foo')
+})

--- a/src/services/urlAssembly.ts
+++ b/src/services/urlAssembly.ts
@@ -11,6 +11,7 @@ import { Route } from '@/types/route'
 type AssembleUrlOptions = {
   params?: Record<string, unknown>,
   query?: Record<string, string>,
+  hash?: string,
 }
 
 export function assembleUrl(route: Route, options: AssembleUrlOptions = {}): string {
@@ -20,7 +21,10 @@ export function assembleUrl(route: Route, options: AssembleUrlOptions = {}): str
   const pathWithParamsSet = assemblePathParamValues(route.path, paramValues)
   const queryWithParamsSet = assembleQueryParamValues(route.query, paramValues)
 
-  return withQuery(`${hostWithParamsSet}${pathWithParamsSet}`, queryWithParamsSet, queryValues)
+  const url = withQuery(`${hostWithParamsSet}${pathWithParamsSet}`, queryWithParamsSet, queryValues)
+  const hash = options.hash ? `#${options.hash.replace(/^#/, '')}` : ''
+
+  return `${url}${hash}`
 }
 
 function assembleHostParamValues(host: Host, paramValues: Record<string, unknown>): string {

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -26,6 +26,10 @@ export type ResolvedRoute<TRoute extends Route = Route> = Readonly<{
   */
   query: ResolvedRouteQuery,
   /**
+   * Hash value of the route.
+  */
+  hash?: string,
+  /**
    * Key value pair for route params, values will be the user provided value from current browser location.
   */
   params: ExtractRouteParamTypes<TRoute>,

--- a/src/types/routerPush.ts
+++ b/src/types/routerPush.ts
@@ -9,6 +9,7 @@ export type RouterPushOptions<
   TState = unknown
 > = {
   query?: Record<string, string>,
+  hash?: string,
   replace?: boolean,
   state?: Partial<TState>,
 }

--- a/src/types/routerReplace.ts
+++ b/src/types/routerReplace.ts
@@ -9,6 +9,7 @@ export type RouterReplaceOptions<
   TState = unknown
 > = {
   query?: Record<string, string>,
+  hash?: string,
   state?: Partial<TState>,
 }
 


### PR DESCRIPTION
This PR adds a missing core piece of the URL, the hash.

## Writing the value

Previously, users could only set the hash by pushing with relative URL syntax with hash included

```ts
router.push('relative/foo#bar')
```

With this change, users can push (and replace) named routes with hash as part of the options

```ts
router.push('foo', {}, { hash: 'bar' })
```

This also works for `RouterLink`

```html
<router-link :to="resolve => resolve('foo', {}, {hash: 'bar'})">
```

And `useLink`

```ts
const { href } = useLink('foo', {}, { hash: 'bar' })
```

## Reading the value

For reading the current hash value, this PR adds `{ hash?: string }` property to `ResolvedRoute`. Which means `route.hash` is available everywhere resolved routes are used.

```ts
const route = useRoute()

route.hash // string | undefined
```

## Future enchancement

In a future PR, I'd like to add support for defining `hash` as part of your route definition. More to come on that.