### PR TITLE
Abstract more of router-link into useLink

### DIFF
--- a/src/components/routerLink.browser.spec.ts
+++ b/src/components/routerLink.browser.spec.ts
@@ -79,7 +79,7 @@ test.each([
 
   const [, options] = spy.mock.lastCall ?? []
 
-  expect(options).toMatchObject({ replace, query: undefined })
+  expect(options).toMatchObject({ replace })
 })
 
 test('to prop as string renders and routes correctly', () => {

--- a/src/components/routerLink.vue
+++ b/src/components/routerLink.vue
@@ -52,20 +52,16 @@
     return options
   })
 
-  const { href, isMatch, isExactMatch } = useLink(resolved, options)
+  const { isMatch, isExactMatch, isExternal, push } = useLink(resolved, options)
 
   const classes = computed(() => ({
     'router-link--match': isMatch.value,
     'router-link--exact-match': isExactMatch.value,
   }))
 
-  const isExternal = computed(() => {
-    return router.isExternal(resolved.value)
-  })
-
   function onClick(event: MouseEvent): void {
     event.preventDefault()
 
-    router.push(href.value, options.value)
+    push()
   }
 </script>

--- a/src/compositions/useLink.ts
+++ b/src/compositions/useLink.ts
@@ -1,4 +1,4 @@
-import { ComputedRef, MaybeRefOrGetter, Ref, computed, toRef, toValue, watch } from 'vue'
+import { ComputedRef, MaybeRefOrGetter, computed, toRef, toValue, watch } from 'vue'
 import { useRouter } from '@/compositions/useRouter'
 import { InvalidRouteParamValueError } from '@/errors/invalidRouteParamValueError'
 import { RouterResolveOptions } from '@/services/createRouterResolve'


### PR DESCRIPTION
# Description
Since `useLink` should contain everything necessary to create a link without using `router-link` I'm moving more of the logic from `router-link` into `useLink`. This makes `useLink` more useful and `router-link` simpler.