### PR TITLE
Pass the entire resolved route rather than just the params

### DIFF
--- a/docs/core-concepts/component-props.md
+++ b/docs/core-concepts/component-props.md
@@ -1,18 +1,21 @@
 # Component Props
 
-With Kitbag Router, you can define a `props` callback on your route. Your callback is given the params for the route and any parents and what it returns will be bound to the component when the component gets mounted inside the `<router-view />`
+With Kitbag Router, you can define a `props` callback on your route. Your callback is given the [`ResolvedRoute`](/api/types/ResolvedRoute) for the route and what it returns will be bound to the component when the component gets mounted inside the `<router-view />`
 
 ```ts
 const user = createRoute({
-  props: (params) => {
-    return { foo: params.bar }
+  name: 'user',
+  path: '/user/[id]',
+  component: UserComponent,
+  props: (route) => {
+    return { userId: route.params.id }
   }
 })
 ```
 
 This is obviously useful for assigning static values or route params down to your view components props but it also gives you
 
-- Correct types on the route params.
+- Correct types on the route's params, query, etc.
 - Correct type for return type.
 - Support for async prop fetching.
 
@@ -33,8 +36,9 @@ const user = createRoute({
   name: 'user',
   path: '/user/[id]',
   component: UserComponent,
-  props: async (({ id }) => {
-    const user = await userStore.getById(id)
+  props: async (route) => {
+    const user = await userStore.getById(route.params.id)
+
     return { user }
   })
 })
@@ -59,9 +63,9 @@ const user = createRoute({
   name: 'user',
   path: '/user/[id]',
   component: UserComponent,
-  props: async (({ id }, { reject }) => {
+  props: async (route, { reject }) => {
     try {
-      const user = await userStore.getById(id)
+      const user = await userStore.getById(route.params.id)
 
       return { user }
     } catch (error) {

--- a/src/components/routerView.browser.spec.ts
+++ b/src/components/routerView.browser.spec.ts
@@ -292,15 +292,15 @@ test('Binds props and attrs from route', async () => {
     name: 'routeA',
     path: '/routeA/[param]',
     component: echo,
-    props: ({ param }) => ({ value: param }),
+    props: (route) => ({ value: route.params.param }),
   })
 
   const routeB = createRoute({
     name: 'routeB',
     path: '/routeB/[param]',
     component: echo,
-    props: async ({ param }) => {
-      return { value: param }
+    props: (route) => {
+      return { value: route.params.param }
     },
   })
 
@@ -334,15 +334,15 @@ test('Updates props and attrs when route params change', async () => {
     name: 'sync',
     path: '/sync/[param]',
     component: echo,
-    props: ({ param }) => ({ value: param }),
+    props: (route) => ({ value: route.params.param }),
   })
 
   const asyncProps = createRoute({
     name: 'async',
     path: '/async/[param]',
     component: echo,
-    props: async ({ param }) => {
-      return { value: param }
+    props: async (route) => {
+      return { value: route.params.param }
     },
   })
 

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -10,7 +10,7 @@ import { getPropsValue } from '@/utilities/props'
 
 export const propStoreKey: InjectionKey<PropStore> = Symbol()
 
-type ComponentProps = { id: string, name: string, props?: (params: Record<string, unknown>, context: CallbackContext) => unknown }
+type ComponentProps = { id: string, name: string, props?: (params: ResolvedRoute, context: CallbackContext) => unknown }
 
 type SetPropsResponse = CallbackSuccessResponse | CallbackPushResponse | CallbackRejectResponse
 
@@ -35,7 +35,7 @@ export function createPropStore(): PropStore {
         }
 
         const key = getPropKey(id, name, route)
-        const value = getPropsValue(() => props(route.params, context))
+        const value = getPropsValue(() => props(route, context))
 
         response[key] = value
 
@@ -64,7 +64,7 @@ export function createPropStore(): PropStore {
       keys.push(key)
 
       if (!store.has(key)) {
-        const value = getPropsValue(() => props(route.params, context))
+        const value = getPropsValue(() => props(route, context))
 
         store.set(key, value)
       }

--- a/src/services/createRoute.ts
+++ b/src/services/createRoute.ts
@@ -10,24 +10,13 @@ import { CreateRouteOptions, WithComponent, WithComponents, WithHooks, WithParen
 import { Hash, toHash, ToHash } from '@/types/hash'
 import { Host } from '@/types/host'
 import { toName, ToName } from '@/types/name'
-import { ExtractParamTypes } from '@/types/params'
 import { Param } from '@/types/paramTypes'
 import { Path, ToPath, toPath } from '@/types/path'
 import { Query, ToQuery, toQuery } from '@/types/query'
 import { RouteMeta } from '@/types/register'
 import { Route } from '@/types/route'
-import { Identity } from '@/types/utilities'
 import { checkDuplicateParams } from '@/utilities/checkDuplicateKeys'
 
-type ParentPath<TParent extends Route | undefined> = TParent extends Route ? TParent['path'] : Path<'', {}>
-type ParentQuery<TParent extends Route | undefined> = TParent extends Route ? TParent['query'] : Query<'', {}>
-
-type RouteParams<
-  TPath extends string | Path | undefined,
-  TQuery extends string | Query | undefined,
-  TParent extends Route | undefined = undefined
-> = ExtractParamTypes<Identity<CombinePath<ParentPath<TParent>, ToPath<TPath>>['params'] & CombineQuery<ParentQuery<TParent>, ToQuery<TQuery>>['params']>>
-
 export function createRoute<
   const TName extends string | undefined = undefined,
   const TPath extends string | Path | undefined = undefined,
@@ -67,7 +56,7 @@ export function createRoute<
   const TState extends Record<string, Param> = Record<string, Param>
 >(options: CreateRouteOptions<TName, TPath, TQuery, THash, TMeta>
   & WithHooks
-  & WithComponent<TComponent, RouteParams<TPath, TQuery>>
+  & WithComponent<TComponent, Route<ToName<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, ToHash<THash>, TMeta, TState, TName>>
   & WithoutParent
   & (WithState<TState> | WithoutState)):
 Route<ToName<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, ToHash<THash>, TMeta, TState, TName>
@@ -83,7 +72,7 @@ export function createRoute<
   const TState extends Record<string, Param> = Record<string, Param>
 >(options: CreateRouteOptions<TName, TPath, TQuery, THash, TMeta>
   & WithHooks
-  & WithComponent<TComponent, RouteParams<TPath, TQuery, TParent>>
+  & WithComponent<TComponent, Route<ToName<TName>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineHash<TParent['hash'], ToHash<THash>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TState, TParent['state']>, TName | TParent['matches'][number]['name']>>
   & WithParent<TParent>
   & (WithState<TState> | WithoutState)):
 Route<ToName<TName>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineHash<TParent['hash'], ToHash<THash>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TState, TParent['state']>, TName | TParent['matches'][number]['name']>
@@ -98,7 +87,7 @@ export function createRoute<
   const TState extends Record<string, Param> = Record<string, Param>
 >(options: CreateRouteOptions<TName, TPath, TQuery, THash, TMeta>
   & WithHooks
-  & WithComponents<TComponents, RouteParams<TPath, TQuery>>
+  & WithComponents<TComponents, Route<ToName<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, ToHash<THash>, TMeta, TState, TName>>
   & WithoutParent
   & (WithState<TState> | WithoutState)):
 Route<ToName<TName>, Host<'', {}>, ToPath<TPath>, ToQuery<TQuery>, ToHash<THash>, TMeta, TState, TName>
@@ -114,7 +103,7 @@ export function createRoute<
   const TState extends Record<string, Param> = Record<string, Param>
 >(options: CreateRouteOptions<TName, TPath, TQuery, THash, TMeta>
   & WithHooks
-  & WithComponents<TComponents, RouteParams<TPath, TQuery, TParent>>
+  & WithComponents<TComponents, Route<ToName<TName>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineHash<TParent['hash'], ToHash<THash>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TState, TParent['state']>, TName | TParent['matches'][number]['name']>>
   & WithParent<TParent>
   & (WithState<TState> | WithoutState)):
 Route<ToName<TName>, Host<'', {}>, CombinePath<TParent['path'], ToPath<TPath>>, CombineQuery<TParent['query'], ToQuery<TQuery>>, CombineHash<TParent['hash'], ToHash<THash>>, CombineMeta<TMeta, TParent['meta']>, CombineState<TState, TParent['state']>, TName | TParent['matches'][number]['name']>

--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -16,6 +16,7 @@ import { RouteMeta } from '@/types/register'
 import { Route } from '@/types/route'
 import { MaybeArray, MaybePromise } from '@/types/utilities'
 import { CallbackContext } from '@/services/createCallbackContext'
+import { ResolvedRoute } from './resolved'
 
 /**
  * Defines route hooks that can be applied before entering, updating, or leaving a route, as well as after these events.
@@ -58,13 +59,13 @@ export type WithoutParent = {
 
 export type WithComponent<
   TComponent extends Component = Component,
-  TParams extends Record<string, unknown> = Record<string, unknown>
+  TRoute extends Route = Route
 > = {
   /**
    * A Vue component, which can be either synchronous or asynchronous components.
    */
   component: TComponent,
-  props?: (params: TParams, context: CallbackContext) => TComponent extends Component ? MaybePromise<ComponentProps<TComponent>> : {},
+  props?: (route: ResolvedRoute<TRoute>, context: CallbackContext) => TComponent extends Component ? MaybePromise<ComponentProps<TComponent>> : {},
 }
 
 export function isWithComponent(options: CreateRouteOptions): options is CreateRouteOptions & WithComponent {
@@ -73,14 +74,14 @@ export function isWithComponent(options: CreateRouteOptions): options is CreateR
 
 export type WithComponents<
   TComponents extends Record<string, Component> = Record<string, Component>,
-  TParams extends Record<string, unknown> = Record<string, unknown>
+  TRoute extends Route = Route
 > = {
   /**
    * Multiple components for named views, which can be either synchronous or asynchronous components.
    */
   components: TComponents,
   props?: {
-    [TKey in keyof TComponents]?: (params: TParams, context: CallbackContext) => TComponents[TKey] extends Component ? MaybePromise<ComponentProps<TComponents[TKey]>> : {}
+    [TKey in keyof TComponents]?: (route: ResolvedRoute<TRoute>, context: CallbackContext) => TComponents[TKey] extends Component ? MaybePromise<ComponentProps<TComponents[TKey]>> : {}
   },
 }
 


### PR DESCRIPTION
# Description
Previously the props callback when creating a route passed just the params for the route in as the first argument. But there are lots of useful pieces on the route itself such as the query, hash, state, etc. Passing in the entire route offers much more functionality. 

**This is a breaking change**
Any uses of the props callback will need to change from 
```ts
createRoute({
   ...,
   props: (params) => {
    return { value: params.foo }
  }
})
```
to
```ts
createRoute({
   ...,
   props: (route) => {
    return { value: route.params.foo }
  }
})
```

Closes https://github.com/kitbagjs/router/issues/340