### PR TITLE
Update the props store to support prefetching

### DIFF
--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -8,14 +8,14 @@ export const propStoreKey: InjectionKey<PropStore> = Symbol()
 type ComponentProps = { id: string, name: string, props?: (params: Record<string, unknown>) => unknown }
 
 export type PropStore = {
-  setProps: (route: ResolvedRoute, options: { prefetched: boolean }) => void,
+  setProps: (route: ResolvedRoute, options: { prefetch: boolean }) => void,
   getProps: (id: string, name: string, params: Record<string, unknown>) => unknown,
 }
 
 export function createPropStore(): PropStore {
   const store: Map<string, unknown> = reactive(new Map())
 
-  const setProps: PropStore['setProps'] = (route, { prefetched }) => {
+  const setProps: PropStore['setProps'] = (route, { prefetch }) => {
     const routeKeys: string[] = []
     const componentProps = route.matches.flatMap(match => getComponentProps(match))
 
@@ -38,7 +38,7 @@ export function createPropStore(): PropStore {
     }
 
     // if props are being prefetched then we return early and don't clear out any other props
-    if (prefetched) {
+    if (prefetch) {
       return
     }
 

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -25,16 +25,13 @@ export function createPropStore(): PropStore {
       }
 
       const key = getPropKey(id, name, route.params)
+      routeKeys.push(key)
 
       if (store.has(key)) {
         continue
       }
 
-      const value = props(route.params)
-
-      store.set(key, value)
-
-      routeKeys.push(key)
+      store.set(key, props(route.params))
     }
 
     // if props are being prefetched then we return early and don't clear out any other props

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -123,7 +123,7 @@ export function createRouter<const TRoutes extends Routes, const TOptions extend
         throw new Error(`Switch is not exhaustive for before hook response status: ${JSON.stringify(beforeResponse satisfies never)}`)
     }
 
-    propStore.setProps(to)
+    propStore.setProps(to, { prefetched: false })
 
     updateRoute(to)
 

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -123,7 +123,7 @@ export function createRouter<const TRoutes extends Routes, const TOptions extend
         throw new Error(`Switch is not exhaustive for before hook response status: ${JSON.stringify(beforeResponse satisfies never)}`)
     }
 
-    propStore.setProps(to, { prefetched: false })
+    propStore.setProps(to, { prefetch: false })
 
     updateRoute(to)
 


### PR DESCRIPTION
# Description
WIP attempt at updating the props store to allow for prefetching. Updates the `setProps` method to accept a `prefetch` boolean and attempts to accurately clear stale props from the store. 

When `prefetch` is `true` props will be put into the store and then we exit. If `prefetch` is `false` then after putting props into the store we then go delete any props from the store that do not match the route that was passed in. 

In both cases if a key already exists in the store we do not execute the prop callback for that match. If a key already exists then it was prefetched and shouldn't be fetched again. 

@stackoverfloweth hopefully this aligns more with the mental model you had in mind for the props store and prefetching in general. 

Note: This doesn't fix the issue with a single boolean not accurately reflecting the fact that a route has multiple matches and each match might have a different prefetch value for props. The `prefetch` option might need to include a callback to determine if the current match should prefetch props based on the `PrefetchConfigs` for that match.