### PR TITLE
Resolve returns url type

### DIFF
--- a/src/components/routerLink.vue
+++ b/src/components/routerLink.vue
@@ -12,7 +12,7 @@
   import { RouterPushOptions } from '@/types/routerPush'
   import { Url, isUrl } from '@/types/url'
 
-  type ToCallback = (resolve: RegisteredRouter['resolve']) => string
+  type ToCallback = (resolve: RegisteredRouter['resolve']) => Url
 
   type RouterLinkProps = {
     /**

--- a/src/errors/invalidRouteUrlError.ts
+++ b/src/errors/invalidRouteUrlError.ts
@@ -1,0 +1,7 @@
+import { Route } from '@/types/route'
+
+export class InvalidRouteUrlError extends Error {
+  public constructor(route: Route) {
+    super(`When assembled, this route does not form valid url ${JSON.stringify(route)}`)
+  }
+}

--- a/src/services/createRouter.spec.ts
+++ b/src/services/createRouter.spec.ts
@@ -8,6 +8,7 @@ import { createRouter } from '@/services/createRouter'
 import * as createRouterHistoryUtilities from '@/services/createRouterHistory'
 import * as resolveUtilities from '@/services/createRouterResolve'
 import { component } from '@/utilities/testHelpers'
+import { InvalidRouteUrlError } from '@/errors/invalidRouteUrlError'
 
 test('initial route is set', async () => {
   const foo = createRoute({
@@ -256,14 +257,14 @@ test('given an array of Routes, combines into single routes collection', () => {
   ])
 })
 
-test('given an array of Routes with duplicate names, throws ', () => {
+test('given an array of Routes with duplicate names, throws DuplicateNamesError', () => {
   const aRoutes = [
-    createRoute({ name: 'foo', component }),
-    createRoute({ name: 'bar', component }),
+    createRoute({ name: 'foo', path: '/foo', component }),
+    createRoute({ name: 'bar', path: '/bar', component }),
   ]
   const bRoutes = [
-    createRoute({ name: 'zoo', component }),
-    createRoute({ name: 'bar', component }),
+    createRoute({ name: 'zoo', path: '/zoo', component }),
+    createRoute({ name: 'bar', path: '/bar', component }),
   ]
 
   const action: () => void = () => createRouter([aRoutes, bRoutes], {
@@ -271,6 +272,19 @@ test('given an array of Routes with duplicate names, throws ', () => {
   })
 
   expect(action).toThrow(DuplicateNamesError)
+})
+
+test('given an array of Routes without params that are invalid url when assembled, throws InvalidRouteUrlError', () => {
+  const routes = [
+    createRoute({ name: 'foo', path: '/foo', component }),
+    createRoute({ name: 'not-valid', path: 'not-valid', component }),
+  ]
+
+  const action: () => void = () => createRouter(routes, {
+    initialUrl: '/',
+  })
+
+  expect(action).toThrow(InvalidRouteUrlError)
 })
 
 test('initial route is not set until the router is started', async () => {

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -25,6 +25,7 @@ import { RoutesName } from '@/types/routesMap'
 import { Url, isUrl } from '@/types/url'
 import { checkDuplicateNames } from '@/utilities/checkDuplicateNames'
 import { isNestedArray } from '@/utilities/guards'
+import { checkUrlAssemblesValidUrl } from '@/utilities/checkUrlAssemblesValidUrl'
 
 type RouterUpdateOptions = {
   replace?: boolean,
@@ -60,6 +61,7 @@ export function createRouter<const TRoutes extends Routes, const TOptions extend
   const flattenedRoutes = isNestedArray(routesOrArrayOfRoutes) ? routesOrArrayOfRoutes.flat() : routesOrArrayOfRoutes
   const routes = insertBaseRoute(flattenedRoutes, options?.base)
 
+  checkUrlAssemblesValidUrl(routes)
   checkDuplicateNames(routes)
 
   const propStore = createPropStore()

--- a/src/services/createRouterResolve.spec.ts
+++ b/src/services/createRouterResolve.spec.ts
@@ -3,6 +3,7 @@ import { createExternalRoute } from '@/services/createExternalRoute'
 import { createRoute } from '@/services/createRoute'
 import { createRouterResolve } from '@/services/createRouterResolve'
 import { component, routes } from '@/utilities/testHelpers'
+import { RouteNotFoundError } from '@/errors/routeNotFoundError'
 
 test('given a url returns that string', () => {
   const resolve = createRouterResolve(routes)
@@ -23,11 +24,13 @@ test('given a route name with query, interpolates param values', () => {
   expect(url).toBe('/parentA/bar?foo=foo')
 })
 
-test('given a route name with params cannot be matched, throws an error', () => {
+test('given a route name with params cannot be matched, throws an RouteNotFoundError', () => {
   const resolve = createRouterResolve(routes)
 
   // @ts-expect-error route doesn't actually exist
-  expect(() => resolve({ route: 'foo' })).toThrowError()
+  const action: () => void = () => resolve({ route: 'foo' })
+
+  expect(action).toThrow(RouteNotFoundError)
 })
 
 test('given a param with a dash or underscore resolves the correct url', () => {

--- a/src/services/createRouterResolve.ts
+++ b/src/services/createRouterResolve.ts
@@ -24,8 +24,8 @@ type RouterResolveArgs<
 export type RouterResolve<
   TRoutes extends Routes
 > = {
-  <TSource extends RoutesName<TRoutes>>(name: TSource, ...args: RouterResolveArgs<TRoutes, TSource>): string,
-  (url: Url, options?: RouterResolveOptions): string,
+  <TSource extends RoutesName<TRoutes>>(name: TSource, ...args: RouterResolveArgs<TRoutes, TSource>): Url,
+  (url: Url, options?: RouterResolveOptions): Url,
 }
 
 export function createRouterResolve<const TRoutes extends Routes>(routes: TRoutes): RouterResolve<TRoutes> {
@@ -33,7 +33,7 @@ export function createRouterResolve<const TRoutes extends Routes>(routes: TRoute
     source: Url | RoutesName<TRoutes>,
     paramsOrOptions?: Record<string, unknown>,
     maybeOptions?: RouterResolveOptions,
-  ): string => {
+  ): Url => {
     if (isUrl(source)) {
       const options: RouterPushOptions = paramsOrOptions ?? {}
 

--- a/src/services/withQuery.ts
+++ b/src/services/withQuery.ts
@@ -1,5 +1,9 @@
+import { Url } from '@/types/url'
+
 export type QueryRecord = Record<string, string>
 
+export function withQuery(url: Url, ...queries: (string | URLSearchParams | QueryRecord | undefined)[]): Url
+export function withQuery(url: string, ...queries: (string | URLSearchParams | QueryRecord | undefined)[]): string
 export function withQuery(url: string, ...queries: (string | URLSearchParams | QueryRecord | undefined)[]): string {
   return queries.reduce<string>((value, query) => {
     if (!query) {

--- a/src/utilities/checkDuplicateNames.spec.ts
+++ b/src/utilities/checkDuplicateNames.spec.ts
@@ -17,7 +17,7 @@ test('given a single array without duplicates, does nothing', () => {
   expect(action).not.toThrow()
 })
 
-test('given a multiple arrays with duplicates, throws DuplicateParamsError', () => {
+test('given a multiple arrays with duplicates, throws DuplicateNamesError', () => {
   const routes = [
     createRoute({ name: 'foo' }),
     createRoute({ name: 'bar' }),

--- a/src/utilities/checkUrlAssemblesValidUrl.spec.ts
+++ b/src/utilities/checkUrlAssemblesValidUrl.spec.ts
@@ -1,0 +1,45 @@
+import { createRoute } from '@/services/createRoute'
+import { expect, test } from 'vitest'
+import { checkUrlAssemblesValidUrl } from './checkUrlAssemblesValidUrl'
+import { InvalidRouteUrlError } from '@/errors/invalidRouteUrlError'
+
+test('given an array with all valid urls, does nothing', () => {
+  const routes = [
+    createRoute({ name: 'foo', path: '/foo' }),
+    createRoute({ name: 'bar', path: '/bar' }),
+    createRoute({ name: 'zoo', path: '/zoo' }),
+  ]
+
+  const action: () => void = () => {
+    checkUrlAssemblesValidUrl(routes)
+  }
+
+  expect(action).not.toThrow()
+})
+
+test('given an array with potentially invalid valid urls but has dynamic params, does nothing', () => {
+  const routes = [
+    createRoute({ name: 'foo', path: 'foo[maybe-slash]' }),
+    createRoute({ name: 'bar', path: '[maybe-slash]bar' }),
+    createRoute({ name: 'zoo', path: 'zo[maybe-slash]oo' }),
+  ]
+
+  const action: () => void = () => {
+    checkUrlAssemblesValidUrl(routes)
+  }
+
+  expect(action).not.toThrow()
+})
+
+test('given an array with invalid urls, throws InvalidRouteUrlError', () => {
+  const routes = [
+    createRoute({ name: 'foo', path: 'foo' }),
+    createRoute({ name: 'bar', path: 'bar' }),
+    createRoute({ name: 'zoo', path: 'zoo' }),
+  ]
+  const action: () => void = () => {
+    checkUrlAssemblesValidUrl(routes)
+  }
+
+  expect(action).toThrow(InvalidRouteUrlError)
+})

--- a/src/utilities/checkUrlAssemblesValidUrl.ts
+++ b/src/utilities/checkUrlAssemblesValidUrl.ts
@@ -1,0 +1,19 @@
+import { InvalidRouteUrlError } from '@/errors/invalidRouteUrlError'
+import { getParamsForString } from '@/services/getParamsForString'
+import { isUrl, Routes } from '@/types'
+
+export function checkUrlAssemblesValidUrl(routes: Routes): void {
+  for (const route of routes) {
+    const params = getParamsForString(`${route.host}${route.path}`, {})
+
+    if (Object.keys(params).length) {
+      continue
+    }
+
+    const url = `${route.host.toString()}${route.path.toString()}`
+
+    if (!isUrl(url)) {
+      throw new InvalidRouteUrlError(route)
+    }
+  }
+}


### PR DESCRIPTION
In an attempt to simplify [common use cases](https://github.com/kitbagjs/router/issues/299) of `route.matches`, we discovered some functions that were returning `string` when they should be returning `Url`. 

This seemed like an obvious change to make, but was complicated by the fact that previously the router was very liberal about routes that didn't actually get assembled to form a valid "url". Now when the router is created, it will check routes to be valid urls. This means that when combining host + path, it should start with "http://", "https://", or "/". 

If a route has params, the router can't know for sure that the param value at runtime wouldn't make an otherwise invalid url become valid, so it won't check those until navigation happens.

As a side quest
- this PR corrects a couple tests that also were testing the throwing of errors so we are consistent 