### PR TITLE
Make `route.query` assignable so the entire query can be replaced

### DIFF
--- a/src/services/createRouter.spec.ts
+++ b/src/services/createRouter.spec.ts
@@ -247,7 +247,7 @@ test('query is writable', async () => {
 
   await start()
 
-  route.query = new URLSearchParams('foo=bar&foo=baz')
+  route.query = 'foo=bar&foo=baz'
 
   await flushPromises()
 

--- a/src/services/createRouter.spec.ts
+++ b/src/services/createRouter.spec.ts
@@ -234,6 +234,26 @@ test('setting an unknown param does not add its value to the route', async () =>
   expect(route.params.nothing).toBeUndefined()
 })
 
+test('query is writable', async () => {
+  const root = createRoute({
+    name: 'root',
+    component,
+    path: '/',
+  })
+
+  const { route, start } = createRouter([root], {
+    initialUrl: '/?foo=bar&fiz=buz',
+  })
+
+  await start()
+
+  route.query = new URLSearchParams('foo=bar&foo=baz')
+
+  await flushPromises()
+
+  expect(route.query.toString()).toBe('foo=bar&foo=baz')
+})
+
 test('query.set updates the route', async () => {
   const root = createRoute({
     name: 'root',

--- a/src/services/createRouterRoute.ts
+++ b/src/services/createRouterRoute.ts
@@ -4,20 +4,23 @@ import { ResolvedRouteQuery } from '@/types/resolvedQuery'
 import { RouterPush, RouterPushOptions } from '@/types/routerPush'
 import { RouteUpdate } from '@/types/routeUpdate'
 import { Writable } from '@/types/utilities'
+import { QuerySource } from '@/types/query'
 
 const isRouterRouteSymbol = Symbol('isRouterRouteSymbol')
 
-export type RouterRoute<TRoute extends ResolvedRoute = ResolvedRoute> = Readonly<{
-  id: TRoute['id'],
-  name: TRoute['name'],
-  matched: TRoute['matched'],
-  matches: TRoute['matches'],
-  state: TRoute['state'],
-  query: ResolvedRouteQuery,
-  hash: TRoute['hash'],
-  params: Writable<TRoute['params']>,
-  update: RouteUpdate<TRoute>,
-}>
+export type RouterRoute<TRoute extends ResolvedRoute = ResolvedRoute> = {
+  readonly id: TRoute['id'],
+  readonly name: TRoute['name'],
+  readonly matched: TRoute['matched'],
+  readonly matches: TRoute['matches'],
+  readonly state: TRoute['state'],
+  readonly hash: TRoute['hash'],
+  readonly params: Writable<TRoute['params']>,
+  readonly update: RouteUpdate<TRoute>,
+
+  get query(): ResolvedRouteQuery,
+  set query(value: QuerySource),
+}
 
 export function isRouterRoute(value: unknown): value is RouterRoute {
   return typeof value === 'object' && value !== null && isRouterRouteSymbol in value
@@ -118,6 +121,16 @@ export function createRouterRoute<TRoute extends ResolvedRoute>(route: TRoute, p
       }
 
       return Reflect.get(target, property, receiver)
+    },
+
+    set(target, property, value, receiver) {
+      if (property === 'query') {
+        update({}, { query: value })
+
+        return true
+      }
+
+      return Reflect.set(target, property, value, receiver)
     },
   })
 }


### PR DESCRIPTION
# Description
https://github.com/kitbagjs/router/pull/309 Make it possible to modify the query directly via the route. But making multiple operations makes multiple `push` calls. You could call `route.update({}, { query: newQuery })` but since we already have the mechanisms to make parts of the route writable we can allow users to assign the query as a nice syntax that is a better devx. 

This PR makes this possible
```ts
const route = useRoute()

route.query = 'foo=bar'

// or any other QuerySource such as URLSearchParams
route.query = new URLSearchParams({ foo: 'bar' })
```