### PR TITLE
Update prop store to support prefetching

### DIFF
--- a/src/components/routerView.vue
+++ b/src/components/routerView.vue
@@ -51,7 +51,7 @@
     }
 
     const component = getComponent(match)
-    const props = getProps(match.id, name, route.params)
+    const props = getProps(match.id, name, route)
 
     if (!component) {
       return null

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -8,14 +8,14 @@ export const propStoreKey: InjectionKey<PropStore> = Symbol()
 type ComponentProps = { id: string, name: string, props?: (params: Record<string, unknown>) => unknown }
 
 export type PropStore = {
-  setProps: (route: ResolvedRoute, options: { prefetched: boolean }) => void,
+  setProps: (route: ResolvedRoute, options: { prefetch: boolean }) => void,
   getProps: (id: string, name: string, params: Record<string, unknown>) => unknown,
 }
 
 export function createPropStore(): PropStore {
   const store: Map<string, unknown> = reactive(new Map())
 
-  const setProps: PropStore['setProps'] = (route, { prefetched }) => {
+  const setProps: PropStore['setProps'] = (route, { prefetch }) => {
     const routeKeys: string[] = []
     const componentProps = route.matches.flatMap(match => getComponentProps(match))
 
@@ -38,7 +38,7 @@ export function createPropStore(): PropStore {
     }
 
     // if props are being prefetched then we return early and don't clear out any other props
-    if (prefetched) {
+    if (prefetch) {
       return
     }
 

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -20,7 +20,7 @@ export function createPropStore(): PropStore {
 
   const prefetchProps: PropStore['prefetchProps'] = (route, prefetch) => {
     route.matches
-      .filter(match => getPrefetchOption({ ...prefetch, routePrefetch: match.prefetch }, 'components'))
+      .filter(match => getPrefetchOption({ ...prefetch, routePrefetch: match.prefetch }, 'props'))
       .flatMap(getComponentProps)
       .forEach(({ id, name, props }) => {
         if (props) {

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -43,8 +43,9 @@ export function createPropStore(): PropStore {
       const value = props(route.params)
 
       store.set(key, value)
+      routeKeys.push(key)
 
-      return [...routeKeys, key]
+      return routeKeys
     }, [])
 
     clearUnusedStoreEntries(routeKeys)

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -1,5 +1,6 @@
 import { InjectionKey, reactive } from 'vue'
 import { isWithComponent, isWithComponents } from '@/types/createRouteOptions'
+import { getPrefetchOption, PrefetchConfigs } from '@/types/prefetch'
 import { ResolvedRoute } from '@/types/resolved'
 import { Route } from '@/types/route'
 
@@ -9,7 +10,7 @@ type ComponentProps = { id: string, name: string, props?: (params: Record<string
 type PropStoreEntry = { prefetched: boolean, value: unknown }
 
 export type PropStore = {
-  prefetchProps: (route: ResolvedRoute) => void,
+  prefetchProps: (route: ResolvedRoute, prefetch: PrefetchConfigs) => void,
   setProps: (route: ResolvedRoute) => void,
   getProps: (id: string, name: string, params: Record<string, unknown>) => unknown,
 }
@@ -17,9 +18,9 @@ export type PropStore = {
 export function createPropStore(): PropStore {
   const store: Map<string, PropStoreEntry> = reactive(new Map())
 
-  const prefetchProps: PropStore['prefetchProps'] = (route) => {
+  const prefetchProps: PropStore['prefetchProps'] = (route, prefetch) => {
     route.matches
-      .filter(match => match.prefetch !== false)
+      .filter(match => getPrefetchOption({ ...prefetch, routePrefetch: match.prefetch }, 'components'))
       .flatMap(getComponentProps)
       .forEach(({ id, name, props }) => {
         if (props) {

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -25,16 +25,13 @@ export function createPropStore(): PropStore {
       }
 
       const key = getPropKey(id, name, route.params)
+      routeKeys.push(key)
 
       if (store.has(key)) {
         continue
       }
 
-      const value = props(route.params)
-
-      store.set(key, value)
-
-      routeKeys.push(key)
+      store.set(key, props(route.params))
     }
 
     // if props are being prefetched then we return early and don't clear out any other props

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -123,7 +123,7 @@ export function createRouter<const TRoutes extends Routes, const TOptions extend
         throw new Error(`Switch is not exhaustive for before hook response status: ${JSON.stringify(beforeResponse satisfies never)}`)
     }
 
-    propStore.setProps(to, { prefetch: false })
+    propStore.setProps(to)
 
     updateRoute(to)
 

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -123,7 +123,7 @@ export function createRouter<const TRoutes extends Routes, const TOptions extend
         throw new Error(`Switch is not exhaustive for before hook response status: ${JSON.stringify(beforeResponse satisfies never)}`)
     }
 
-    propStore.setProps(to)
+    propStore.setProps(to, { prefetched: false })
 
     updateRoute(to)
 

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -123,7 +123,7 @@ export function createRouter<const TRoutes extends Routes, const TOptions extend
         throw new Error(`Switch is not exhaustive for before hook response status: ${JSON.stringify(beforeResponse satisfies never)}`)
     }
 
-    propStore.setProps(to, { prefetched: false })
+    propStore.setProps(to, { prefetch: false })
 
     updateRoute(to)
 

--- a/src/types/prefetch.ts
+++ b/src/types/prefetch.ts
@@ -17,7 +17,7 @@ export const DEFAULT_PREFETCH_CONFIG: Required<PrefetchConfigOptions> = {
   components: true,
 }
 
-type PrefetchConfigs = {
+export type PrefetchConfigs = {
   routerPrefetch: PrefetchConfig | undefined,
   routePrefetch: PrefetchConfig | undefined,
   linkPrefetch: PrefetchConfig | undefined,

--- a/src/types/prefetch.ts
+++ b/src/types/prefetch.ts
@@ -6,6 +6,11 @@ export type PrefetchConfigOptions = {
    * @default true
    */
   components?: boolean,
+  /**
+   * When true any props for routes will be prefetched
+   * @default false
+   */
+  props?: boolean,
 }
 
 /**
@@ -15,6 +20,7 @@ export type PrefetchConfig = boolean | PrefetchConfigOptions
 
 export const DEFAULT_PREFETCH_CONFIG: Required<PrefetchConfigOptions> = {
   components: true,
+  props: false,
 }
 
 export type PrefetchConfigs = {


### PR DESCRIPTION
this PR is my pass at solving the same problems as [this PR](https://github.com/kitbagjs/router/pull/281).

most notably
- moves from an option `prefetch: true` to separate methods because the implementations are considerably different
- updates the store type to put `prefetched: true` on each store entry
- ensures that matches that have `prefetch: false` in their route definition will not be prefetched even when the parent tries to