### PR TITLE
Refactor callback context and handling

### DIFF
--- a/src/services/createCallbackContext.ts
+++ b/src/services/createCallbackContext.ts
@@ -1,0 +1,66 @@
+import { RouterPushError } from '@/errors/routerPushError'
+import { RouterRejectionError } from '@/errors/routerRejectionError'
+import { RegisteredRejectionType, RegisteredRouterPush, RegisteredRouterReject, RegisteredRouterReplace } from '@/types/register'
+import { RouterPushOptions } from '@/types/routerPush'
+import { isUrl } from '@/types/url'
+
+/**
+ * Defines the structure of a successful callback response.
+ */
+export type CallbackSuccessResponse = {
+  status: 'SUCCESS',
+}
+
+/**
+ * Defines the structure of an aborted callback response.
+ */
+export type CallbackAbortResponse = {
+  status: 'ABORT',
+}
+
+/**
+ * Defines the structure of a callback response that results in a push to a new route.
+ */
+export type CallbackPushResponse = {
+  status: 'PUSH',
+  to: Parameters<RegisteredRouterPush>,
+}
+
+/**
+ * Defines the structure of a callback response that results in the rejection of a route transition.
+ */
+export type CallbackRejectResponse = {
+  status: 'REJECT',
+  type: RegisteredRejectionType,
+}
+
+export type CallbackResponse = CallbackSuccessResponse | CallbackPushResponse | CallbackRejectResponse | CallbackAbortResponse
+
+export type CallbackContext = {
+  reject: RegisteredRouterReject,
+  push: RegisteredRouterPush,
+  replace: RegisteredRouterReplace,
+}
+
+export function createCallbackContext(): CallbackContext {
+  const reject: RegisteredRouterReject = (type) => {
+    throw new RouterRejectionError(type)
+  }
+
+  const push: RegisteredRouterPush = (...parameters: any[]) => {
+    throw new RouterPushError(parameters)
+  }
+
+  const replace: RegisteredRouterPush = (source: any, paramsOrOptions?: any, maybeOptions?: any) => {
+    if (isUrl(source)) {
+      const options: RouterPushOptions = paramsOrOptions ?? {}
+      throw new RouterPushError([source, { ...options, replace: true }])
+    }
+
+    const params = paramsOrOptions
+    const options: RouterPushOptions = maybeOptions ?? {}
+    throw new RouterPushError([source, params, { ...options, replace: true }])
+  }
+
+  return { reject, push, replace }
+}

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,8 +1,7 @@
+import { CallbackAbortResponse, CallbackPushResponse, CallbackRejectResponse, CallbackSuccessResponse } from '@/services/createCallbackContext'
 import { RegisteredRejectionType, RegisteredRouterPush, RegisteredRouterReplace } from '@/types/register'
 import { ResolvedRoute } from '@/types/resolved'
-import { Routes } from '@/types/route'
 import { RouterReject } from '@/types/router'
-import { RouterPush } from '@/types/routerPush'
 import { MaybePromise } from '@/types/utilities'
 
 /**
@@ -89,50 +88,19 @@ export type AfterRouteHookLifecycle = 'onAfterRouteEnter' | 'onAfterRouteUpdate'
 export type RouteHookLifecycle = BeforeRouteHookLifecycle | AfterRouteHookLifecycle
 
 /**
- * Defines the structure of a successful route hook response.
- */
-type RouteHookSuccessResponse = {
-  status: 'SUCCESS',
-}
-
-/**
- * Defines the structure of an aborted route hook response.
- */
-type RouteHookAbortResponse = {
-  status: 'ABORT',
-}
-
-/**
- * Defines the structure of a route hook response that results in a push to a new route.
- * @template T - The type of the routes configuration.
- */
-type RouteHookPushResponse<T extends Routes> = {
-  status: 'PUSH',
-  to: Parameters<RouterPush<T>>,
-}
-
-/**
- * Defines the structure of a route hook response that results in the rejection of a route transition.
- */
-type RouteHookRejectResponse = {
-  status: 'REJECT',
-  type: RegisteredRejectionType,
-}
-
-/**
  * Type for responses from a before route hook, which may indicate different outcomes such as success, push, reject, or abort.
  * @template TRoutes - The type of the routes configuration.
  */
-export type BeforeRouteHookResponse<TRoutes extends Routes> = RouteHookSuccessResponse | RouteHookPushResponse<TRoutes> | RouteHookRejectResponse | RouteHookAbortResponse
+export type BeforeRouteHookResponse = CallbackSuccessResponse | CallbackPushResponse | CallbackRejectResponse | CallbackAbortResponse
 
 /**
  * Type for responses from an after route hook, which may indicate different outcomes such as success, push, or reject.
  * @template TRoutes - The type of the routes configuration.
  */
-export type AfterRouteHookResponse<TRoutes extends Routes> = RouteHookSuccessResponse | RouteHookPushResponse<TRoutes> | RouteHookRejectResponse
+export type AfterRouteHookResponse = CallbackSuccessResponse | CallbackPushResponse | CallbackRejectResponse
 
 /**
  * Union type for all possible route hook responses, covering both before and after scenarios.
  * @template TRoutes - The type of the routes configuration.
  */
-export type RouteHookResponse<TRoutes extends Routes> = BeforeRouteHookResponse<TRoutes> | AfterRouteHookResponse<TRoutes>
+export type RouteHookResponse = BeforeRouteHookResponse | AfterRouteHookResponse

--- a/src/types/register.ts
+++ b/src/types/register.ts
@@ -73,3 +73,8 @@ export type RegisteredRouterPush = RouterPush<RegisteredRoutes>
  * Represents the type for router `replace`, with types for routes registered within {@link Register}
  */
 export type RegisteredRouterReplace = RouterReplace<RegisteredRoutes>
+
+/**
+ * Type for Router Reject method. Triggers rejections registered within {@link Register}
+ */
+export type RegisteredRouterReject = (type: RegisteredRejectionType) => void


### PR DESCRIPTION
# Description
Not a change to routing behavior. But abstracts the callback context for hooks into something more generic so we can use it for props. Half of this is copied from https://github.com/kitbagjs/router/pull/276 which is getting pretty outdated because main has changed quite a bit due to prefetching.

I've removed the generic from hook runners which was used for typing `push`. But that wasn't really accomplishing anything. So I replaced it with `RegisteredRouterPush` from the callback context utility. 

I also moved the hook response types to be more generic callback response types and wrote a generic handler in `createRouter`. There are some special cases for before hooks which are handled separately but before and after hooks and in the next PR props can all share the same callback response handler.