### PR TITLE
Fix losing history on browser back

### DIFF
--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -74,7 +74,7 @@ export function createRouter<const TRoutes extends Routes, const TOptions extend
     listener: ({ location }) => {
       const url = createPath(location)
 
-      set(url, { state: location.state })
+      set(url, { state: location.state, replace: true })
     },
   })
 


### PR DESCRIPTION
@hagabaka found that after using the browser back, the rest of history would be lost. The issue was not using `replace: true` when the history listener fires inside createRouter.