### PR TITLE
fixed bug with urlAssembly of query

### DIFF
--- a/src/services/urlAssembly.spec.ts
+++ b/src/services/urlAssembly.spec.ts
@@ -230,6 +230,24 @@ describe('query params', () => {
 
     expect(url).toBe('/?simple=ABC')
   })
+
+  test('given route with multiple empty and optional query params, removes both from url', () => {
+    const parent = createRoute({
+      query: 'search=[?search]'
+    })
+
+    const route = createRoute({
+      parent,
+      name: 'simple',
+      path: '/',
+      query: query('sort=[?sort]', {sort: Boolean}),
+      component,
+    })
+
+    const url = assembleUrl(route)
+
+    expect(url).toBe('/')
+  })
 })
 
 describe('static query', () => {

--- a/src/services/urlAssembly.ts
+++ b/src/services/urlAssembly.ts
@@ -64,7 +64,7 @@ function assembleQueryParamValues(query: Query, paramValues: Record<string, unkn
     return search
   }
 
-  for (const [key, value] of search.entries()) {
+  for (const [key, value] of Array.from(search.entries())) {
     const paramName = getParamName(value)
     const isNotParam = !paramName
 


### PR DESCRIPTION
Back in https://github.com/kitbagjs/router/pull/310, we extend route query support to match `URLSeachParams`. This switched from merging 2 deconstructed objects into a `for of` loop of `search.entries()`. However I discovered in our router-preview which has a `key` page with 2 optional query params and in the first iteration of `search.entries()` it found a key to delete. When it deleted it, it also updated the source of the loop, and ended up exiting the `for of` seeing only 1 total entry now.