### PR TITLE
fix bug with router base

### DIFF
--- a/src/services/insertBaseRoute.spec.ts
+++ b/src/services/insertBaseRoute.spec.ts
@@ -23,6 +23,7 @@ test.each([
 
 test('given value for base, returns routes with base prefixed', () => {
   const base = '/kitbag'
+
   const parent = createRoute({ name: 'c', path: '/c' })
   const routes = [
     createRoute({ name: 'a', path: '/a' }),

--- a/src/services/insertBaseRoute.ts
+++ b/src/services/insertBaseRoute.ts
@@ -9,8 +9,12 @@ export function insertBaseRoute(routes: Routes, base?: string): Routes {
 
   const baseRoute = createRoute({ path: base })
 
-  return routes.map((route) => createRoute({
-    parent: baseRoute,
-    ...route,
-  }))
+  return routes.map((route) => {
+    const matched: any = route.matched
+
+    return createRoute({
+      parent: baseRoute,
+      ...matched,
+    })
+  })
 }

--- a/src/services/insertBaseRoute.ts
+++ b/src/services/insertBaseRoute.ts
@@ -1,20 +1,18 @@
-import { createRoute } from '@/services/createRoute'
 import { Routes } from '@/types'
 import { stringHasValue } from '@/utilities/guards'
+import { path } from './path'
 
 export function insertBaseRoute(routes: Routes, base?: string): Routes {
   if (!stringHasValue(base)) {
     return routes
   }
 
-  const baseRoute = createRoute({ path: base })
-
   return routes.map((route) => {
-    const matched: any = route.matched
+    const value = `${base}${route.path.value}`
 
-    return createRoute({
-      parent: baseRoute,
-      ...matched,
-    })
+    return {
+      ...route,
+      path: path(value, route.path.params),
+    }
   })
 }


### PR DESCRIPTION
closes #302 

when `base` is supplied, the router acts as though the user created a parent above all other routes. When it's re-creating the rest of the routes, it was incorrectly passing in the `Route` type (from router) and not the `route.matched`, which is the options the user would have supplied when calling `createRoute`.  

Note, because there are so many overloads, the type is unhappy and I didn't want to mess with it right now 😄 