### PR TITLE
Remove requirement on `<Suspense>`  for async component props

### DIFF
--- a/src/components/routerView.browser.spec.ts
+++ b/src/components/routerView.browser.spec.ts
@@ -128,7 +128,7 @@ test('resolves async components', async () => {
   })
 
   const root = {
-    template: '<suspense><RouterView/></suspense>',
+    template: '<RouterView/>',
   }
 
   const app = mount(root, {
@@ -311,7 +311,7 @@ test('Binds props and attrs from route', async () => {
   await router.initialized
 
   const root = {
-    template: '<Suspense><RouterView/></Suspense>',
+    template: '<RouterView/>',
   }
 
   const app = mount(root, {
@@ -325,9 +325,6 @@ test('Binds props and attrs from route', async () => {
   expect(app.html()).toBe('hello')
 
   await router.push('/routeB/world')
-
-  // needed because of suspense
-  await flushPromises()
 
   expect(app.html()).toBe('world')
 })
@@ -358,7 +355,7 @@ test('Updates props and attrs when route params change', async () => {
   await router.initialized
 
   const root = {
-    template: '<Suspense><RouterView/></Suspense>',
+    template: '<RouterView/>',
   }
 
   const app = mount(root, {

--- a/src/services/component.browser.spec.ts
+++ b/src/services/component.browser.spec.ts
@@ -18,7 +18,6 @@ test('renders component with sync props', async () => {
 
   await router.initialized
 
-  // purposefully not using suspense here to make sure sync props doesn't require suspense
   const root = {
     template: '<RouterView/>',
   }
@@ -50,7 +49,7 @@ test('renders component with async props', async () => {
   await router.initialized
 
   const root = {
-    template: '<Suspense><RouterView/></Suspense>',
+    template: '<RouterView/>',
   }
 
   const app = mount(root, {
@@ -61,7 +60,7 @@ test('renders component with async props', async () => {
 
   await router.push('echo')
 
-  // needed because of suspense
+  // needed for async props
   await flushPromises()
 
   expect(app.html()).toBe('echo')

--- a/src/services/component.ts
+++ b/src/services/component.ts
@@ -1,5 +1,5 @@
 /* eslint-disable vue/one-component-per-file */
-import { AsyncComponentLoader, Component, FunctionalComponent, defineComponent, h } from 'vue'
+import { AsyncComponentLoader, Component, FunctionalComponent, defineComponent, h, ref } from 'vue'
 import { MaybePromise } from '@/types/utilities'
 
 type Constructor = new (...args: any) => any
@@ -52,10 +52,21 @@ function asyncPropsWrapper<TComponent extends Component>(component: TComponent, 
   return defineComponent({
     name: 'AsyncPropsWrapper',
     expose: [],
-    async setup() {
-      const values = await props
+    setup() {
+      const values = ref()
 
-      return () => h(component, values)
+      // eslint-disable-next-line semi-style
+      ;(async () => {
+        values.value = await props
+      })()
+
+      return () => {
+        if (values.value) {
+          return h(component, values.value)
+        }
+
+        return ''
+      }
     },
   })
 }


### PR DESCRIPTION
# Description
When working on https://github.com/kitbagjs/router/pull/278 I noticed some `Suspense` warnings.

```
<Suspense> is an experimental feature and its API will likely change.
```

I started out attempting to just silence these. But researching more I'm not sure we even need to use suspense. You do not need to use suspense for async components. Its optional and only needs to be used for loading/error states. 

You do however seem to need `Suspense` when using `async setup`. Which we were using in the `AsyncPropsWrapper`. But we don't have to. Rewriting that component to not need top level await removes the need for `Suspense` altogether. 

I'm not 100% sure if this removes the possibility for leveraging `Suspense` for loading states. But we haven't really proved out some of those ideas around `Suspense` anyway. So removing the requirement of using `Suspense` seems like a good thing at least for now. 