### PR TITLE
Delay initializing the router until it is installed or manually started

### DIFF
--- a/docs/api/types/Router.md
+++ b/docs/api/types/Router.md
@@ -38,13 +38,13 @@ go: (delta: number) => void;
 
 Moves the current history entry to a specific point in the history stack.
 
-### initialized
+### start
 
 ```ts
-initialized: Promise<void>;
+start: () => Promise<void>;
 ```
 
-A promise that resolves when the router is fully initialized.
+Initializes the router based on the initial route. Automatically called when the router is installed. Calling this more than once has no effect.
 
 ### isExternal
 

--- a/src/components/routerLink.browser.spec.ts
+++ b/src/components/routerLink.browser.spec.ts
@@ -61,7 +61,7 @@ test.each([
     initialUrl: '/routeA',
   })
 
-  await router.initialized
+  await router.start()
 
   const spy = vi.spyOn(router, 'push')
 
@@ -150,7 +150,7 @@ test('when current route matches descendant, parent has "match" class', async ()
     },
   })
 
-  await router.initialized
+  await router.start()
 
   const anchor = wrapper.find('a')
   expect(anchor.classes()).toContain('router-link--match')
@@ -186,7 +186,7 @@ test('when current route matches to prop, parent has "match" and "exact-match" c
     },
   })
 
-  await router.initialized
+  await router.start()
 
   const anchor = wrapper.find('a')
   expect(anchor.classes()).toContain('router-link--match')
@@ -225,7 +225,7 @@ test.each([
     },
   })
 
-  await router.initialized
+  await router.start()
 
   const anchor = wrapper.find('a')
   const element = anchor.element as HTMLAnchorElement

--- a/src/components/routerView.browser.spec.ts
+++ b/src/components/routerView.browser.spec.ts
@@ -19,7 +19,7 @@ test('renders component for initial route', async () => {
     initialUrl: '/',
   })
 
-  await router.initialized
+  await router.start()
 
   const root = {
     template: '<RouterView/>',
@@ -51,7 +51,7 @@ test('renders components for initial route', async () => {
     initialUrl: '/parent/child',
   })
 
-  await router.initialized
+  await router.start()
 
   const root = {
     template: '<RouterView />',
@@ -99,7 +99,7 @@ test('updates components when route changes', async () => {
     },
   })
 
-  await router.initialized
+  await router.start()
 
   expect(app.html()).toBe('Foo')
 
@@ -137,7 +137,7 @@ test('resolves async components', async () => {
     },
   })
 
-  await router.initialized
+  await router.start()
   await flushPromises()
 
   expect(app.html()).toBe(helloWorld.template)
@@ -148,7 +148,7 @@ test('Renders the genericRejection component when the initialUrl does not match'
     initialUrl: '/does-not-exist',
   })
 
-  await router.initialized
+  await router.start()
 
   const root = {
     template: '<RouterView/>',
@@ -172,7 +172,7 @@ test('Renders custom genericRejection component when the initialUrl does not mat
     },
   })
 
-  await router.initialized
+  await router.start()
 
   const root = {
     template: '<RouterView/>',
@@ -205,7 +205,7 @@ test('Renders the NotFound component when the router.push does not match', async
     initialUrl: '/',
   })
 
-  await router.initialized
+  await router.start()
 
   const root = {
     template: '<RouterView/>',
@@ -233,7 +233,7 @@ test('Renders the route component when the router.push does match after a reject
     initialUrl: '/does-not-exist',
   })
 
-  await router.initialized
+  await router.start()
 
   const root = {
     template: '<RouterView/>',
@@ -267,7 +267,7 @@ test('Renders the multiple components when using named route views', async () =>
     initialUrl: '/',
   })
 
-  await router.initialized
+  await router.start()
 
   const root = {
     template: `
@@ -308,7 +308,7 @@ test('Binds props and attrs from route', async () => {
     initialUrl: '/',
   })
 
-  await router.initialized
+  await router.start()
 
   const root = {
     template: '<Suspense><RouterView/></Suspense>',
@@ -355,7 +355,7 @@ test('Updates props and attrs when route params change', async () => {
     initialUrl: '/',
   })
 
-  await router.initialized
+  await router.start()
 
   const root = {
     template: '<Suspense><RouterView/></Suspense>',

--- a/src/compositions/useRoute.browser.spec.ts
+++ b/src/compositions/useRoute.browser.spec.ts
@@ -10,7 +10,7 @@ test('when given no routeKey returns the router route', async () => {
     initialUrl: '/routeA',
   })
 
-  await router.initialized
+  await router.start()
 
   const component = {
     template: '',
@@ -35,7 +35,7 @@ test('when given a routeKey that matches the current route returns the router ro
     initialUrl: '/parentB',
   })
 
-  await router.initialized
+  await router.start()
 
   const component = {
     template: '',
@@ -60,7 +60,7 @@ test('when given a routeKey that matches exactly the current route returns the r
     initialUrl: '/parentA/parentAParam/childAParam',
   })
 
-  await router.initialized
+  await router.start()
 
   const component = {
     template: '',
@@ -85,7 +85,7 @@ test('when given a routeKey that does not match the current route throws an erro
     initialUrl: '/parentB',
   })
 
-  await router.initialized
+  await router.start()
 
   const component = {
     template: '',
@@ -112,7 +112,7 @@ test('when given a routeKey that does not match exactly the current route throws
     initialUrl: '/parentA/parentAParam/childAParam',
   })
 
-  await router.initialized
+  await router.start()
 
   const component = {
     template: '',

--- a/src/services/component.browser.spec.ts
+++ b/src/services/component.browser.spec.ts
@@ -16,7 +16,7 @@ test('renders component with sync props', async () => {
     initialUrl: '/',
   })
 
-  await router.initialized
+  await router.start()
 
   // purposefully not using suspense here to make sure sync props doesn't require suspense
   const root = {
@@ -47,7 +47,7 @@ test('renders component with async props', async () => {
     initialUrl: '/',
   })
 
-  await router.initialized
+  await router.start()
 
   const root = {
     template: '<Suspense><RouterView/></Suspense>',

--- a/src/services/createRouter.browser.spec.ts
+++ b/src/services/createRouter.browser.spec.ts
@@ -1,0 +1,34 @@
+import { mount } from '@vue/test-utils'
+import { expect, test } from 'vitest'
+import { createRoute } from '@/services/createRoute'
+import { createRouter } from '@/services/createRouter'
+import { component } from '@/utilities/testHelpers'
+
+test('Router is automatically started when installed', async () => {
+  const route = createRoute({
+    name: 'root',
+    path: '/',
+    component,
+  })
+
+  const router = createRouter([route], {
+    initialUrl: '/',
+  })
+
+  const root = {
+    template: '<RouterView/>',
+  }
+
+  expect(router.route.name).toBe('NotFound')
+
+  mount(root, {
+    global: {
+      plugins: [router],
+    },
+  })
+
+  await router.start()
+
+  expect(router.route.name).toBe('root')
+
+})

--- a/src/services/createRouter.spec.ts
+++ b/src/services/createRouter.spec.ts
@@ -7,7 +7,7 @@ import { createRoute } from '@/services/createRoute'
 import { createRouter } from '@/services/createRouter'
 import * as createRouterHistoryUtilities from '@/services/createRouterHistory'
 import * as resolveUtilities from '@/services/createRouterResolve'
-import { component, routes } from '@/utilities/testHelpers'
+import { component } from '@/utilities/testHelpers'
 
 test('initial route is set', async () => {
   const foo = createRoute({

--- a/src/services/createRouter.spec.ts
+++ b/src/services/createRouter.spec.ts
@@ -7,7 +7,7 @@ import { createRoute } from '@/services/createRoute'
 import { createRouter } from '@/services/createRouter'
 import * as createRouterHistoryUtilities from '@/services/createRouterHistory'
 import * as resolveUtilities from '@/services/createRouterResolve'
-import { component } from '@/utilities/testHelpers'
+import { component, routes } from '@/utilities/testHelpers'
 
 test('initial route is set', async () => {
   const foo = createRoute({
@@ -272,4 +272,22 @@ test('given an array of Routes with duplicate names, throws ', () => {
   })
 
   expect(action).toThrow(DuplicateNamesError)
+})
+
+test('initial route is not set until the router is started', async () => {
+  const route = createRoute({
+    name: 'root',
+    path: '/',
+    component,
+  })
+
+  const router = createRouter([route], {
+    initialUrl: '/',
+  })
+
+  expect(router.route.name).toBe('NotFound')
+
+  await router.start()
+
+  expect(router.route.name).toBe('root')
 })

--- a/src/services/createRouter.spec.ts
+++ b/src/services/createRouter.spec.ts
@@ -16,11 +16,11 @@ test('initial route is set', async () => {
     path: '/',
   })
 
-  const { route, initialized } = createRouter([foo], {
+  const { route, start } = createRouter([foo], {
     initialUrl: '/',
   })
 
-  await initialized
+  await start()
 
   expect(route.matched.name).toBe('root')
 })
@@ -47,11 +47,11 @@ test('initial state is set', async () => {
     state: { zoo: Number },
   })
 
-  const { route, initialized } = createRouter([foo], {
+  const { route, start } = createRouter([foo], {
     initialUrl: '/',
   })
 
-  await initialized
+  await start()
 
   expect(route.state).toMatchObject({ zoo: 123 })
 })
@@ -77,11 +77,11 @@ test('updates the route when navigating', async () => {
     }),
   ]
 
-  const { push, route, initialized } = createRouter(routes, {
+  const { push, route, start } = createRouter(routes, {
     initialUrl: '/first',
   })
 
-  await initialized
+  await start()
 
   await push('first', {}, { state: { foo: 123 } })
 
@@ -104,7 +104,7 @@ test('route update updates the current route', async () => {
     initialUrl: '/one',
   })
 
-  await router.initialized
+  await router.start()
 
   await router.route.update('param', 'two')
 
@@ -127,11 +127,11 @@ test.fails('route is readonly except for individual params', async () => {
     }),
   ]
 
-  const { route, initialized } = createRouter(routes, {
+  const { route, start } = createRouter(routes, {
     initialUrl: '/',
   })
 
-  await initialized
+  await start()
 
   // @ts-expect-error
   route.name = 'child'
@@ -159,11 +159,11 @@ test('individual params are writable', async () => {
     }),
   ]
 
-  const { route, initialized } = createRouter(routes, {
+  const { route, start } = createRouter(routes, {
     initialUrl: '/one',
   })
 
-  await initialized
+  await start()
 
   route.params.param = 'goodbye'
 
@@ -197,11 +197,11 @@ test('individual params are writable when using toRefs', async () => {
     }),
   ]
 
-  const { route, initialized } = createRouter(routes, {
+  const { route, start } = createRouter(routes, {
     initialUrl: '/one',
   })
 
-  await initialized
+  await start()
 
   const { param } = toRefs(route.params)
 
@@ -220,11 +220,11 @@ test('setting an unknown param does not add its value to the route', async () =>
       path: '/',
     }),
   ]
-  const { route, initialized } = createRouter(routes, {
+  const { route, start } = createRouter(routes, {
     initialUrl: '/',
   })
 
-  await initialized
+  await start()
 
   // @ts-expect-error
   route.params.nothing = 'nothing'
@@ -256,7 +256,6 @@ test('given an array of Routes, combines into single routes collection', () => {
     ...bRoutes,
   ])
 })
-
 
 test('given an array of Routes with duplicate names, throws ', () => {
   const aRoutes = [

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -214,7 +214,18 @@ export function createRouter<const TRoutes extends Routes, const TOptions extend
   const initialState = history.location.state
   const { host } = createMaybeRelativeUrl(initialUrl)
   const isExternal = createIsExternal(host)
-  const initialized = set(initialUrl, { replace: true, state: initialState })
+
+  let initialized = false
+
+  async function start(): Promise<void> {
+    if (initialized) {
+      return
+    }
+
+    await set(initialUrl, { replace: true, state: initialState })
+
+    initialized = true
+  }
 
   function getRoute(name: string): Route | undefined {
     return routes.find(route => route.name === name)
@@ -230,6 +241,8 @@ export function createRouter<const TRoutes extends Routes, const TOptions extend
     // We cant technically guarantee that the user registered the same router that they installed
     // So we're making an assumption here that when installing a router its the same as the RegisteredRouter
     app.provide(routerInjectionKey, router as any)
+
+    start()
   }
 
   const router: Router<TRoutes> = {
@@ -244,7 +257,6 @@ export function createRouter<const TRoutes extends Routes, const TOptions extend
     back: history.back,
     go: history.go,
     install,
-    initialized,
     isExternal,
     onBeforeRouteEnter,
     onAfterRouteUpdate,
@@ -253,6 +265,7 @@ export function createRouter<const TRoutes extends Routes, const TOptions extend
     onBeforeRouteUpdate,
     onAfterRouteLeave,
     prefetch: options?.prefetch,
+    start,
   }
 
   return router

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -114,10 +114,6 @@ export type Router<
    */
   onAfterRouteUpdate: AddAfterRouteHook,
   /**
-   * A promise that resolves when the router is fully initialized.
-   */
-  initialized: Promise<void>,
-  /**
   * Given a URL, returns true if host does not match host stored on router instance
   */
   isExternal: (url: string) => boolean,
@@ -125,6 +121,10 @@ export type Router<
    * Determines what assets are prefetched.
    */
   prefetch?: PrefetchConfig,
+  /**
+   * Initializes the router based on the initial route. Automatically called when the router is installed. Calling this more than once has no effect.
+   */
+  start: () => Promise<void>,
 }
 
 /**


### PR DESCRIPTION
# Description
Because global hooks need to be defined on the router AFTER it is created it is problematic that the initial route is set immediately on creation. This can cause race conditions and import issues with other modules. 

By replacing the `initialized` property of the router with a `start` method and then automatically calling `start` when the router is installed we can make sure that the user is able to define global hooks and have them run on that initial route while avoiding module errors. 

Closes https://github.com/kitbagjs/router/issues/269