### PR TITLE
Add `context` to props callback, similar to hooks

### DIFF
--- a/src/components/routerView.browser.spec.ts
+++ b/src/components/routerView.browser.spec.ts
@@ -387,3 +387,91 @@ test('Updates props and attrs when route params change', async () => {
 
   expect(app.html()).toBe('async-bar')
 })
+
+test('Props from route can trigger push', async () => {
+
+  const routeA = createRoute({
+    name: 'routeA',
+    path: '/routeA',
+    component: echo,
+    props: (__, context) => {
+      throw context.push('routeB')
+    },
+  })
+
+  const routeB = createRoute({
+    name: 'routeB',
+    path: '/routeB',
+    component: echo,
+    props: () => ({
+      value: 'routeB',
+    }),
+  })
+
+  const router = createRouter([routeA, routeB], {
+    initialUrl: '/',
+  })
+
+  await router.initialized
+
+  const root = {
+    template: '<Suspense><RouterView/></Suspense>',
+  }
+
+  const app = mount(root, {
+    global: {
+      plugins: [router],
+    },
+  })
+
+  await router.push('/routeA')
+
+  // needed because of suspense
+  await flushPromises()
+
+  expect(app.html()).toBe('routeB')
+})
+
+test('Props from route can trigger reject', async () => {
+
+  const routeA = createRoute({
+    name: 'routeA',
+    path: '/routeA',
+    component: echo,
+    props: (__, context) => {
+      throw context.reject('NotFound')
+    },
+  })
+
+  const routeB = createRoute({
+    name: 'routeB',
+    path: '/routeB',
+    component: echo,
+    props: () => ({
+      value: 'routeB',
+    }),
+  })
+
+  const router = createRouter([routeA, routeB], {
+    initialUrl: '/',
+  })
+
+  await router.initialized
+
+  const root = {
+    template: '<Suspense><RouterView/></Suspense>',
+  }
+
+  const app = mount(root, {
+    global: {
+      plugins: [router],
+    },
+  })
+
+  await router.push('/routeA')
+
+  // needed because of suspense
+  await flushPromises()
+
+  expect(app.html()).toBe('<h1>NotFound</h1>')
+})

--- a/src/services/createCallbackContext.ts
+++ b/src/services/createCallbackContext.ts
@@ -1,0 +1,34 @@
+import { RouterPushError } from '@/errors/routerPushError'
+import { RouterRejectionError } from '@/errors/routerRejectionError'
+import { RegisteredRouterPush, RegisteredRouterReject, RegisteredRouterReplace } from '@/types/register'
+import { RouterPushOptions } from '@/types/routerPush'
+import { isUrl } from '@/types/url'
+
+export type CallbackContext = {
+  reject: RegisteredRouterReject,
+  push: RegisteredRouterPush,
+  replace: RegisteredRouterReplace,
+}
+
+export function createCallbackContext(): CallbackContext {
+  const reject: RegisteredRouterReject = (type) => {
+    throw new RouterRejectionError(type)
+  }
+
+  const push: RegisteredRouterPush = (...parameters: any[]) => {
+    throw new RouterPushError(parameters)
+  }
+
+  const replace: RegisteredRouterPush = (source: any, paramsOrOptions?: any, maybeOptions?: any) => {
+    if (isUrl(source)) {
+      const options: RouterPushOptions = paramsOrOptions ?? {}
+      throw new RouterPushError([source, { ...options, replace: true }])
+    }
+
+    const params = paramsOrOptions
+    const options: RouterPushOptions = maybeOptions ?? {}
+    throw new RouterPushError([source, params, { ...options, replace: true }])
+  }
+
+  return { reject, push, replace }
+}

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -1,4 +1,5 @@
 import { InjectionKey, reactive } from 'vue'
+import { CallbackContext, createCallbackContext } from '@/services/createCallbackContext'
 import { isWithComponent, isWithComponents } from '@/types/createRouteOptions'
 import { ResolvedRoute } from '@/types/resolved'
 import { Route } from '@/types/route'
@@ -6,7 +7,7 @@ import { MaybePromise } from '@/types/utilities'
 
 export const propStoreKey: InjectionKey<PropStore> = Symbol()
 
-type ComponentProps = { id: string, name: string, props?: (params: Record<string, unknown>) => unknown }
+type ComponentProps = { id: string, name: string, props?: (params: Record<string, unknown>, context: CallbackContext) => unknown }
 
 export type PropStore = {
   setProps: (route: ResolvedRoute) => void,
@@ -14,6 +15,7 @@ export type PropStore = {
 }
 
 export function createPropStore(): PropStore {
+  const context = createCallbackContext()
   const store = reactive(new Map<string, unknown>())
 
   function setProps(route: ResolvedRoute): void {
@@ -24,7 +26,7 @@ export function createPropStore(): PropStore {
       .forEach(({ id, name, props }) => {
         if (props) {
           const key = getPropKey(id, name, route.params)
-          const value = props(route.params)
+          const value = props(route.params, context)
 
           store.set(key, value)
         }

--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -5,6 +5,7 @@ import { combinePath } from '@/services/combinePath'
 import { combineQuery } from '@/services/combineQuery'
 import { combineState } from '@/services/combineState'
 import { ComponentProps } from '@/services/component'
+import { CallbackContext } from '@/services/createCallbackContext'
 import { Hash } from '@/types/hash'
 import { AfterRouteHook, BeforeRouteHook } from '@/types/hooks'
 import { Host } from '@/types/host'
@@ -63,7 +64,7 @@ export type WithComponent<
    * A Vue component, which can be either synchronous or asynchronous components.
    */
   component: TComponent,
-  props?: (params: TParams) => TComponent extends Component ? MaybePromise<ComponentProps<TComponent>> : {},
+  props?: (params: TParams, context: CallbackContext) => TComponent extends Component ? MaybePromise<ComponentProps<TComponent>> : {},
 }
 
 export function isWithComponent(options: CreateRouteOptions): options is CreateRouteOptions & WithComponent {
@@ -79,7 +80,7 @@ export type WithComponents<
    */
   components: TComponents,
   props?: {
-    [TKey in keyof TComponents]?: (params: TParams) => TComponents[TKey] extends Component ? MaybePromise<ComponentProps<TComponents[TKey]>> : {}
+    [TKey in keyof TComponents]?: (params: TParams, context: CallbackContext) => TComponents[TKey] extends Component ? MaybePromise<ComponentProps<TComponents[TKey]>> : {}
   },
 }
 

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,7 +1,7 @@
-import { RegisteredRejectionType, RegisteredRouterPush, RegisteredRouterReplace } from '@/types/register'
+import { CallbackContext } from '@/services/createCallbackContext'
+import { RegisteredRejectionType } from '@/types/register'
 import { ResolvedRoute } from '@/types/resolved'
 import { Routes } from '@/types/route'
-import { RouterReject } from '@/types/router'
 import { RouterPush } from '@/types/routerPush'
 import { MaybePromise } from '@/types/utilities'
 
@@ -29,10 +29,7 @@ export type RouteHookAbort = () => void
  */
 type RouteHookContext = {
   from: ResolvedRoute | null,
-  reject: RouterReject,
-  push: RegisteredRouterPush,
-  replace: RegisteredRouterReplace,
-}
+} & CallbackContext
 
 /**
  * Context provided to route hooks, containing context of previous route and functions for triggering rejections, push/replace to another route,

--- a/src/types/register.ts
+++ b/src/types/register.ts
@@ -43,6 +43,11 @@ export type RegisteredRejectionType = Register extends { router: Router<Routes, 
   : BuiltInRejectionType
 
 /**
+ * Type for Router Reject method. Triggers rejections registered within {@link Register}
+ */
+export type RegisteredRouterReject = (type: RegisteredRejectionType) => void
+
+/**
  * Represents additional metadata associated with a route, customizable via declaration merging.
  */
 export type RouteMeta = Register extends { routeMeta: infer RouteMeta extends Record<string, unknown> }

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -4,14 +4,12 @@ import { RouterResolve } from '@/services/createRouterResolve'
 import { RouterRoute } from '@/services/createRouterRoute'
 import { AddAfterRouteHook, AddBeforeRouteHook } from '@/types/hooks'
 import { PrefetchConfig } from '@/types/prefetch'
-import { RegisteredRejectionType } from '@/types/register'
+import { RegisteredRouterReject } from '@/types/register'
 import { ResolvedRoute } from '@/types/resolved'
 import { Routes } from '@/types/route'
 import { RouterFind } from '@/types/routerFind'
 import { RouterPush } from '@/types/routerPush'
 import { RouterReplace } from '@/types/routerReplace'
-
-export type RouterReject = (type: RegisteredRejectionType) => void
 
 /**
  * Options to initialize a {@link Router} instance.
@@ -72,7 +70,7 @@ export type Router<
   /**
    * Handles route rejection based on a specified rejection type.
    */
-  reject: RouterReject,
+  reject: RegisteredRouterReject,
   /**
    * Forces the router to re-evaluate the current route.
    */


### PR DESCRIPTION
This PR extends the useful functionality of triggering `push`, `replace`, and `reject` from `hooks` into the `props` callback.

Fundamentally the approach is the same, if a callback wants to use these methods it will actually throw a specific type of exception. So I wrapped the `setProps` call in `createRouter` in a try catch so that if the developers props callback throws one of these errors the router can perform the expected task.

Since the approach was the same as hooks I decided to extract the logic from hooks into a `createCallbackContext()` service used by both.

As a side quest this PR also moves and renames `RouterReject` from `Router.ts` to `RegisteredRouterReject` in `Register.ts` since it actually assumes the types for rejection are the registered rejections. 