### PR TITLE
Make route.params assignable so all params can be replaced

### DIFF
--- a/src/services/createRouter.spec.ts
+++ b/src/services/createRouter.spec.ts
@@ -144,7 +144,6 @@ test.fails('route is readonly except for individual params', async () => {
   route.matches = 'matches'
   expect(route.matches).toMatchObject(routes[0].matches)
 
-  // @ts-expect-error value is immutable
   route.params = { foo: 'bar' }
   expect(route.params).toMatchObject({})
 })
@@ -232,6 +231,40 @@ test('setting an unknown param does not add its value to the route', async () =>
 
   // @ts-expect-error value is immutable
   expect(route.params.nothing).toBeUndefined()
+})
+
+test('params are writable', async () => {
+  const routes = [
+    createRoute({
+      name: 'root',
+      component,
+      path: '/[paramA]/[paramB]/[?paramC]',
+    }),
+  ]
+
+  const { route, start } = createRouter(routes, {
+    initialUrl: '/one/two/three',
+  })
+
+  await start()
+
+  expect(route.params).toMatchObject({
+    paramA: 'one',
+    paramB: 'two',
+    paramC: 'three',
+  })
+
+  route.params = {
+    paramA: 'four',
+    paramB: 'five',
+  }
+
+  await flushPromises()
+
+  expect(route.params).toMatchObject({
+    paramA: 'four',
+    paramB: 'five',
+  })
 })
 
 test('query is writable', async () => {

--- a/src/services/createRouterRoute.ts
+++ b/src/services/createRouterRoute.ts
@@ -3,7 +3,6 @@ import { ResolvedRoute } from '@/types/resolved'
 import { ResolvedRouteQuery } from '@/types/resolvedQuery'
 import { RouterPush, RouterPushOptions } from '@/types/routerPush'
 import { RouteUpdate } from '@/types/routeUpdate'
-import { Writable } from '@/types/utilities'
 import { QuerySource } from '@/types/query'
 
 const isRouterRouteSymbol = Symbol('isRouterRouteSymbol')
@@ -15,8 +14,9 @@ export type RouterRoute<TRoute extends ResolvedRoute = ResolvedRoute> = {
   readonly matches: TRoute['matches'],
   readonly state: TRoute['state'],
   readonly hash: TRoute['hash'],
-  readonly params: Writable<TRoute['params']>,
   readonly update: RouteUpdate<TRoute>,
+
+  params: TRoute['params'],
 
   get query(): ResolvedRouteQuery,
   set query(value: QuerySource),
@@ -27,7 +27,7 @@ export function isRouterRoute(value: unknown): value is RouterRoute {
 }
 
 export function createRouterRoute<TRoute extends ResolvedRoute>(route: TRoute, push: RouterPush): RouterRoute<TRoute> {
-  function update(nameOrParams: PropertyKey | Partial<ResolvedRoute['params']>, valueOrOptions: any, maybeOptions?: RouterPushOptions): Promise<void> {
+  function update(nameOrParams: PropertyKey | Partial<ResolvedRoute['params']>, valueOrOptions?: any, maybeOptions?: RouterPushOptions): Promise<void> {
     if (typeof nameOrParams === 'object') {
       const params = {
         ...route.params,
@@ -124,6 +124,12 @@ export function createRouterRoute<TRoute extends ResolvedRoute>(route: TRoute, p
     },
 
     set(target, property, value, receiver) {
+      if (property === 'params') {
+        update(value)
+
+        return true
+      }
+
       if (property === 'query') {
         update({}, { query: value })
 

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -30,5 +30,3 @@ export type OnlyRequiredProperties<T> = {
 export type AllPropertiesAreOptional<T> = Record<string, unknown> extends T
   ? true
   : IsEmptyObject<OnlyRequiredProperties<T>>
-
-export type Writable<T> = { -readonly [P in keyof T]: T[P] }


### PR DESCRIPTION
# Description
Sugar around `route.update({ foo: 'bar', fuz: 'buz' })` to make it possible to just write

```ts
route.params = { foo: 'bar', fuz: 'buz' }
```