### PR TITLE
Update the types for prop callback context to remove `abort`

### DIFF
--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -15,8 +15,8 @@ import { Query } from '@/types/query'
 import { RouteMeta } from '@/types/register'
 import { Route } from '@/types/route'
 import { MaybeArray, MaybePromise } from '@/types/utilities'
-import { CallbackContext } from '@/services/createCallbackContext'
 import { ResolvedRoute } from './resolved'
+import { PropsCallbackContext } from './props'
 
 /**
  * Defines route hooks that can be applied before entering, updating, or leaving a route, as well as after these events.
@@ -65,7 +65,7 @@ export type WithComponent<
    * A Vue component, which can be either synchronous or asynchronous components.
    */
   component: TComponent,
-  props?: (route: ResolvedRoute<TRoute>, context: CallbackContext) => TComponent extends Component ? MaybePromise<ComponentProps<TComponent>> : {},
+  props?: (route: ResolvedRoute<TRoute>, context: PropsCallbackContext) => TComponent extends Component ? MaybePromise<ComponentProps<TComponent>> : {},
 }
 
 export function isWithComponent(options: CreateRouteOptions): options is CreateRouteOptions & WithComponent {
@@ -81,7 +81,7 @@ export type WithComponents<
    */
   components: TComponents,
   props?: {
-    [TKey in keyof TComponents]?: (route: ResolvedRoute<TRoute>, context: CallbackContext) => TComponents[TKey] extends Component ? MaybePromise<ComponentProps<TComponents[TKey]>> : {}
+    [TKey in keyof TComponents]?: (route: ResolvedRoute<TRoute>, context: PropsCallbackContext) => TComponents[TKey] extends Component ? MaybePromise<ComponentProps<TComponents[TKey]>> : {}
   },
 }
 

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,7 +1,5 @@
-import { CallbackAbortResponse, CallbackContextAbort, CallbackPushResponse, CallbackRejectResponse, CallbackSuccessResponse } from '@/services/createCallbackContext'
-import { RegisteredRouterPush, RegisteredRouterReplace } from '@/types/register'
+import { CallbackAbortResponse, CallbackContext, CallbackContextAbort, CallbackPushResponse, CallbackRejectResponse, CallbackSuccessResponse } from '@/services/createCallbackContext'
 import { ResolvedRoute } from '@/types/resolved'
-import { RouterReject } from '@/types/router'
 import { MaybePromise } from '@/types/utilities'
 
 /**
@@ -23,9 +21,9 @@ export type AddAfterRouteHook = (hook: AfterRouteHook) => RouteHookRemove
  */
 type RouteHookContext = {
   from: ResolvedRoute | null,
-  reject: RouterReject,
-  push: RegisteredRouterPush,
-  replace: RegisteredRouterReplace,
+  reject: CallbackContext['reject'],
+  push: CallbackContext['push'],
+  replace: CallbackContext['replace'],
 }
 
 /**

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -1,0 +1,10 @@
+import { CallbackContext } from "@/services/createCallbackContext";
+
+/**
+ * Context provided to props callback functions
+ */
+export type PropsCallbackContext = {
+  push: CallbackContext['push'],
+  replace: CallbackContext['replace'],
+  reject: CallbackContext['reject'],
+}


### PR DESCRIPTION
# Description
Prop callbacks were incorrectly being passed the `abort` callback. Fetching props is not a blocking operation so navigation cannot be aborted.