### PR TITLE
updated syntax on url types to use `value`

### DIFF
--- a/src/services/combinePath.ts
+++ b/src/services/combinePath.ts
@@ -5,8 +5,8 @@ import { checkDuplicateParams } from '@/utilities/checkDuplicateKeys'
 export type CombinePath<
   TParent extends Path,
   TChild extends Path
-> = ToPath<TParent> extends { path: infer TParentPath extends string, params: infer TParentParams extends Record<string, unknown> }
-  ? ToPath<TChild> extends { path: infer TChildPath extends string, params: infer TChildParams extends Record<string, unknown> }
+> = ToPath<TParent> extends { value: infer TParentPath extends string, params: infer TParentParams extends Record<string, unknown> }
+  ? ToPath<TChild> extends { value: infer TChildPath extends string, params: infer TChildParams extends Record<string, unknown> }
     ? RemoveLeadingQuestionMarkFromKeys<TParentParams> & RemoveLeadingQuestionMarkFromKeys<TChildParams> extends PathParamsWithParamNameExtracted<`${TParentPath}${TChildPath}`>
       ? Path<`${TParentPath}${TChildPath}`, RemoveLeadingQuestionMarkFromKeys<TParentParams> & RemoveLeadingQuestionMarkFromKeys<TChildParams>>
       : Path<'', {}>
@@ -17,10 +17,10 @@ export function combinePath<TParentPath extends Path, TChildPath extends Path>(p
 export function combinePath(parentPath: Path, childPath: Path): Path {
   checkDuplicateParams(parentPath.params, childPath.params)
 
-  const newPathString = `${parentPath.path}${childPath.path}`
+  const newPathString = `${parentPath.value}${childPath.value}`
 
   return {
-    path: newPathString,
+    value: newPathString,
     params: { ...parentPath.params, ...childPath.params },
     toString: () => newPathString,
   }

--- a/src/services/combineQuery.ts
+++ b/src/services/combineQuery.ts
@@ -12,8 +12,8 @@ type CombineQueryString<TParent extends string | undefined, TChild extends strin
 export type CombineQuery<
   TParent extends Query,
   TChild extends Query
-> = ToQuery<TParent> extends { query: infer TParentQuery extends string, params: infer TParentParams extends Record<string, unknown> }
-  ? ToQuery<TChild> extends { query: infer TChildQuery extends string, params: infer TChildParams extends Record<string, unknown> }
+> = ToQuery<TParent> extends { value: infer TParentQuery extends string, params: infer TParentParams extends Record<string, unknown> }
+  ? ToQuery<TChild> extends { value: infer TChildQuery extends string, params: infer TChildParams extends Record<string, unknown> }
     ? RemoveLeadingQuestionMarkFromKeys<TParentParams> & RemoveLeadingQuestionMarkFromKeys<TChildParams> extends QueryParamsWithParamNameExtracted<CombineQueryString<TParentQuery, TChildQuery>>
       ? Query<CombineQueryString<TParentQuery, TChildQuery>, RemoveLeadingQuestionMarkFromKeys<TParentParams> & RemoveLeadingQuestionMarkFromKeys<TChildParams>>
       : Query<'', {}>
@@ -24,12 +24,12 @@ export function combineQuery<TParentQuery extends Query, TChildQuery extends Que
 export function combineQuery(parentQuery: Query, childQuery: Query): Query {
   checkDuplicateParams(parentQuery.params, childQuery.params)
 
-  const newQueryString = [parentQuery.query, childQuery.query]
+  const newQueryString = [parentQuery.value, childQuery.value]
     .filter(stringHasValue)
     .join('&')
 
   return {
-    query: newQueryString,
+    value: newQueryString,
     params: { ...parentQuery.params, ...childQuery.params },
     toString: () => newQueryString,
   }

--- a/src/services/createRoute.spec.ts
+++ b/src/services/createRoute.spec.ts
@@ -14,7 +14,7 @@ test('given parent, path is combined', () => {
   })
 
   expect(child.path).toMatchObject({
-    path: '/parent/child/[id]',
+    value: '/parent/child/[id]',
     params: {
       id: Number,
     },
@@ -32,7 +32,7 @@ test('given parent, query is combined', () => {
   })
 
   expect(child.query).toMatchObject({
-    query: 'static=123&sort=[sort]',
+    value: 'static=123&sort=[sort]',
     params: {
       sort: Boolean,
     },

--- a/src/services/host.ts
+++ b/src/services/host.ts
@@ -8,7 +8,7 @@ import { Identity } from '@/types/utilities'
  *
  * @template THost - The string literal type that represents the host.
  * @template TParams - The type of the host parameters associated with the host.
- * @param host - The host string.
+ * @param value - The host string.
  * @param params - The parameters associated with the host, typically as key-value pairs.
  * @returns An object representing the host which includes the host string, its parameters,
  *          and a toString method for getting the host as a string.
@@ -24,11 +24,11 @@ import { Identity } from '@/types/utilities'
  * })
  * ```
  */
-export function host<THost extends string, TParams extends HostParamsWithParamNameExtracted<THost>>(host: THost, params: Identity<TParams>): Host<THost, TParams>
-export function host(host: string, params: Record<string, Param | undefined>): Host {
+export function host<THost extends string, TParams extends HostParamsWithParamNameExtracted<THost>>(value: THost, params: Identity<TParams>): Host<THost, TParams>
+export function host(value: string, params: Record<string, Param | undefined>): Host {
   return {
-    host,
-    params: getParamsForString(host, params),
-    toString: () => host,
+    value,
+    params: getParamsForString(value, params),
+    toString: () => value,
   }
 }

--- a/src/services/path.ts
+++ b/src/services/path.ts
@@ -8,7 +8,7 @@ import { Identity } from '@/types/utilities'
  *
  * @template TPath - The string literal type that represents the path.
  * @template TParams - The type of the path parameters associated with the path.
- * @param path - The path string.
+ * @param value - The path string.
  * @param params - The parameters associated with the path, typically as key-value pairs.
  * @returns An object representing the path which includes the path string, its parameters,
  *          and a toString method for getting the path as a string.
@@ -24,11 +24,11 @@ import { Identity } from '@/types/utilities'
  * })
  * ```
  */
-export function path<TPath extends string, TParams extends PathParamsWithParamNameExtracted<TPath>>(path: TPath, params: Identity<TParams>): Path<TPath, TParams>
-export function path(path: string, params: Record<string, Param | undefined>): Path {
+export function path<TPath extends string, TParams extends PathParamsWithParamNameExtracted<TPath>>(value: TPath, params: Identity<TParams>): Path<TPath, TParams>
+export function path(value: string, params: Record<string, Param | undefined>): Path {
   return {
-    path,
-    params: getParamsForString(path, params),
-    toString: () => path,
+    value,
+    params: getParamsForString(value, params),
+    toString: () => value,
   }
 }

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -8,7 +8,7 @@ import { Identity } from '@/types/utilities'
  *
  * @template TQuery - The string literal type that represents the query.
  * @template TParams - The type of the query parameters associated with the query.
- * @param query - The query string.
+ * @param value - The query string.
  * @param params - The parameters associated with the query, typically as key-value pairs.
  * @returns An object representing the query which includes the query string, its parameters,
  *          and a toString method for getting the query as a string.
@@ -24,11 +24,11 @@ import { Identity } from '@/types/utilities'
  * })
  * ```
  */
-export function query<TQuery extends string, TParams extends QueryParamsWithParamNameExtracted<TQuery>>(query: TQuery, params: Identity<TParams>): Query<TQuery, TParams>
-export function query(query: string, params: Record<string, Param | undefined>): Query {
+export function query<TQuery extends string, TParams extends QueryParamsWithParamNameExtracted<TQuery>>(value: TQuery, params: Identity<TParams>): Query<TQuery, TParams>
+export function query(value: string, params: Record<string, Param | undefined>): Query {
   return {
-    query,
-    params: getParamsForString(query, params),
-    toString: () => query,
+    value,
+    params: getParamsForString(value, params),
+    toString: () => value,
   }
 }

--- a/src/types/host.ts
+++ b/src/types/host.ts
@@ -1,4 +1,4 @@
-import { host } from '@/services/host'
+import { host as createHost } from '@/services/host'
 import { ExtractParamName, ExtractPathParamType, ParamEnd, ParamStart } from '@/types/params'
 import { Param } from '@/types/paramTypes'
 import { Identity } from '@/types/utilities'
@@ -23,7 +23,7 @@ export type Host<
   THost extends string = string,
   TParams extends HostParamsWithParamNameExtracted<THost> = Record<string, Param | undefined>
 > = {
-  host: THost,
+  value: THost,
   params: string extends THost ? Record<string, Param> : Identity<ExtractParamsFromHostString<THost, TParams>>,
   toString: () => string,
 }
@@ -36,15 +36,15 @@ export type ToHost<T extends string | Host | undefined> = T extends string
       ? Host<'', {}>
       : T
 
-function isHost(value: unknown): value is Host {
-  return isRecord(value) && typeof value.host === 'string'
+function isHost(maybeHost: unknown): maybeHost is Host {
+  return isRecord(maybeHost) && typeof maybeHost.value === 'string'
 }
 
-export function toHost<T extends string | Host>(value: T): ToHost<T>
-export function toHost<T extends string | Host>(value: T): Host {
-  if (isHost(value)) {
-    return value
+export function toHost<T extends string | Host>(host: T): ToHost<T>
+export function toHost<T extends string | Host>(host: T): Host {
+  if (isHost(host)) {
+    return host
   }
 
-  return host(value, {})
+  return createHost(host, {})
 }

--- a/src/types/path.ts
+++ b/src/types/path.ts
@@ -1,4 +1,4 @@
-import { path } from '@/services/path'
+import { path as createPath } from '@/services/path'
 import { ExtractParamName, ExtractPathParamType, ParamEnd, ParamStart } from '@/types/params'
 import { Param } from '@/types/paramTypes'
 import { Identity } from '@/types/utilities'
@@ -23,7 +23,7 @@ export type Path<
   TPath extends string = string,
   TParams extends PathParamsWithParamNameExtracted<TPath> = Record<string, Param | undefined>
 > = {
-  path: TPath,
+  value: TPath,
   params: string extends TPath ? Record<string, Param> : Identity<ExtractParamsFromPathString<TPath, TParams>>,
   toString: () => string,
 }
@@ -35,19 +35,19 @@ export type ToPath<T extends string | Path | undefined> = T extends string
       ? Path<'', {}>
       : T
 
-function isPath(value: unknown): value is Path {
-  return isRecord(value) && typeof value.path === 'string'
+function isPath(maybePath: unknown): maybePath is Path {
+  return isRecord(maybePath) && typeof maybePath.value === 'string'
 }
 
-export function toPath<T extends string | Path | undefined>(value: T): ToPath<T>
-export function toPath<T extends string | Path | undefined>(value: T): Path {
-  if (value === undefined) {
-    return path('', {})
+export function toPath<T extends string | Path | undefined>(path: T): ToPath<T>
+export function toPath<T extends string | Path | undefined>(path: T): Path {
+  if (path === undefined) {
+    return createPath('', {})
   }
 
-  if (isPath(value)) {
-    return value
+  if (isPath(path)) {
+    return path
   }
 
-  return path(value, {})
+  return createPath(path, {})
 }

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -1,4 +1,4 @@
-import { query } from '@/services/query'
+import { query as createQuery } from '@/services/query'
 import { ExtractParamName, ExtractPathParamType, ParamEnd, ParamStart } from '@/types/params'
 import { Param } from '@/types/paramTypes'
 import { Identity } from '@/types/utilities'
@@ -23,7 +23,7 @@ export type Query<
   TQuery extends string = string,
   TQueryParams extends QueryParamsWithParamNameExtracted<TQuery> = Record<string, Param | undefined>
 > = {
-  query: TQuery,
+  value: TQuery,
   params: string extends TQuery ? Record<string, Param> : Identity<ExtractQueryParamsFromQueryString<TQuery, TQueryParams>>,
   toString: () => string,
 }
@@ -36,19 +36,19 @@ export type ToQuery<T extends string | Query | undefined> = T extends string
       ? Query<'', {}>
       : T
 
-function isQuery(value: unknown): value is Query {
-  return isRecord(value) && typeof value.query === 'string'
+function isQuery(maybeQuery: unknown): maybeQuery is Query {
+  return isRecord(maybeQuery) && typeof maybeQuery.value === 'string'
 }
 
-export function toQuery<T extends string | Query | undefined>(value: T): ToQuery<T>
-export function toQuery<T extends string | Query | undefined>(value: T): Query {
-  if (value === undefined) {
-    return query('', {})
+export function toQuery<T extends string | Query | undefined>(query: T): ToQuery<T>
+export function toQuery<T extends string | Query | undefined>(query: T): Query {
+  if (query === undefined) {
+    return createQuery('', {})
   }
 
-  if (isQuery(value)) {
-    return value
+  if (isQuery(query)) {
+    return query
   }
 
-  return query(value, {})
+  return createQuery(query, {})
 }


### PR DESCRIPTION
When I created the `hash` utility I decided to use `hash.value` instead of `hash.hash` like we have on `path`, `host`, and `query`. It felt like a better name for the property that holds the string value of each. 

This PR updates `path`, `host`, and `query` to use "value" for this property to avoid `route.path.path`, `route.host.host`, and `route.query.query`.

Should have no impact on devex or actual router behavior