### PR TITLE
Hash on route definition

### DIFF
--- a/src/services/combineHash.ts
+++ b/src/services/combineHash.ts
@@ -1,27 +1,16 @@
-import { StringHasValue, stringHasValue } from '@/utilities/guards'
+import { hash } from '@/services/hash'
+import { Hash, ToHash } from '@/types/hash'
 
 export type CombineHash<
-  TParent extends string | undefined,
-  TChild extends string | undefined
-> = HashHasValue<TParent> extends true
-  ? HashHasValue<TChild> extends true
-    ? `${TParent}${TChild}`
-    : TParent
-  : HashHasValue<TChild> extends true
-    ? TChild
-    : undefined
+  TParent extends Hash,
+  TChild extends Hash
+> = ToHash<TParent> extends { value: infer TParentHash extends string }
+  ? ToHash<TChild> extends { value: infer ChildHash extends string }
+    ? Hash<`${TParentHash}${ChildHash}`>
+    : Hash<''>
+  : Hash<''>
 
-type HashHasValue<T> = StringHasValue<T> extends true
-  ? string extends T
-    ? false
-    : true
-  : false
-
-export function combineHash<TParentHash extends string | undefined, TChildHash extends string | undefined>(parentHash: TParentHash, childHash: TChildHash): CombineHash<TParentHash, TChildHash>
-export function combineHash(parentHash: string | undefined, childHash: string | undefined): string | undefined {
-  if (!stringHasValue(parentHash) && !stringHasValue(childHash)) {
-    return undefined
-  }
-
-  return `${parentHash ?? ''}${childHash ?? ''}`
+export function combineHash<TParentHash extends Hash, TChildHash extends Hash>(parentHash: TParentHash, childHash: TChildHash): CombineHash<TParentHash, TChildHash>
+export function combineHash(parentHash: Hash, childHash: Hash): Hash {
+  return hash(`${parentHash.value}${childHash.value}`)
 }

--- a/src/services/combineHash.ts
+++ b/src/services/combineHash.ts
@@ -7,10 +7,10 @@ export type CombineHash<
 > = ToHash<TParent> extends { value: infer TParentHash extends string }
   ? ToHash<TChild> extends { value: infer ChildHash extends string }
     ? Hash<`${TParentHash}${ChildHash}`>
-    : Hash<''>
-  : Hash<''>
+    : TParent
+  : Hash
 
 export function combineHash<TParentHash extends Hash, TChildHash extends Hash>(parentHash: TParentHash, childHash: TChildHash): CombineHash<TParentHash, TChildHash>
 export function combineHash(parentHash: Hash, childHash: Hash): Hash {
-  return hash(`${parentHash.value}${childHash.value}`)
+  return hash(`${parentHash.value ?? ''}${childHash.value ?? ''}`)
 }

--- a/src/services/combineHash.ts
+++ b/src/services/combineHash.ts
@@ -1,0 +1,27 @@
+import { StringHasValue, stringHasValue } from '@/utilities/guards'
+
+export type CombineHash<
+  TParent extends string | undefined,
+  TChild extends string | undefined
+> = HashHasValue<TParent> extends true
+  ? HashHasValue<TChild> extends true
+    ? `${TParent}${TChild}`
+    : TParent
+  : HashHasValue<TChild> extends true
+    ? TChild
+    : undefined
+
+type HashHasValue<T> = StringHasValue<T> extends true
+  ? string extends T
+    ? false
+    : true
+  : false
+
+export function combineHash<TParentHash extends string | undefined, TChildHash extends string | undefined>(parentHash: TParentHash, childHash: TChildHash): CombineHash<TParentHash, TChildHash>
+export function combineHash(parentHash: string | undefined, childHash: string | undefined): string | undefined {
+  if (!stringHasValue(parentHash) && !stringHasValue(childHash)) {
+    return undefined
+  }
+
+  return `${parentHash ?? ''}${childHash ?? ''}`
+}

--- a/src/services/createExternalRoute.ts
+++ b/src/services/createExternalRoute.ts
@@ -1,4 +1,6 @@
 import { markRaw } from 'vue'
+import { CombineHash } from '@/services/combineHash'
+import { CombineMeta } from '@/services/combineMeta'
 import { CombinePath } from '@/services/combinePath'
 import { CombineQuery } from '@/services/combineQuery'
 import { combineRoutes, CreateRouteOptions, isWithHost, isWithParent, WithHost, WithoutHost, WithoutParent, WithParent } from '@/types/createRouteOptions'
@@ -6,6 +8,7 @@ import { Host, toHost, ToHost } from '@/types/host'
 import { toName, ToName } from '@/types/name'
 import { Path, toPath, ToPath } from '@/types/path'
 import { Query, toQuery, ToQuery } from '@/types/query'
+import { RouteMeta } from '@/types/register'
 import { Route } from '@/types/route'
 import { checkDuplicateParams } from '@/utilities/checkDuplicateKeys'
 
@@ -13,15 +16,21 @@ export function createExternalRoute<
   const THost extends string | Host,
   const TName extends string | undefined = undefined,
   const TPath extends string | Path | undefined = undefined,
-  const TQuery extends string | Query | undefined = undefined
->(options: CreateRouteOptions<TName, TPath, TQuery> & WithHost<THost> & WithoutParent): Route<ToName<TName>, ToHost<THost>, ToPath<TPath>, ToQuery<TQuery>>
+  const TQuery extends string | Query | undefined = undefined,
+  const TMeta extends RouteMeta = RouteMeta,
+  const THash extends string | undefined = string | undefined
+>(options: CreateRouteOptions<TName, TPath, TQuery> & WithHost<THost> & WithoutParent):
+Route<ToName<TName>, ToHost<THost>, ToPath<TPath>, ToQuery<TQuery>, TMeta, THash>
 
 export function createExternalRoute<
   const TParent extends Route,
   const TName extends string | undefined = undefined,
   const TPath extends string | Path | undefined = undefined,
-  const TQuery extends string | Query | undefined = undefined
->(options: CreateRouteOptions<TName, TPath, TQuery> & WithoutHost & WithParent<TParent>): Route<ToName<TName>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>>
+  const TQuery extends string | Query | undefined = undefined,
+  const TMeta extends RouteMeta = RouteMeta,
+  const THash extends string | undefined = string | undefined
+>(options: CreateRouteOptions<TName, TPath, TQuery> & WithoutHost & WithParent<TParent>):
+Route<ToName<TName>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineHash<TParent['hash'], THash>>
 
 export function createExternalRoute(options: CreateRouteOptions): Route {
   const name = toName(options.name)
@@ -41,6 +50,7 @@ export function createExternalRoute(options: CreateRouteOptions): Route {
     meta,
     depth: 1,
     state: {},
+    hash: options.hash,
   }
 
   const merged = isWithParent(options) ? combineRoutes(options.parent, route) : route

--- a/src/services/createExternalRoute.ts
+++ b/src/services/createExternalRoute.ts
@@ -4,6 +4,7 @@ import { CombineMeta } from '@/services/combineMeta'
 import { CombinePath } from '@/services/combinePath'
 import { CombineQuery } from '@/services/combineQuery'
 import { combineRoutes, CreateRouteOptions, isWithHost, isWithParent, WithHost, WithoutHost, WithoutParent, WithParent } from '@/types/createRouteOptions'
+import { Hash, toHash, ToHash } from '@/types/hash'
 import { Host, toHost, ToHost } from '@/types/host'
 import { toName, ToName } from '@/types/name'
 import { Path, toPath, ToPath } from '@/types/path'
@@ -17,25 +18,26 @@ export function createExternalRoute<
   const TName extends string | undefined = undefined,
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
-  const TMeta extends RouteMeta = RouteMeta,
-  const THash extends string | undefined = string | undefined
+  const THash extends string | Hash | undefined = undefined,
+  const TMeta extends RouteMeta = RouteMeta
 >(options: CreateRouteOptions<TName, TPath, TQuery> & WithHost<THost> & WithoutParent):
-Route<ToName<TName>, ToHost<THost>, ToPath<TPath>, ToQuery<TQuery>, TMeta, THash>
+Route<ToName<TName>, ToHost<THost>, ToPath<TPath>, ToQuery<TQuery>, ToHash<THash>, TMeta>
 
 export function createExternalRoute<
   const TParent extends Route,
   const TName extends string | undefined = undefined,
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
-  const TMeta extends RouteMeta = RouteMeta,
-  const THash extends string | undefined = string | undefined
+  const THash extends string | Hash | undefined = undefined,
+  const TMeta extends RouteMeta = RouteMeta
 >(options: CreateRouteOptions<TName, TPath, TQuery> & WithoutHost & WithParent<TParent>):
-Route<ToName<TName>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineHash<TParent['hash'], THash>>
+Route<ToName<TName>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineHash<TParent['hash'], ToHash<THash>>, CombineMeta<TMeta, TParent['meta']>>
 
 export function createExternalRoute(options: CreateRouteOptions): Route {
   const name = toName(options.name)
   const path = toPath(options.path)
   const query = toQuery(options.query)
+  const hash = toHash(options.hash)
   const meta = options.meta ?? {}
   const host = isWithHost(options) ? toHost(options.host) : toHost('')
   const rawRoute = markRaw({ meta: {}, state: {}, ...options })
@@ -47,10 +49,10 @@ export function createExternalRoute(options: CreateRouteOptions): Route {
     host,
     path,
     query,
+    hash,
     meta,
     depth: 1,
     state: {},
-    hash: options.hash,
   }
 
   const merged = isWithParent(options) ? combineRoutes(options.parent, route) : route

--- a/src/services/createRoute.spec.ts
+++ b/src/services/createRoute.spec.ts
@@ -44,6 +44,7 @@ test('given parent, state is combined into state', () => {
     state: {
       foo: Number,
     },
+    hash: 'foo',
   })
 
   const child = createRoute({
@@ -51,7 +52,10 @@ test('given parent, state is combined into state', () => {
     state: {
       bar: String,
     },
+    hash: 'bar',
   })
+
+  child.host
 
   expect(child.state).toMatchObject({
     foo: Number,

--- a/src/services/createRoute.spec.ts
+++ b/src/services/createRoute.spec.ts
@@ -44,7 +44,6 @@ test('given parent, state is combined into state', () => {
     state: {
       foo: Number,
     },
-    hash: 'foo',
   })
 
   const child = createRoute({
@@ -52,10 +51,7 @@ test('given parent, state is combined into state', () => {
     state: {
       bar: String,
     },
-    hash: 'bar',
   })
-
-  child.host
 
   expect(child.state).toMatchObject({
     foo: Number,

--- a/src/services/createRoute.ts
+++ b/src/services/createRoute.ts
@@ -1,4 +1,5 @@
 import { Component, markRaw } from 'vue'
+import { CombineHash } from '@/services/combineHash'
 import { CombineMeta } from '@/services/combineMeta'
 import { CombinePath } from '@/services/combinePath'
 import { CombineQuery } from '@/services/combineQuery'
@@ -30,8 +31,14 @@ export function createRoute<
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
+  const THash extends string | undefined = string | undefined,
   const TState extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithoutComponents & WithoutParent & (WithState<TState> | WithoutState)): Route<ToName<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, TMeta, TState>
+>(options: CreateRouteOptions<TName, TPath, TQuery, TMeta, THash>
+& WithHooks
+& WithoutComponents
+& WithoutParent
+& (WithState<TState> | WithoutState)):
+Route<ToName<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, TMeta, THash, TState>
 
 export function createRoute<
   const TParent extends Route,
@@ -39,8 +46,14 @@ export function createRoute<
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
+  const THash extends string | undefined = string | undefined,
   const TState extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithoutComponents & WithParent<TParent> & (WithState<TState> | WithoutState)): Route<ToName<TName>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TState, TParent['state']>>
+>(options: CreateRouteOptions<TName, TPath, TQuery, TMeta, THash>
+& WithHooks
+& WithoutComponents
+& WithParent<TParent>
+& (WithState<TState> | WithoutState)):
+Route<ToName<TName>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineHash<TParent['hash'], THash>, CombineState<TState, TParent['state']>>
 
 export function createRoute<
   TComponent extends Component,
@@ -48,8 +61,14 @@ export function createRoute<
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
+  const THash extends string | undefined = string | undefined,
   const TState extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponent<TComponent, RouteParams<TPath, TQuery>> & WithoutParent & (WithState<TState> | WithoutState)): Route<ToName<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, TMeta, TState>
+>(options: CreateRouteOptions<TName, TPath, TQuery, TMeta, THash>
+& WithHooks
+& WithComponent<TComponent, RouteParams<TPath, TQuery>>
+& WithoutParent
+& (WithState<TState> | WithoutState)):
+Route<ToName<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, TMeta, THash, TState>
 
 export function createRoute<
   TComponent extends Component,
@@ -58,8 +77,14 @@ export function createRoute<
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
+  const THash extends string | undefined = string | undefined,
   const TState extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponent<TComponent, RouteParams<TPath, TQuery, TParent>> & WithParent<TParent> & (WithState<TState> | WithoutState)): Route<ToName<TName>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TState, TParent['state']>>
+>(options: CreateRouteOptions<TName, TPath, TQuery, TMeta, THash>
+& WithHooks
+& WithComponent<TComponent, RouteParams<TPath, TQuery, TParent>>
+& WithParent<TParent>
+& (WithState<TState> | WithoutState)):
+Route<ToName<TName>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineHash<TParent['hash'], THash>, CombineState<TState, TParent['state']>>
 
 export function createRoute<
   TComponents extends Record<string, Component>,
@@ -67,8 +92,14 @@ export function createRoute<
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
+  const THash extends string | undefined = string | undefined,
   const TState extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponents<TComponents, RouteParams<TPath, TQuery>> & WithoutParent & (WithState<TState> | WithoutState)): Route<ToName<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, TMeta, TState>
+>(options: CreateRouteOptions<TName, TPath, TQuery, TMeta, THash>
+& WithHooks
+& WithComponents<TComponents, RouteParams<TPath, TQuery>>
+& WithoutParent
+& (WithState<TState> | WithoutState)):
+Route<ToName<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, TMeta, THash, TState>
 
 export function createRoute<
   TComponents extends Record<string, Component>,
@@ -77,8 +108,14 @@ export function createRoute<
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
+  const THash extends string | undefined = string | undefined,
   const TState extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta> & WithHooks & WithComponents<TComponents, RouteParams<TPath, TQuery, TParent>> & WithParent<TParent> & (WithState<TState> | WithoutState)): Route<ToName<TName>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TState, TParent['state']>>
+>(options: CreateRouteOptions<TName, TPath, TQuery, TMeta, THash>
+& WithHooks
+& WithComponents<TComponents, RouteParams<TPath, TQuery, TParent>>
+& WithParent<TParent>
+& (WithState<TState> | WithoutState)):
+Route<ToName<TName>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineHash<TParent['hash'], THash>, CombineState<TState, TParent['state']>>
 
 export function createRoute(options: CreateRouteOptions): Route {
   const name = toName(options.name)
@@ -98,6 +135,7 @@ export function createRoute(options: CreateRouteOptions): Route {
     state,
     depth: 1,
     host: host('', {}),
+    hash: options.hash,
     prefetch: options.prefetch,
   }
 

--- a/src/services/createRoute.ts
+++ b/src/services/createRoute.ts
@@ -6,6 +6,7 @@ import { CombineQuery } from '@/services/combineQuery'
 import { CombineState } from '@/services/combineState'
 import { host } from '@/services/host'
 import { CreateRouteOptions, WithComponent, WithComponents, WithHooks, WithParent, WithState, WithoutComponents, WithoutParent, WithoutState, combineRoutes, isWithParent, isWithState } from '@/types/createRouteOptions'
+import { Hash, toHash, ToHash } from '@/types/hash'
 import { Host } from '@/types/host'
 import { toName, ToName } from '@/types/name'
 import { ExtractParamTypes } from '@/types/params'
@@ -30,45 +31,45 @@ export function createRoute<
   const TName extends string | undefined = undefined,
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
+  const THash extends string | Hash | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
-  const THash extends string | undefined = string | undefined,
   const TState extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta, THash>
+>(options: CreateRouteOptions<TName, TPath, TQuery, THash, TMeta>
 & WithHooks
 & WithoutComponents
 & WithoutParent
 & (WithState<TState> | WithoutState)):
-Route<ToName<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, TMeta, THash, TState>
+Route<ToName<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, ToHash<THash>, TMeta, TState>
 
 export function createRoute<
   const TParent extends Route,
   const TName extends string | undefined = undefined,
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
+  const THash extends string | Hash | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
-  const THash extends string | undefined = string | undefined,
   const TState extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta, THash>
+>(options: CreateRouteOptions<TName, TPath, TQuery, THash, TMeta>
 & WithHooks
 & WithoutComponents
 & WithParent<TParent>
 & (WithState<TState> | WithoutState)):
-Route<ToName<TName>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineHash<TParent['hash'], THash>, CombineState<TState, TParent['state']>>
+Route<ToName<TName>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineHash<TParent['hash'], ToHash<THash>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TState, TParent['state']>>
 
 export function createRoute<
   TComponent extends Component,
   const TName extends string | undefined = undefined,
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
+  const THash extends string | Hash | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
-  const THash extends string | undefined = string | undefined,
   const TState extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta, THash>
+>(options: CreateRouteOptions<TName, TPath, TQuery, THash, TMeta>
 & WithHooks
 & WithComponent<TComponent, RouteParams<TPath, TQuery>>
 & WithoutParent
 & (WithState<TState> | WithoutState)):
-Route<ToName<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, TMeta, THash, TState>
+Route<ToName<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, ToHash<THash>, TMeta, TState>
 
 export function createRoute<
   TComponent extends Component,
@@ -76,30 +77,30 @@ export function createRoute<
   const TName extends string | undefined = undefined,
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
+  const THash extends string | Hash | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
-  const THash extends string | undefined = string | undefined,
   const TState extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta, THash>
+>(options: CreateRouteOptions<TName, TPath, TQuery, THash, TMeta>
 & WithHooks
 & WithComponent<TComponent, RouteParams<TPath, TQuery, TParent>>
 & WithParent<TParent>
 & (WithState<TState> | WithoutState)):
-Route<ToName<TName>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineHash<TParent['hash'], THash>, CombineState<TState, TParent['state']>>
+Route<ToName<TName>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineHash<TParent['hash'], ToHash<THash>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TState, TParent['state']>>
 
 export function createRoute<
   TComponents extends Record<string, Component>,
   const TName extends string | undefined = undefined,
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
+  const THash extends string | Hash | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
-  const THash extends string | undefined = string | undefined,
   const TState extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta, THash>
+>(options: CreateRouteOptions<TName, TPath, TQuery, THash, TMeta>
 & WithHooks
 & WithComponents<TComponents, RouteParams<TPath, TQuery>>
 & WithoutParent
 & (WithState<TState> | WithoutState)):
-Route<ToName<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, TMeta, THash, TState>
+Route<ToName<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, ToHash<THash>, TMeta, TState>
 
 export function createRoute<
   TComponents extends Record<string, Component>,
@@ -107,20 +108,21 @@ export function createRoute<
   const TName extends string | undefined = undefined,
   const TPath extends string | Path | undefined = undefined,
   const TQuery extends string | Query | undefined = undefined,
+  const THash extends string | Hash | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta,
-  const THash extends string | undefined = string | undefined,
   const TState extends Record<string, Param> = Record<string, Param>
->(options: CreateRouteOptions<TName, TPath, TQuery, TMeta, THash>
+>(options: CreateRouteOptions<TName, TPath, TQuery, THash, TMeta>
 & WithHooks
 & WithComponents<TComponents, RouteParams<TPath, TQuery, TParent>>
 & WithParent<TParent>
 & (WithState<TState> | WithoutState)):
-Route<ToName<TName>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineMeta<TMeta, TParent['meta']>, CombineHash<TParent['hash'], THash>, CombineState<TState, TParent['state']>>
+Route<ToName<TName>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineHash<TParent['hash'], ToHash<THash>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TState, TParent['state']>>
 
 export function createRoute(options: CreateRouteOptions): Route {
   const name = toName(options.name)
   const path = toPath(options.path)
   const query = toQuery(options.query)
+  const hash = toHash(options.hash)
   const meta = options.meta ?? {}
   const state = isWithState(options) ? options.state : {}
   const rawRoute = markRaw({ meta: {}, state: {}, ...options })
@@ -131,11 +133,11 @@ export function createRoute(options: CreateRouteOptions): Route {
     name,
     path,
     query,
+    hash,
     meta,
     state,
     depth: 1,
     host: host('', {}),
-    hash: options.hash,
     prefetch: options.prefetch,
   }
 

--- a/src/services/getResolvedRouteForUrl.browser.spec.ts
+++ b/src/services/getResolvedRouteForUrl.browser.spec.ts
@@ -216,7 +216,7 @@ test('given state that matches state params, returns state', () => {
   expect(response?.state).toMatchObject({ foo: true, bar: 'abc' })
 })
 
-test('given a route with hash returns hash property', () => {
+test('given a url with hash, returns hash property', () => {
   const route = createRoute({
     name: 'route',
     path: '/foo',
@@ -225,4 +225,28 @@ test('given a route with hash returns hash property', () => {
   const response = getResolvedRouteForUrl([route], '/foo#bar')
 
   expect(response?.hash).toBe('#bar')
+})
+
+test.only('given a route with hash, matches url with same hash', () => {
+  const noHashRoute = createRoute({
+    name: 'no-hash',
+    path: '/foo',
+    component,
+  })
+  const differentHashRoute = createRoute({
+    name: 'different-hash',
+    path: '/foo',
+    component,
+    hash: 'bar',
+  })
+  const matchingRoute = createRoute({
+    name: 'matching-route',
+    path: '/foo',
+    component,
+    hash: 'foo',
+  })
+
+  const response = getResolvedRouteForUrl([noHashRoute, matchingRoute, differentHashRoute], '/foo#foo')
+
+  expect(response?.name).toBe('matching-route')
 })

--- a/src/services/getResolvedRouteForUrl.browser.spec.ts
+++ b/src/services/getResolvedRouteForUrl.browser.spec.ts
@@ -1,9 +1,13 @@
-import { expect, test, vi } from 'vitest'
+import { afterEach, expect, test, vi } from 'vitest'
 import { createRoute } from '@/services/createRoute'
 import { getResolvedRouteForUrl } from '@/services/getResolvedRouteForUrl'
 import * as utilities from '@/services/routeMatchScore'
 import { Route } from '@/types'
 import { component } from '@/utilities/testHelpers'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 test('given path WITHOUT params, returns match', () => {
   const parent = createRoute({
@@ -227,7 +231,7 @@ test('given a url with hash, returns hash property', () => {
   expect(response?.hash).toBe('#bar')
 })
 
-test.only('given a route with hash, matches url with same hash', () => {
+test('given a route with hash, matches url with same hash', () => {
   const noHashRoute = createRoute({
     name: 'no-hash',
     path: '/foo',

--- a/src/services/getResolvedRouteForUrl.ts
+++ b/src/services/getResolvedRouteForUrl.ts
@@ -1,7 +1,7 @@
 import { createMaybeRelativeUrl } from '@/services/createMaybeRelativeUrl'
 import { createResolvedRouteQuery } from '@/services/createResolvedRouteQuery'
 import { getRouteParamValues, routeParamsAreValid } from '@/services/paramValidation'
-import { isNamedRoute, routePathMatches, routeQueryMatches } from '@/services/routeMatchRules'
+import { isNamedRoute, routePathMatches, routeQueryMatches, routeHashMatches } from '@/services/routeMatchRules'
 import { getRouteScoreSortMethod } from '@/services/routeMatchScore'
 import { getStateValues } from '@/services/state'
 import { ResolvedRoute } from '@/types/resolved'
@@ -12,6 +12,7 @@ const rules: RouteMatchRule[] = [
   isNamedRoute,
   routePathMatches,
   routeQueryMatches,
+  routeHashMatches,
   routeParamsAreValid,
 ]
 

--- a/src/services/hash.ts
+++ b/src/services/hash.ts
@@ -1,0 +1,18 @@
+import { Hash } from '@/types/hash'
+import { stringHasValue } from '@/utilities/guards'
+
+export function hash<THash extends string>(hash: THash): Hash<THash>
+export function hash(hash?: string): Hash {
+  const value = !stringHasValue(hash) ? '' : hash.replace(/^#/, '')
+
+  return {
+    value,
+    toString: () => {
+      if (stringHasValue(hash)) {
+        return `#${hash}`
+      }
+
+      return ''
+    },
+  }
+}

--- a/src/services/hash.ts
+++ b/src/services/hash.ts
@@ -1,18 +1,25 @@
 import { Hash } from '@/types/hash'
 import { stringHasValue } from '@/utilities/guards'
 
-export function hash<THash extends string>(hash: THash): Hash<THash>
+export function hash<THash extends string>(hash?: THash): Hash<THash>
 export function hash(hash?: string): Hash {
-  const value = !stringHasValue(hash) ? '' : hash.replace(/^#/, '')
+  const value = !stringHasValue(hash) ? undefined : hash.replace(/^#/, '')
+
+  function hasValue(): boolean {
+    return value !== undefined
+  }
+
+  function toString(): string {
+    if (hasValue()) {
+      return `#${hash}`
+    }
+
+    return ''
+  }
 
   return {
     value,
-    toString: () => {
-      if (stringHasValue(hash)) {
-        return `#${hash}`
-      }
-
-      return ''
-    },
+    hasValue,
+    toString,
   }
 }

--- a/src/services/routeMatchRules.spec.ts
+++ b/src/services/routeMatchRules.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest'
 import { createRoute } from '@/services/createRoute'
 import { query } from '@/services/query'
-import { routePathMatches, routeQueryMatches } from '@/services/routeMatchRules'
+import { routeHashMatches, routePathMatches, routeQueryMatches } from '@/services/routeMatchRules'
 import { withDefault } from '@/services/withDefault'
 import { component } from '@/utilities/testHelpers'
 
@@ -187,6 +187,57 @@ describe('routeQueryMatches', () => {
     })
 
     const response = routeQueryMatches(route, 'www.kitbag.io/some/path?second=2&first=1&third=3')
+
+    expect(response).toBe(true)
+  })
+})
+
+describe('routeHashMatches', () => {
+  test.each([
+    ['we*23mf#0'],
+    ['http://www.kitbag.io'],
+    ['http://www.kitbag.io/'],
+    ['http://www.kitbag.io/empty'],
+    ['http://www.kitbag.io/empty#'],
+    ['http://www.kitbag.io/empty#bar'],
+  ])('given %s and route.hash that does NOT match, returns false', (url) => {
+    const route = createRoute({
+      name: 'not-matches',
+      path: '/',
+      component,
+      hash: 'foo',
+    })
+
+    const response = routeHashMatches(route, url)
+
+    expect(response).toBe(false)
+  })
+
+  test.each([
+    ['/#foo'],
+    ['http://www.kitbag.io/#foo'],
+  ])('given url and route.path WITHOUT params that does match, returns true', (url) => {
+    const route = createRoute({
+      name: 'hash-matches',
+      path: '/',
+      component,
+      hash: 'foo',
+    })
+
+    const response = routeHashMatches(route, url)
+
+    expect(response).toBe(true)
+  })
+
+  test('route matching logic is case insensitive', () => {
+    const route = createRoute({
+      name: 'hash-matches',
+      path: '/',
+      component,
+      hash: 'foo',
+    })
+
+    const response = routeHashMatches(route, '/#FOO')
 
     expect(response).toBe(true)
   })

--- a/src/services/routeMatchRules.ts
+++ b/src/services/routeMatchRules.ts
@@ -1,7 +1,6 @@
 import { createMaybeRelativeUrl } from '@/services/createMaybeRelativeUrl'
 import { generateRoutePathRegexPattern, generateRouteQueryRegexPatterns } from '@/services/routeRegex'
 import { RouteMatchRule } from '@/types/routeMatchRule'
-import { stringHasValue } from '@/utilities/guards'
 
 export const isNamedRoute: RouteMatchRule = (route) => {
   return 'name' in route.matched && !!route.matched.name
@@ -25,5 +24,5 @@ export const routeHashMatches: RouteMatchRule = (route, url) => {
   const { hash } = createMaybeRelativeUrl(url)
   const value = route.hash.toString()
 
-  return !stringHasValue(value) || value.toLowerCase() === hash.toLowerCase()
+  return !route.hash.hasValue() || value.toLowerCase() === hash.toLowerCase()
 }

--- a/src/services/routeMatchRules.ts
+++ b/src/services/routeMatchRules.ts
@@ -1,6 +1,7 @@
 import { createMaybeRelativeUrl } from '@/services/createMaybeRelativeUrl'
 import { generateRoutePathRegexPattern, generateRouteQueryRegexPatterns } from '@/services/routeRegex'
 import { RouteMatchRule } from '@/types/routeMatchRule'
+import { stringHasValue } from '@/utilities/guards'
 
 export const isNamedRoute: RouteMatchRule = (route) => {
   return 'name' in route.matched && !!route.matched.name
@@ -18,4 +19,11 @@ export const routeQueryMatches: RouteMatchRule = (route, url) => {
   const queryPatterns = generateRouteQueryRegexPatterns(route)
 
   return queryPatterns.every(pattern => pattern.test(search))
+}
+
+export const routeHashMatches: RouteMatchRule = (route, url) => {
+  const { hash } = createMaybeRelativeUrl(url)
+  const value = route.hash.toString()
+
+  return !stringHasValue(value) || value.toLowerCase() === hash.toLowerCase()
 }

--- a/src/services/routeMatchScore.ts
+++ b/src/services/routeMatchScore.ts
@@ -29,6 +29,14 @@ export function getRouteScoreSortMethod(url: string): RouteSortMethod {
       return sortAfter
     }
 
+    const { hash } = createMaybeRelativeUrl(url)
+    if (aRoute.hash.toString() === hash) {
+      return sortBefore
+    }
+    if (bRoute.hash.toString() === hash) {
+      return sortAfter
+    }
+
     return 0
   }
 }

--- a/src/services/urlAssembly.ts
+++ b/src/services/urlAssembly.ts
@@ -23,7 +23,7 @@ export function assembleUrl(route: Route, options: AssembleUrlOptions = {}): str
   const queryWithParamsSet = assembleQueryParamValues(route.query, paramValues)
 
   const url = withQuery(`${hostWithParamsSet}${pathWithParamsSet}`, queryWithParamsSet, queryValues)
-  const hash = createHash(options.hash ?? route.hash.value).toString()
+  const hash = createHash(route.hash.value ?? options.hash).toString()
 
   return `${url}${hash}`
 }

--- a/src/services/urlAssembly.ts
+++ b/src/services/urlAssembly.ts
@@ -1,3 +1,4 @@
+import { hash as createHash } from '@/services/hash'
 import { setParamValue } from '@/services/params'
 import { setParamValueOnUrl } from '@/services/paramsFinder'
 import { getParamName, isOptionalParamSyntax } from '@/services/routeRegex'
@@ -22,7 +23,7 @@ export function assembleUrl(route: Route, options: AssembleUrlOptions = {}): str
   const queryWithParamsSet = assembleQueryParamValues(route.query, paramValues)
 
   const url = withQuery(`${hostWithParamsSet}${pathWithParamsSet}`, queryWithParamsSet, queryValues)
-  const hash = options.hash ? `#${options.hash.replace(/^#/, '')}` : ''
+  const hash = createHash(options.hash ?? route.hash.value).toString()
 
   return `${url}${hash}`
 }

--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -1,4 +1,5 @@
 import { Component } from 'vue'
+import { combineHash } from '@/services/combineHash'
 import { combineMeta } from '@/services/combineMeta'
 import { combinePath } from '@/services/combinePath'
 import { combineQuery } from '@/services/combineQuery'
@@ -110,7 +111,8 @@ export type CreateRouteOptions<
   TName extends string | undefined = string | undefined,
   TPath extends string | Path | undefined = string | Path | undefined,
   TQuery extends string | Query | undefined = string | Query | undefined,
-  TMeta extends RouteMeta = RouteMeta
+  TMeta extends RouteMeta = RouteMeta,
+  THash extends string | undefined = string | undefined
 > = {
   /**
    * Name for route, used to create route keys and in navigation.
@@ -124,6 +126,10 @@ export type CreateRouteOptions<
    * Query (aka search) part of URL.
    */
   query?: TQuery,
+  /**
+   * Hash part of URL.
+   */
+  hash?: THash,
   /**
    * Represents additional metadata associated with a route, customizable via declaration merging.
    */
@@ -141,6 +147,7 @@ export function combineRoutes(parent: Route, child: Route): Route {
     query: combineQuery(parent.query, child.query),
     meta: combineMeta(parent.meta, child.meta),
     state: combineState(parent.state, child.state),
+    hash: combineHash(parent.hash, child.hash),
     matches: [...parent.matches, child.matched],
     host: parent.host,
     depth: parent.depth + 1,

--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -5,6 +5,7 @@ import { combinePath } from '@/services/combinePath'
 import { combineQuery } from '@/services/combineQuery'
 import { combineState } from '@/services/combineState'
 import { ComponentProps } from '@/services/component'
+import { Hash } from '@/types/hash'
 import { AfterRouteHook, BeforeRouteHook } from '@/types/hooks'
 import { Host } from '@/types/host'
 import { Param } from '@/types/paramTypes'
@@ -111,8 +112,8 @@ export type CreateRouteOptions<
   TName extends string | undefined = string | undefined,
   TPath extends string | Path | undefined = string | Path | undefined,
   TQuery extends string | Query | undefined = string | Query | undefined,
-  TMeta extends RouteMeta = RouteMeta,
-  THash extends string | undefined = string | undefined
+  THash extends string | Hash | undefined = string | Hash | undefined,
+  TMeta extends RouteMeta = RouteMeta
 > = {
   /**
    * Name for route, used to create route keys and in navigation.

--- a/src/types/hash.ts
+++ b/src/types/hash.ts
@@ -2,9 +2,10 @@ import { hash } from '@/services/hash'
 import { isRecord } from '@/utilities/guards'
 
 export type Hash<
-  THash extends string = string
+  THash extends string | undefined = string | undefined
 > = {
   value: THash,
+  hasValue: () => boolean,
   toString: () => string,
 }
 export type ToHash<T extends string | Hash | undefined> = T extends string
@@ -22,7 +23,7 @@ function isHash(value: unknown): value is Hash {
 export function toHash<T extends string | Hash | undefined>(value: T): ToHash<T>
 export function toHash<T extends string | Hash | undefined>(value: T): Hash {
   if (value === undefined) {
-    return hash('')
+    return hash()
   }
 
   if (isHash(value)) {

--- a/src/types/hash.ts
+++ b/src/types/hash.ts
@@ -1,0 +1,33 @@
+import { hash } from '@/services/hash'
+import { isRecord } from '@/utilities/guards'
+
+export type Hash<
+  THash extends string = string
+> = {
+  value: THash,
+  toString: () => string,
+}
+export type ToHash<T extends string | Hash | undefined> = T extends string
+  ? Hash<T>
+  : T extends undefined
+    ? Hash<''>
+    : unknown extends T
+      ? Hash<''>
+      : T
+
+function isHash(value: unknown): value is Hash {
+  return isRecord(value) && typeof value.hash === 'string'
+}
+
+export function toHash<T extends string | Hash | undefined>(value: T): ToHash<T>
+export function toHash<T extends string | Hash | undefined>(value: T): Hash {
+  if (value === undefined) {
+    return hash('')
+  }
+
+  if (isHash(value)) {
+    return value
+  }
+
+  return hash(value)
+}

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -28,6 +28,7 @@ export type Route<
   TPath extends Path = Path,
   TQuery extends Query = Query,
   TMeta extends RouteMeta = RouteMeta,
+  THash extends string | undefined = string | undefined,
   TState extends Record<string, Param> = Record<string, Param>
 > = {
   /**
@@ -55,6 +56,10 @@ export type Route<
    * Represents the structured query of the route, including query params.
   */
   query: TQuery,
+  /**
+   * Represents the hash of the route.
+   */
+  hash: THash,
   /**
    * Represents additional metadata associated with a route, combined with any parents.
   */

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -1,4 +1,5 @@
 import { CreateRouteOptions, WithComponent, WithComponents, WithHooks, WithHost, WithParent, WithState, WithoutComponents, WithoutHost, WithoutParent, WithoutState } from '@/types/createRouteOptions'
+import { Hash } from '@/types/hash'
 import { Host } from '@/types/host'
 import { Param } from '@/types/paramTypes'
 import { Path } from '@/types/path'
@@ -27,8 +28,8 @@ export type Route<
   THost extends Host = Host,
   TPath extends Path = Path,
   TQuery extends Query = Query,
+  THash extends Hash = Hash,
   TMeta extends RouteMeta = RouteMeta,
-  THash extends string | undefined = string | undefined,
   TState extends Record<string, Param> = Record<string, Param>
 > = {
   /**

--- a/src/types/routeWithParams.spec-d.ts
+++ b/src/types/routeWithParams.spec-d.ts
@@ -1,4 +1,5 @@
 import { expectTypeOf, test } from 'vitest'
+import { Hash } from '@/types/hash'
 import { Host } from '@/types/host'
 import { Path } from '@/types/path'
 import { Query } from '@/types/query'
@@ -8,7 +9,7 @@ import { routes } from '@/utilities/testHelpers'
 
 test('RouteGetByName works as expected', () => {
   type Source = RouteGetByKey<typeof routes, 'parentA'>
-  type Expect = Route<'parentA', Host<'', {}>, Path<'/parentA/[paramA]', {}>, Query<'', {}>>
+  type Expect = Route<'parentA', Host<'', {}>, Path<'/parentA/[paramA]', {}>, Query<'', {}>, Hash<''>>
 
   expectTypeOf<Source>().toEqualTypeOf<Expect>()
 })


### PR DESCRIPTION
This PR introduces a type and service for Hash similar to `Path`, `Query`, and `Host`. Each of these parts of the url can be defined when calling `createRoute`. It's normalized from `string | undefined | Host` on `Route` and is combined down from parent routes to children routes. Host is checked for route matching rules, route scoring (for multiple matches), and is used when assembling a URL for a given route. 

Some places where `Host` is different
- Host doesn't currently have any params, so there are no `param` on the host type
- The Host type also adds `hasValue: () => boolean` to the type. I found this useful because host will insert "#" only when there is a value that passes `stringHasValue` check. 
- Users can use the `host` utility when calling `createRoute` but it won't offer any utility over a plain string
- Route push/replace also takes a `{ host: string }` in the options, the `route.hash` wins over the `options.hash`