### PR TITLE
`useQueryValue` composition to make working with query values that are not params just as easy

### DIFF
--- a/src/compositions/useQueryValue.browser.spec.ts
+++ b/src/compositions/useQueryValue.browser.spec.ts
@@ -1,0 +1,184 @@
+import { createRouter } from '@/services'
+import { createRoute } from '@/services/createRoute'
+import { expect, test } from 'vitest'
+import { useQueryValue } from './useQueryValue'
+import { flushPromises, mount } from '@vue/test-utils'
+
+test('returns correct value and values when key does not exist', async () => {
+  const root = createRoute({
+    name: 'root',
+    path: '/',
+  })
+
+  const router = createRouter([root], {
+    initialUrl: '/',
+  })
+
+  await router.start()
+
+  const component = {
+    setup() {
+      return useQueryValue('foo')
+    },
+  }
+
+  const wrapper = mount(component, {
+    global: {
+      plugins: [router],
+    },
+  })
+
+  expect(wrapper.vm.value).toBe(null)
+  expect(wrapper.vm.values).toEqual([])
+})
+
+test('returns correct value and values when key does exist', async () => {
+  const root = createRoute({
+    name: 'root',
+    path: '/',
+  })
+
+  const router = createRouter([root], {
+    initialUrl: '/?foo=1&foo=2',
+  })
+
+  await router.start()
+
+  const component = {
+    setup() {
+      return useQueryValue('foo')
+    },
+  }
+
+  const wrapper = mount(component, {
+    global: {
+      plugins: [router],
+    },
+  })
+
+  expect(wrapper.vm.value).toBe('1')
+  expect(wrapper.vm.values).toEqual(['1', '2'])
+})
+
+test('returns correct value and values when a param is used', async () => {
+  const root = createRoute({
+    name: 'root',
+    path: '/',
+  })
+
+  const router = createRouter([root], {
+    initialUrl: '/?foo=1&foo=2',
+  })
+
+  await router.start()
+
+  const component = {
+    setup() {
+      return useQueryValue('foo', Number)
+    },
+  }
+
+  const wrapper = mount(component, {
+    global: {
+      plugins: [router],
+    },
+  })
+
+  expect(wrapper.vm.value).toBe(1)
+  expect(wrapper.vm.values).toEqual([1, 2])
+})
+
+test('updates value and values when the query string changes', async () => {
+  const root = createRoute({
+    name: 'root',
+    path: '/',
+  })
+
+  const router = createRouter([root], {
+    initialUrl: '/?foo=1&foo=2',
+  })
+
+  await router.start()
+
+  const component = {
+    setup() {
+      return useQueryValue('foo', Number)
+    },
+  }
+
+  const wrapper = mount(component, {
+    global: {
+      plugins: [router],
+    },
+  })
+
+  expect(wrapper.vm.value).toBe(1)
+  expect(wrapper.vm.values).toEqual([1, 2])
+
+  await router.push('/?foo=3')
+
+  expect(wrapper.vm.value).toBe(3)
+  expect(wrapper.vm.values).toEqual([3])
+})
+
+test('updates the query string when the value is set', async () => {
+  const root = createRoute({
+    name: 'root',
+    path: '/',
+  })
+
+  const router = createRouter([root], {
+    initialUrl: '/?foo=1&foo=2',
+  })
+
+  await router.start()
+
+  const component = {
+    setup() {
+      const { value } = useQueryValue('foo', Number)
+
+      value.value = 3
+    },
+  }
+
+  mount(component, {
+    global: {
+      plugins: [router],
+    },
+  })
+
+  await flushPromises()
+
+  expect(router.route.query.toString()).toBe('foo=3')
+})
+
+test('updates the query string when the values is set', async () => {
+  const root = createRoute({
+    name: 'root',
+    path: '/',
+  })
+
+  const router = createRouter([root], {
+    initialUrl: '/?foo=1&foo=2',
+  })
+
+  await router.start()
+
+  const component = {
+    setup() {
+      const { values } = useQueryValue('foo', Number)
+
+      values.value = [3, 4]
+    },
+  }
+
+  mount(component, {
+    global: {
+      plugins: [router],
+    },
+  })
+
+  await flushPromises()
+
+  expect(router.route.query.toString()).toBe('foo=3&foo=4')
+})

--- a/src/compositions/useQueryValue.browser.spec.ts
+++ b/src/compositions/useQueryValue.browser.spec.ts
@@ -182,3 +182,34 @@ test('updates the query string when the values is set', async () => {
 
   expect(router.route.query.toString()).toBe('foo=3&foo=4')
 })
+
+test('removes the query string when the remove method is called', async () => {
+  const root = createRoute({
+    name: 'root',
+    path: '/',
+  })
+
+  const router = createRouter([root], {
+    initialUrl: '/?foo=1&foo=2',
+  })
+
+  await router.start()
+
+  const component = {
+    setup() {
+      const { remove } = useQueryValue('foo')
+
+      remove()
+    },
+  }
+
+  mount(component, {
+    global: {
+      plugins: [router],
+    },
+  })
+
+  await flushPromises()
+
+  expect(router.route.query.toString()).toBe('')
+})

--- a/src/compositions/useQueryValue.ts
+++ b/src/compositions/useQueryValue.ts
@@ -12,12 +12,11 @@ export type UseQueryValue<T> = {
 export function useQueryValue(key: MaybeRefOrGetter<string>): UseQueryValue<string>
 
 export function useQueryValue<
-  TParam extends Param,
-  TParamType extends ExtractParamType<TParam>
+  TParam extends Param
 >(
   key: MaybeRefOrGetter<string>,
   param: TParam
-): UseQueryValue<ExtractParamType<TParamType>>
+): UseQueryValue<ExtractParamType<TParam>>
 
 export function useQueryValue(
   key: MaybeRefOrGetter<string>,

--- a/src/compositions/useQueryValue.ts
+++ b/src/compositions/useQueryValue.ts
@@ -7,6 +7,7 @@ import { safeGetParamValue, setParamValue } from '@/services/params'
 export type UseQueryValue<T> = {
   value: Ref<T | null>,
   values: Ref<T[]>,
+  remove: () => void,
 }
 
 export function useQueryValue(key: MaybeRefOrGetter<string>): UseQueryValue<string>
@@ -63,5 +64,8 @@ export function useQueryValue(
   return {
     value,
     values,
+    remove: () => {
+      route.query.delete(toValue(key))
+    },
   }
 }

--- a/src/compositions/useQueryValue.ts
+++ b/src/compositions/useQueryValue.ts
@@ -1,0 +1,75 @@
+import { computed, Ref, MaybeRefOrGetter, toValue } from 'vue'
+import { useRoute } from './useRoute'
+import { Param } from '@/types'
+import { ExtractParamType } from '@/types/params'
+import { getParamValue, setParamValue } from '@/services/params'
+import { InvalidRouteParamValueError } from '@/errors/invalidRouteParamValueError'
+
+export type UseQueryValue<T> = {
+  value: Ref<T | null>,
+  values: Ref<T[]>,
+}
+
+export function useQueryValue<
+  TParam extends Param,
+  TParamType extends ExtractParamType<TParam>
+>(
+  key: MaybeRefOrGetter<string>,
+  type: TParam,
+): UseQueryValue<TParamType> {
+  const route = useRoute()
+
+  const value = computed<TParamType | null>({
+    get() {
+      const value = route.query.get(toValue(key))
+
+      if (value === null) {
+        return null
+      }
+
+      try {
+        return getParamValue(value, type)
+      } catch (error) {
+        if (error instanceof InvalidRouteParamValueError) {
+          return null
+        }
+
+        throw error
+      }
+    },
+    set(value: TParamType | null) {
+      route.query.set(toValue(key), setParamValue(value, type))
+    },
+  })
+
+  const values = computed<TParamType[]>({
+    get() {
+      const values = route.query.getAll(toValue(key))
+
+      return values
+        .map((value) => {
+          try {
+            return getParamValue(value, type)
+          } catch (error) {
+            if (error instanceof InvalidRouteParamValueError) {
+              return null
+            }
+            throw error
+          }
+        })
+        .filter((value): value is TParamType => value !== null)
+    },
+    set(values: TParamType[]) {
+      route.query.delete(toValue(key))
+
+      values.forEach((value) => {
+        route.query.append(toValue(key), setParamValue(value, type))
+      })
+    },
+  })
+
+  return {
+    value,
+    values,
+  }
+}

--- a/src/compositions/useQueryValue.ts
+++ b/src/compositions/useQueryValue.ts
@@ -49,11 +49,15 @@ export function useQueryValue(
         .filter((value) => value !== null)
     },
     set(values) {
-      route.query.delete(toValue(key))
+      const query = new URLSearchParams(route.query.toString())
+
+      query.delete(toValue(key))
 
       values.forEach((value) => {
-        route.query.append(toValue(key), setParamValue(value, param))
+        query.append(toValue(key), setParamValue(value, param))
       })
+
+      route.query = query
     },
   })
 

--- a/src/compositions/useQueryValue.ts
+++ b/src/compositions/useQueryValue.ts
@@ -2,24 +2,30 @@ import { computed, Ref, MaybeRefOrGetter, toValue } from 'vue'
 import { useRoute } from './useRoute'
 import { Param } from '@/types'
 import { ExtractParamType } from '@/types/params'
-import { getParamValue, setParamValue } from '@/services/params'
-import { InvalidRouteParamValueError } from '@/errors/invalidRouteParamValueError'
+import { safeGetParamValue, setParamValue } from '@/services/params'
 
 export type UseQueryValue<T> = {
   value: Ref<T | null>,
   values: Ref<T[]>,
 }
 
+export function useQueryValue(key: MaybeRefOrGetter<string>): UseQueryValue<string>
+
 export function useQueryValue<
   TParam extends Param,
   TParamType extends ExtractParamType<TParam>
 >(
   key: MaybeRefOrGetter<string>,
-  type: TParam,
-): UseQueryValue<TParamType> {
+  param: TParam
+): UseQueryValue<ExtractParamType<TParamType>>
+
+export function useQueryValue(
+  key: MaybeRefOrGetter<string>,
+  param: Param = String,
+): UseQueryValue<unknown> {
   const route = useRoute()
 
-  const value = computed<TParamType | null>({
+  const value = computed({
     get() {
       const value = route.query.get(toValue(key))
 
@@ -27,43 +33,26 @@ export function useQueryValue<
         return null
       }
 
-      try {
-        return getParamValue(value, type)
-      } catch (error) {
-        if (error instanceof InvalidRouteParamValueError) {
-          return null
-        }
-
-        throw error
-      }
+      return safeGetParamValue(value, param)
     },
-    set(value: TParamType | null) {
-      route.query.set(toValue(key), setParamValue(value, type))
+    set(value) {
+      route.query.set(toValue(key), setParamValue(value, param))
     },
   })
 
-  const values = computed<TParamType[]>({
+  const values = computed({
     get() {
       const values = route.query.getAll(toValue(key))
 
       return values
-        .map((value) => {
-          try {
-            return getParamValue(value, type)
-          } catch (error) {
-            if (error instanceof InvalidRouteParamValueError) {
-              return null
-            }
-            throw error
-          }
-        })
-        .filter((value): value is TParamType => value !== null)
+        .map((value) => safeGetParamValue(value, param))
+        .filter((value) => value !== null)
     },
-    set(values: TParamType[]) {
+    set(values) {
       route.query.delete(toValue(key))
 
       values.forEach((value) => {
-        route.query.append(toValue(key), setParamValue(value, type))
+        route.query.append(toValue(key), setParamValue(value, param))
       })
     },
   })

--- a/src/services/params.ts
+++ b/src/services/params.ts
@@ -157,6 +157,17 @@ export function getParamValue<T extends Param>(value: string | undefined, param:
   return value
 }
 
+export function safeGetParamValue<T extends Param>(value: string | undefined, param: T, isOptional = false): ExtractParamType<T> | undefined {
+  try {
+    return getParamValue(value, param, isOptional)
+  } catch (error) {
+    if (error instanceof InvalidRouteParamValueError) {
+      return undefined
+    }
+    throw error
+  }
+}
+
 export function setParamValue(value: unknown, param: Param, isOptional = false): string {
   if (value === undefined) {
     if (isOptional) {


### PR DESCRIPTION
# Description
Query params are useful for route matching and declaring known route state. But sometimes the query state cannot be known ahead of time, is dynamic, or for other reasons cannot be declared on the route. 

`useQueryValue` aims to make working with query values that are not params as feature rich as params themselves. 

Working with simple values
```ts
const { value } = useQueryValue('foo')
//           ?^ Ref<string | null>
```

Working with arrays
```ts
const { values } = useQueryValue('foo')
//           ?^ Ref<string[]>
```

Using params
```ts
const { value, values } = useQueryValue('foo', Number)

value // Ref<number | null>

values // Ref<number[]>
```

A `remove` callback is also returned to make deleting query keys simple
```ts
const { value, remove } = useQueryValue('foo')

value.value = 'bar'

// ?foo=bar

remove()

// query is empty
```