### PR TITLE
Props callback context review

### DIFF
--- a/src/errors/afterCallbackContextError.ts
+++ b/src/errors/afterCallbackContextError.ts
@@ -1,0 +1,12 @@
+import { AfterCallbackResponse } from '@/services/createCallbackContext'
+import { BeforeCallbackContextError } from '@/errors/beforeCallbackContextError'
+
+export class AfterCallbackContextError extends BeforeCallbackContextError {
+  public response: AfterCallbackResponse
+
+  public constructor(message: string, response: AfterCallbackResponse) {
+    super(message, response)
+
+    this.response = response
+  }
+}

--- a/src/errors/beforeCallbackContextError.ts
+++ b/src/errors/beforeCallbackContextError.ts
@@ -1,0 +1,11 @@
+import { BeforeCallbackResponse } from '@/services/createCallbackContext'
+
+export class BeforeCallbackContextError extends Error {
+  public response: BeforeCallbackResponse
+
+  public constructor(message: string, response: BeforeCallbackResponse) {
+    super(message)
+
+    this.response = response
+  }
+}

--- a/src/errors/callbackContextAbortError.ts
+++ b/src/errors/callbackContextAbortError.ts
@@ -1,11 +1,10 @@
 import { CallbackAbortResponse } from '@/services/createCallbackContext'
+import { BeforeCallbackContextError } from '@/errors/beforeCallbackContextError'
 
-export class CallbackContextAbortError extends Error {
-  public response: CallbackAbortResponse
-
+export class CallbackContextAbortError extends BeforeCallbackContextError {
   public constructor() {
-    super('Uncaught CallbackContextAbortError')
+    const response: CallbackAbortResponse = { status: 'ABORT' }
 
-    this.response = { status: 'ABORT' }
+    super('Uncaught CallbackContextAbortError', response)
   }
 }

--- a/src/errors/callbackContextPushError.ts
+++ b/src/errors/callbackContextPushError.ts
@@ -1,12 +1,11 @@
 import { RegisteredRouterPush } from '@/types/register'
 import { CallbackPushResponse } from '@/services/createCallbackContext'
+import { AfterCallbackContextError } from '@/errors/afterCallbackContextError'
 
-export class CallbackContextPushError extends Error {
-  public response: CallbackPushResponse
-
+export class CallbackContextPushError extends AfterCallbackContextError {
   public constructor(to: unknown[]) {
-    super('Uncaught CallbackContextPushError')
+    const response: CallbackPushResponse = { status: 'PUSH', to: to as Parameters<RegisteredRouterPush> }
 
-    this.response = { status: 'PUSH', to: to as Parameters<RegisteredRouterPush> }
+    super('Uncaught CallbackContextPushError', response)
   }
 }

--- a/src/errors/callbackContextRejectionError.ts
+++ b/src/errors/callbackContextRejectionError.ts
@@ -1,12 +1,11 @@
 import { RegisteredRejectionType } from '@/types/register'
 import { CallbackRejectResponse } from '@/services/createCallbackContext'
+import { AfterCallbackContextError } from '@/errors/afterCallbackContextError'
 
-export class CallbackContextRejectionError extends Error {
-  public response: CallbackRejectResponse
-
+export class CallbackContextRejectionError extends AfterCallbackContextError {
   public constructor(type: RegisteredRejectionType) {
-    super('Uncaught CallbackContextRejectionError')
+    const response: CallbackRejectResponse = { status: 'REJECT', type }
 
-    this.response = { status: 'REJECT', type }
+    super('Uncaught CallbackContextRejectionError', response)
   }
 }

--- a/src/services/createCallbackContext.ts
+++ b/src/services/createCallbackContext.ts
@@ -36,9 +36,14 @@ export type CallbackRejectResponse = {
 }
 
 /**
- * Defines the structure of a callback response.
+ * Defines the structure of a callback response thrown before a route changes.
  */
-export type CallbackResponse = CallbackSuccessResponse | CallbackPushResponse | CallbackRejectResponse | CallbackAbortResponse
+export type BeforeCallbackResponse = CallbackSuccessResponse | CallbackPushResponse | CallbackRejectResponse | CallbackAbortResponse
+
+/**
+ * Defines the structure of a callback response thrown after a route changes.
+ */
+export type AfterCallbackResponse = CallbackSuccessResponse | CallbackPushResponse | CallbackRejectResponse
 
 /**
  * A function that can be called to abort a routing operation.

--- a/src/services/hooks.ts
+++ b/src/services/hooks.ts
@@ -1,11 +1,10 @@
-import { CallbackContextAbortError } from '@/errors/callbackContextAbortError'
-import { CallbackContextPushError } from '@/errors/callbackContextPushError'
-import { CallbackContextRejectionError } from '@/errors/callbackContextRejectionError'
 import { RouteHookStore } from '@/services/createRouteHookStore'
 import { getAfterRouteHooksFromRoutes, getBeforeRouteHooksFromRoutes } from '@/services/getRouteHooks'
 import { AfterRouteHook, AfterRouteHookResponse, BeforeRouteHook, BeforeRouteHookResponse, RouteHookLifecycle } from '@/types/hooks'
 import { ResolvedRoute } from '@/types/resolved'
 import { createCallbackContext } from './createCallbackContext'
+import { AfterCallbackContextError } from '@/errors/afterCallbackContextError'
+import { BeforeCallbackContextError } from '@/errors/beforeCallbackContextError'
 
 type RouteHookRunners = {
   runBeforeRouteHooks: RouteHookBeforeRunner,
@@ -57,15 +56,7 @@ export function createRouteHookRunners(): RouteHookRunners {
 
       await Promise.all(results)
     } catch (error) {
-      if (error instanceof CallbackContextPushError) {
-        return error.response
-      }
-
-      if (error instanceof CallbackContextRejectionError) {
-        return error.response
-      }
-
-      if (error instanceof CallbackContextAbortError) {
+      if (error instanceof BeforeCallbackContextError) {
         return error.response
       }
 
@@ -103,11 +94,7 @@ export function createRouteHookRunners(): RouteHookRunners {
 
       await Promise.all(results)
     } catch (error) {
-      if (error instanceof CallbackContextPushError) {
-        return error.response
-      }
-
-      if (error instanceof CallbackContextRejectionError) {
+      if (error instanceof AfterCallbackContextError) {
         return error.response
       }
 


### PR DESCRIPTION
further implements the suggestion of a shared parent class so checking instances is as simple as

```ts
} catch (error) {
  if (error instanceof AfterCallbackContextError) {
    return error.response
  }

  throw error
}
```