### PR TITLE
0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kitbag/router",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kitbag/router",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "history": "^5.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kitbag/router",
   "private": false,
-  "version": "0.9.0",
+  "version": "0.10.0",
   "bugs": {
     "url": "https://github.com/kitbagjs/router/issues"
   },


### PR DESCRIPTION
This PR publishes `hash` on route definition, and the minor syntax change on `path`, `query`, and `host` which I'll test in our demo repo