### PR TITLE
Add `usePrefetching` composition to abstract prefetching logic out of `useLink`

### DIFF
--- a/src/compositions/useLink.ts
+++ b/src/compositions/useLink.ts
@@ -1,11 +1,9 @@
-import { ComputedRef, MaybeRefOrGetter, computed, toRef, toValue, watch } from 'vue'
+import { ComputedRef, MaybeRefOrGetter, computed, toRef, toValue } from 'vue'
 import { usePrefetching } from '@/compositions/usePrefetching'
-import { usePropStore } from '@/compositions/usePropStore'
 import { useRouter } from '@/compositions/useRouter'
 import { InvalidRouteParamValueError } from '@/errors/invalidRouteParamValueError'
 import { RouterResolveOptions } from '@/services/createRouterResolve'
-import { isWithComponent, isWithComponents } from '@/types/createRouteOptions'
-import { PrefetchConfig, PrefetchConfigs, getPrefetchOption } from '@/types/prefetch'
+import { PrefetchConfig } from '@/types/prefetch'
 import { RegisteredRoutes, RegisteredRoutesName } from '@/types/register'
 import { ResolvedRoute } from '@/types/resolved'
 import { RouterPushOptions } from '@/types/routerPush'
@@ -13,7 +11,6 @@ import { RouterReplaceOptions } from '@/types/routerReplace'
 import { RouteParamsByKey } from '@/types/routeWithParams'
 import { Url, isUrl } from '@/types/url'
 import { AllPropertiesAreOptional } from '@/types/utilities'
-import { isAsyncComponent } from '@/utilities/components'
 
 export type UseLink = {
   /**

--- a/src/compositions/usePrefetching.ts
+++ b/src/compositions/usePrefetching.ts
@@ -1,0 +1,66 @@
+import { MaybeRefOrGetter, toValue, watch } from 'vue'
+import { usePropStore } from '@/compositions/usePropStore'
+import { isWithComponent, isWithComponents } from '@/types/createRouteOptions'
+import { getPrefetchOption, PrefetchConfigs } from '@/types/prefetch'
+import { ResolvedRoute } from '@/types/resolved'
+import { isAsyncComponent } from '@/utilities/components'
+
+type UsePrefetchingConfig = PrefetchConfigs & {
+  route: ResolvedRoute | undefined,
+}
+
+type UsePrefetching = {
+  commit: () => void,
+}
+
+export function usePrefetching(config: MaybeRefOrGetter<UsePrefetchingConfig>): UsePrefetching {
+  let props: Record<string, unknown> = {}
+
+  const { getPrefetchProps, setPrefetchProps } = usePropStore()
+
+  watch(() => toValue(config), ({ route, ...configs }) => {
+    if (!route) {
+      return
+    }
+
+    prefetchComponentsForRoute(route, configs)
+
+    props = getPrefetchProps(route, configs)
+  }, { immediate: true })
+
+  const commit: UsePrefetching['commit'] = () => {
+    setPrefetchProps(props)
+  }
+
+  return {
+    commit,
+  }
+}
+
+function prefetchComponentsForRoute(route: ResolvedRoute, { routerPrefetch, linkPrefetch }: PrefetchConfigs): void {
+
+  route.matches.forEach(route => {
+    const shouldPrefetchComponents = getPrefetchOption({
+      routePrefetch: route.prefetch,
+      routerPrefetch,
+      linkPrefetch,
+    }, 'components')
+
+    if (!shouldPrefetchComponents) {
+      return
+    }
+
+    if (isWithComponent(route) && isAsyncComponent(route.component)) {
+      route.component.setup()
+    }
+
+    if (isWithComponents(route)) {
+      Object.values(route.components).forEach(component => {
+        if (isAsyncComponent(component)) {
+          component.setup()
+        }
+      })
+    }
+  })
+
+}


### PR DESCRIPTION
# Description
Gives us a place to iterate on prefetching logic. Keeps `useLink` clear of prefetching logic. 

Duplicate of https://github.com/kitbagjs/router/pull/288