### PR TITLE
add missing docs for hash on route definition

### DIFF
--- a/docs/advanced-concepts/route-matching.md
+++ b/docs/advanced-concepts/route-matching.md
@@ -138,4 +138,5 @@ const route {
 If there are more than 1 routes that pass the rules then we sort the results by the following.
 
 1. **Route Depth:** prioritize routes that are more deeply nested
-2. **Optional Params:** prioritize routes that match the greater number of optional path and query params
+1. **Optional Params:** prioritize routes that match the greater number of optional path and query params
+2. **Matching Hash:** prioritize routes that match have a static hash that matches the URL hash.

--- a/docs/api/components/RouterLink.md
+++ b/docs/api/components/RouterLink.md
@@ -8,6 +8,7 @@ RouterLink component renders anchor tag (`<a>`) for routing both within the SPA 
 | :---- | :---- |
 | to | [`Url`](/api/types/Url) \| `(resolve: RouterResolve) => Url` |
 | query | `Record<string, string>` \| `undefined` |
+| hash | `string` \| `undefined` |
 | replace | `boolean` \| `undefined` |
 | prefetch | `boolean` \| `PrefetchConfigOptions` \| `undefined` |
 

--- a/docs/api/types/Route.md
+++ b/docs/api/types/Route.md
@@ -13,6 +13,7 @@ Represents the structure of a route within the application. Return value of `cre
 | `TName` *extends* `string` \| `undefined` | `string` | Represents the unique name identifying the route, typically a string. |
 | `TPath` *extends* `string` \| `Path` | `Path` | The type or structure of the route's path. |
 | `TQuery` *extends* `string` \| `Query` \| `undefined` | `Query` | The type or structure of the query parameters associated with the route. |
+| `THash` *extends* `string` \| `Hash` \| `undefined` | The type or structure of the static hash associated with the route. |
 
 ## Type declaration
 
@@ -62,6 +63,14 @@ query: ToQuery<TQuery>;
 ```
 
 Represents the structured query of the route, including query params.
+
+### hash
+
+```ts
+hash: ToHash<THash>;
+```
+
+Represents the hash of the route.
 
 ### prefetch
 

--- a/docs/core-concepts/defining-routes.md
+++ b/docs/core-concepts/defining-routes.md
@@ -83,6 +83,10 @@ Learn more about [navigating](/core-concepts/navigating) to routes.
 
 By default route paths are NOT case sensitive. If you need part of your route to be case sensitive, we recommend using a [Regex Param](/core-concepts/route-params#regexp-params).
 
+## Hash
+
+With the `hash` property, you can assign a static value expected for the route to match. The behavior of the hash is very similar to how Kitbag Router treats the `path`. If a parent and a child both define `hash`, the end result is the concatenation of parent and child values. Unlike the `path` however, `hash` only supports a static `string` value without params.
+
 ## External Routes
 
 Kitbag Router supports defining routes that are "external" to your single-page app (SPA). With `createExternalRoute`, you can get all of the benefits of defined routes for routing that takes the user to another website, like perhaps your docs.

--- a/docs/core-concepts/navigating.md
+++ b/docs/core-concepts/navigating.md
@@ -94,6 +94,16 @@ router.push('/user/settings', {
 })
 ```
 
+### Hash
+
+Another options argument is `hash`. Providing this value will populate the `hash` part of the end URL. If the target route has a static `hash` value, any `hash` sent during a navigation event will be ignored.
+
+```ts
+router.push('settings', params, {
+  hash: '#examples'
+})
+```
+
 ## Replace
 
 If you want to change the current route without pushing an entry to the browser's history, you can use `router.replace`.


### PR DESCRIPTION
With recent PRs adding `hash` functionality to Kitbag Router
 - https://github.com/kitbagjs/router/pull/265
 - https://github.com/kitbagjs/router/pull/267

Our documentation was lacking this important information