### PR TITLE
remove match name from rejection route

### DIFF
--- a/src/services/createRouterReject.ts
+++ b/src/services/createRouterReject.ts
@@ -41,7 +41,6 @@ export function createRouterReject({
 
     const route = {
       id: createRouteId(),
-      name: type,
       component,
       meta: {},
       state: {},


### PR DESCRIPTION
when testing the usability of `route.matches`, I came up with the following test case

```ts
import { Url, isUrl, useRoute, useRouter } from '@kitbag/router';
import { computed } from 'vue';

const router = useRouter()
const route = useRoute()

function isRouteName(name: string | undefined): name is typeof route['name'] {
  return !!name && name !== 'NotFound'
}

const matches = computed(() => {
  return route.matches.reduce<Url[]>((matches, match) => {
    if(isRouteName(match.name)){
      const url = router.resolve(match.name, route.params)

      if(isUrl(url)){
        matches.push(url)
      }
    }

    return matches
  }, [])
})
```

You'll notice how my `isRouteName` had to check that the name existed AND was not the rejection route. This feels wrong, and would not continue to work if additional rejection types were added. 

Instead, this PR removes the `name` property from the auto-generated route generated for a rejection type.  My expectation is that this will have no effect on the router functionality but should make it easier for end users to validate a given route in matches.