### PR TITLE
Extend query support to match URLSeachParams

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -111,6 +111,7 @@ export default defineConfig({
             { text: 'RouterReplace', link: '/api/types/RouterReplace' },
             { text: 'RouterResolve', link: '/api/types/RouterResolve' },
             { text: 'Routes', link: '/api/types/Routes' },
+            { text: 'QuerySource', link: '/api/types/QuerySource' },
             { text: 'Url', link: '/api/types/Url' },
           ],
         },

--- a/docs/api/components/RouterLink.md
+++ b/docs/api/components/RouterLink.md
@@ -7,10 +7,12 @@ RouterLink component renders anchor tag (`<a>`) for routing both within the SPA 
 | Parameter | Type |
 | :---- | :---- |
 | to | [`Url`](/api/types/Url) \| `(resolve: RouterResolve) => Url` |
-| query | `ConstructorParameters<typeof URLSearchParams>[0]` \| `undefined` |
+| query | `QuerySource` \| `undefined` |
 | hash | `string` \| `undefined` |
 | replace | `boolean` \| `undefined` |
 | prefetch | `boolean` \| `PrefetchConfigOptions` \| `undefined` |
+
+[QuerySource](/api/types/QuerySource)
 
 [RouterResolve](/api/types/RouterResolve)
 

--- a/docs/api/components/RouterLink.md
+++ b/docs/api/components/RouterLink.md
@@ -7,7 +7,7 @@ RouterLink component renders anchor tag (`<a>`) for routing both within the SPA 
 | Parameter | Type |
 | :---- | :---- |
 | to | [`Url`](/api/types/Url) \| `(resolve: RouterResolve) => Url` |
-| query | `Record<string, string>` \| `undefined` |
+| query | `ConstructorParameters<typeof URLSearchParams>[0]` \| `undefined` |
 | hash | `string` \| `undefined` |
 | replace | `boolean` \| `undefined` |
 | prefetch | `boolean` \| `PrefetchConfigOptions` \| `undefined` |

--- a/docs/api/types/QuerySource.md
+++ b/docs/api/types/QuerySource.md
@@ -1,0 +1,7 @@
+# QuerySource
+
+QuerySource is our name for the constructor type passed to the built in [URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams).
+
+```ts
+export type QuerySource = ConstructorParameters<typeof URLSearchParams>[0]
+```

--- a/docs/api/types/RouterPush.md
+++ b/docs/api/types/RouterPush.md
@@ -19,7 +19,7 @@ Push will update the URL for the browser and also add the URL into the history s
 
 ```ts
 {
-  query?: Record<string, string>,
+  query?: ConstructorParameters<typeof URLSearchParams>[0],
   replace?: boolean,
   hash?: string,
 }

--- a/docs/api/types/RouterPush.md
+++ b/docs/api/types/RouterPush.md
@@ -19,11 +19,13 @@ Push will update the URL for the browser and also add the URL into the history s
 
 ```ts
 {
-  query?: ConstructorParameters<typeof URLSearchParams>[0],
+  query?: QuerySource,
   replace?: boolean,
   hash?: string,
 }
 ```
+
+[QuerySource](/api/types/QuerySource)
 
 ## Returns
 

--- a/docs/api/types/RouterReplace.md
+++ b/docs/api/types/RouterReplace.md
@@ -19,10 +19,12 @@ Replace has the same effect as [`RouterPush`](/api/types/RouterPush) but without
 
 ```ts
 {
-  query?: ConstructorParameters<typeof URLSearchParams>[0],
+  query?: QuerySource,
   hash?: string,
 }
 ```
+
+[QuerySource](/api/types/QuerySource)
 
 ## Returns
 

--- a/docs/api/types/RouterReplace.md
+++ b/docs/api/types/RouterReplace.md
@@ -19,7 +19,7 @@ Replace has the same effect as [`RouterPush`](/api/types/RouterPush) but without
 
 ```ts
 {
-  query?: Record<string, string>,
+  query?: ConstructorParameters<typeof URLSearchParams>[0],
   hash?: string,
 }
 ```

--- a/docs/api/types/RouterResolve.md
+++ b/docs/api/types/RouterResolve.md
@@ -33,10 +33,12 @@ If source is `Url`, expected type for params is `never`. Else when source is `TS
 
 ```ts
 {
-  query?: ConstructorParameters<typeof URLSearchParams>[0]****,
+  query?: QuerySource,
   hash?: string,
 }
 ```
+
+[QuerySource](/api/types/QuerySource)
 
 ## Returns
 

--- a/docs/api/types/RouterResolve.md
+++ b/docs/api/types/RouterResolve.md
@@ -33,7 +33,7 @@ If source is `Url`, expected type for params is `never`. Else when source is `TS
 
 ```ts
 {
-  query?: Record<string, string>,
+  query?: ConstructorParameters<typeof URLSearchParams>[0]****,
   hash?: string,
 }
 ```

--- a/src/services/createRouter.spec.ts
+++ b/src/services/createRouter.spec.ts
@@ -306,7 +306,7 @@ test('query.delete updates the route', async () => {
   expect(route.query.toString()).toBe('fiz=buz')
 })
 
-test.fails('query.values is reactive', async () => {
+test('query.values is reactive', async () => {
   const root = createRoute({
     name: 'root',
     component,
@@ -314,20 +314,20 @@ test.fails('query.values is reactive', async () => {
   })
 
   const { route, start } = createRouter([root], {
-    initialUrl: '/?foo=bar&fiz=buz',
+    initialUrl: '/?foo=foo1&bar=bar1',
   })
 
   await start()
 
   const values = computed(() => Array.from(route.query.values()))
 
-  expect(values.value).toMatchObject(['bar', 'buz'])
+  expect(values.value).toMatchObject(['foo1', 'bar1'])
 
-  route.query.append('foo', 'bar2')
+  route.query.append('foo', 'foo2')
 
   await flushPromises()
 
-  expect(values.value).toMatchObject(['bar', 'buz', 'bar2'])
+  expect(values.value).toMatchObject(['foo1', 'bar1', 'foo2'])
 })
 
 test('given an array of Routes, combines into single routes collection', () => {

--- a/src/services/createRouterResolve.ts
+++ b/src/services/createRouterResolve.ts
@@ -8,10 +8,10 @@ import { isUrl, Url } from '@/types/url'
 import { AllPropertiesAreOptional } from '@/types/utilities'
 import { createUrl } from '@/services/urlCreator'
 import { parseUrl } from '@/services/urlParser'
-import { QueryRecord } from '@/types/query'
+import { QuerySource } from '@/types/query'
 
 export type RouterResolveOptions = {
-  query?: QueryRecord,
+  query?: QuerySource,
   hash?: string,
 }
 

--- a/src/services/createRouterResolve.ts
+++ b/src/services/createRouterResolve.ts
@@ -6,11 +6,12 @@ import { RoutesName } from '@/types/routesMap'
 import { RouteParamsByKey } from '@/types/routeWithParams'
 import { isUrl, Url } from '@/types/url'
 import { AllPropertiesAreOptional } from '@/types/utilities'
-import { createUrl } from './urlCreator'
-import { parseUrl } from './urlParser'
+import { createUrl } from '@/services/urlCreator'
+import { parseUrl } from '@/services/urlParser'
+import { QueryRecord } from '@/types/query'
 
 export type RouterResolveOptions = {
-  query?: Record<string, string>,
+  query?: QueryRecord,
   hash?: string,
 }
 

--- a/src/services/createRouterRoute.ts
+++ b/src/services/createRouterRoute.ts
@@ -46,21 +46,21 @@ export function createRouterRoute<TRoute extends ResolvedRoute>(route: TRoute, p
     const query = new URLSearchParams(route.query.toString())
     query.set(...parameters)
 
-    update({}, { query: Object.fromEntries(query.entries()) })
+    update({}, { query })
   }
 
   const queryAppend: URLSearchParams['append'] = (...parameters) => {
     const query = new URLSearchParams(route.query.toString())
     query.append(...parameters)
 
-    update({}, { query: Object.fromEntries(query.entries()) })
+    update({}, { query })
   }
 
   const queryDelete: URLSearchParams['delete'] = (...parameters) => {
     const query = new URLSearchParams(route.query.toString())
     query.delete(...parameters)
 
-    update({}, { query: Object.fromEntries(query.entries()) })
+    update({}, { query })
   }
 
   const { id, matched, matches, name, query, params, state, hash } = toRefs(route)

--- a/src/services/routeMatchScore.ts
+++ b/src/services/routeMatchScore.ts
@@ -1,7 +1,7 @@
 import { parseUrl } from '@/services/urlParser'
 import { getParamValueFromUrl } from '@/services/paramsFinder'
 import { Route } from '@/types/route'
-import { routeHashMatches } from './routeMatchRules'
+import { routeHashMatches } from '@/services/routeMatchRules'
 
 type RouteSortMethod = (aRoute: Route, bRoute: Route) => number
 

--- a/src/services/urlAssembly.ts
+++ b/src/services/urlAssembly.ts
@@ -5,7 +5,7 @@ import { getParamName, isOptionalParamSyntax } from '@/services/routeRegex'
 import { Host } from '@/types/host'
 import { paramEnd, paramStart } from '@/types/params'
 import { Path } from '@/types/path'
-import { Query, QueryRecord } from '@/types/query'
+import { Query, QuerySource } from '@/types/query'
 import { Route } from '@/types/route'
 import { Url } from '@/types/url'
 import { createUrl } from '@/services/urlCreator'
@@ -14,7 +14,7 @@ import { combineUrlSearchParams } from '@/utilities/urlSearchParams'
 
 type AssembleUrlOptions = {
   params?: Record<string, unknown>,
-  query?: QueryRecord,
+  query?: QuerySource,
   hash?: string,
 }
 

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -4,6 +4,8 @@ import { Param } from '@/types/paramTypes'
 import { Identity } from '@/types/utilities'
 import { isRecord } from '@/utilities/guards'
 
+export type QueryRecord = ConstructorParameters<typeof URLSearchParams>[0]
+
 type ExtractQueryParamsFromQueryString<
   TQuery extends string,
   TParams extends Record<string, Param | undefined> = Record<never, never>

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -4,7 +4,7 @@ import { Param } from '@/types/paramTypes'
 import { Identity } from '@/types/utilities'
 import { isRecord } from '@/utilities/guards'
 
-export type QueryRecord = ConstructorParameters<typeof URLSearchParams>[0]
+export type QuerySource = ConstructorParameters<typeof URLSearchParams>[0]
 
 type ExtractQueryParamsFromQueryString<
   TQuery extends string,

--- a/src/types/routerPush.ts
+++ b/src/types/routerPush.ts
@@ -4,12 +4,12 @@ import { RouteParamsByKey } from '@/types/routeWithParams'
 import { RouteStateByName } from '@/types/state'
 import { Url } from '@/types/url'
 import { AllPropertiesAreOptional } from '@/types/utilities'
-import { QueryRecord } from '@/types/query'
+import { QuerySource } from '@/types/query'
 
 export type RouterPushOptions<
   TState = unknown
 > = {
-  query?: QueryRecord,
+  query?: QuerySource,
   hash?: string,
   replace?: boolean,
   state?: Partial<TState>,

--- a/src/types/routerPush.ts
+++ b/src/types/routerPush.ts
@@ -4,11 +4,12 @@ import { RouteParamsByKey } from '@/types/routeWithParams'
 import { RouteStateByName } from '@/types/state'
 import { Url } from '@/types/url'
 import { AllPropertiesAreOptional } from '@/types/utilities'
+import { QueryRecord } from '@/types/query'
 
 export type RouterPushOptions<
   TState = unknown
 > = {
-  query?: Record<string, string>,
+  query?: QueryRecord,
   hash?: string,
   replace?: boolean,
   state?: Partial<TState>,

--- a/src/types/routerReplace.ts
+++ b/src/types/routerReplace.ts
@@ -4,11 +4,12 @@ import { RouteParamsByKey } from '@/types/routeWithParams'
 import { RouteStateByName } from '@/types/state'
 import { Url } from '@/types/url'
 import { AllPropertiesAreOptional } from '@/types/utilities'
+import { QueryRecord } from '@/types/query'
 
 export type RouterReplaceOptions<
   TState = unknown
 > = {
-  query?: Record<string, string>,
+  query?: QueryRecord,
   hash?: string,
   state?: Partial<TState>,
 }

--- a/src/types/routerReplace.ts
+++ b/src/types/routerReplace.ts
@@ -4,12 +4,12 @@ import { RouteParamsByKey } from '@/types/routeWithParams'
 import { RouteStateByName } from '@/types/state'
 import { Url } from '@/types/url'
 import { AllPropertiesAreOptional } from '@/types/utilities'
-import { QueryRecord } from '@/types/query'
+import { QuerySource } from '@/types/query'
 
 export type RouterReplaceOptions<
   TState = unknown
 > = {
-  query?: QueryRecord,
+  query?: QuerySource,
   hash?: string,
   state?: Partial<TState>,
 }

--- a/src/utilities/urlSearchParams.spec.ts
+++ b/src/utilities/urlSearchParams.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from 'vitest'
+import { combineUrlSearchParams } from './urlSearchParams'
+
+test.each([
+  'foo=bar',
+  { foo: 'bar' },
+  [['foo', 'bar']],
+])('given different constructor types, normalizes into URLSearchParams', (params) => {
+  const response = combineUrlSearchParams(params, undefined)
+
+  expect(Array.from(response.entries())).toMatchObject([
+    ['foo', 'bar'],
+  ])
+})
+
+test('given duplicate keys, appends new entry', () => {
+  const aParams = new URLSearchParams({ foo: 'foo' })
+  const bParams = new URLSearchParams({ foo: 'bar' })
+
+  const response = combineUrlSearchParams(aParams, bParams)
+
+  expect(Array.from(response.entries())).toMatchObject([
+    ['foo', 'foo'],
+    ['foo', 'bar'],
+  ])
+})

--- a/src/utilities/urlSearchParams.ts
+++ b/src/utilities/urlSearchParams.ts
@@ -1,6 +1,6 @@
-import { QueryRecord } from '@/types/query'
+import { QuerySource } from '@/types/query'
 
-export function combineUrlSearchParams(aParams: URLSearchParams | QueryRecord, bParams: URLSearchParams | QueryRecord): URLSearchParams {
+export function combineUrlSearchParams(aParams: URLSearchParams | QuerySource, bParams: URLSearchParams | QuerySource): URLSearchParams {
   const combinedParams = new URLSearchParams(aParams)
   const paramsToAdd = new URLSearchParams(bParams)
 

--- a/src/utilities/urlSearchParams.ts
+++ b/src/utilities/urlSearchParams.ts
@@ -1,0 +1,12 @@
+import { QueryRecord } from '@/types/query'
+
+export function combineUrlSearchParams(aParams: URLSearchParams | QueryRecord, bParams: URLSearchParams | QueryRecord): URLSearchParams {
+  const combinedParams = new URLSearchParams(aParams)
+  const paramsToAdd = new URLSearchParams(bParams)
+
+  for (const [key, value] of paramsToAdd.entries()) {
+    combinedParams.append(key, value)
+  }
+
+  return combinedParams
+}


### PR DESCRIPTION
We discovered [in a recent PR](https://github.com/kitbagjs/router/pull/308) that the type we're using to pass query values (`Record<string, string>`) was limiting our ability to mirror native behavior of built in `URLSeachParams` type. Specifically, the object syntax doesn't allow for multiple entries with the same key.

This PR updates our `QueryRecord` type to match any value accepted by the constructor of `URLSeachParams`. 