### PR TITLE
Fix isRoute return type for non exact matches

### DIFF
--- a/src/guards/routes.spec-d.ts
+++ b/src/guards/routes.spec-d.ts
@@ -27,7 +27,7 @@ test('router route can be narrowed', () => {
       path: '/parentB',
       component,
     }),
-  ]
+  ]as const
 
   const { route } = createRouter(routes)
 
@@ -42,11 +42,11 @@ test('router route can be narrowed', () => {
   }
 
   if (isRoute(route, 'parentA', { exact: false })) {
-    expectTypeOf<typeof route.name>().toMatchTypeOf<'parentA' | 'parentA.childA'>()
+    expectTypeOf<typeof route.name>().toMatchTypeOf<'parentA' | 'childA'>()
   }
 
   if (isRoute(route, 'parentA')) {
-    expectTypeOf<typeof route.name>().toMatchTypeOf<'parentA' | 'parentA.childA'>()
+    expectTypeOf<typeof route.name>().toMatchTypeOf<'parentA' | 'childA'>()
   }
 
   if (route.name === 'parentA') {

--- a/src/guards/routes.ts
+++ b/src/guards/routes.ts
@@ -1,21 +1,33 @@
 import { RouterRoute, isRouterRoute } from '@/services/createRouterRoute'
+import { CreateRouteOptionsMatched } from '@/types'
 import { RegisteredRouterRoute, RegisteredRoutesName } from '@/types/register'
 
 export type IsRouteOptions = {
   exact?: boolean,
 }
 
+type RouteNamesInMatches<
+  TRoute extends RouterRoute,
+  TRouteName extends TRoute['name'],
+> = TRoute['matches'] extends (infer U)[]
+  ? U extends CreateRouteOptionsMatched<infer TNames>
+    ? TRouteName extends TNames
+      ? TNames
+      : never
+    : never
+  : never
+
 export function isRoute(route: unknown): route is RouterRoute
 
 export function isRoute<
   TRoute extends RouterRoute,
   TRouteName extends TRoute['name']
->(route: TRoute, routeName: TRouteName, options: IsRouteOptions & { exact: true }): route is TRoute & { name: TRouteName }
+>(route: TRoute, routeName: TRouteName, options: IsRouteOptions & { exact: true }): route is TRoute & {name: TRouteName}
 
 export function isRoute<
   TRoute extends RouterRoute,
   TRouteName extends TRoute['name']
->(route: TRoute, routeName: TRouteName, options?: IsRouteOptions): route is TRoute & { name: `${TRouteName}${string}` }
+>(route: TRoute, routeName: TRouteName, options?: IsRouteOptions): route is TRoute & {name: RouteNamesInMatches<typeof route, TRouteName>}
 
 export function isRoute<
   TRouteName extends RegisteredRoutesName
@@ -23,7 +35,7 @@ export function isRoute<
 
 export function isRoute<
   TRouteName extends RegisteredRoutesName
->(route: unknown, routeName: TRouteName, options?: IsRouteOptions): route is RegisteredRouterRoute & { name: `${TRouteName}${string}` }
+>(route: unknown, routeName: TRouteName, options?: IsRouteOptions): route is RegisteredRouterRoute & {name: RouteNamesInMatches<RegisteredRouterRoute, TRouteName>}
 
 export function isRoute(route: unknown, routeName?: string, options?: IsRouteOptions): boolean
 

--- a/src/guards/routes.ts
+++ b/src/guards/routes.ts
@@ -1,5 +1,4 @@
 import { RouterRoute, isRouterRoute } from '@/services/createRouterRoute'
-import { toName } from '@/types/name'
 import { RegisteredRouterRoute, RegisteredRoutesName } from '@/types/register'
 
 export type IsRouteOptions = {
@@ -37,13 +36,9 @@ export function isRoute(route: unknown, routeName?: string, { exact }: IsRouteOp
     return true
   }
 
-  const names = route.matches.map((route) => toName(route.name))
-
   if (exact) {
-    const actualRouteName = names.at(-1)
-
-    return routeName === actualRouteName
+    return route.matched.name === routeName
   }
 
-  return names.includes(routeName)
+  return route.matches.map((route) => route.name).includes(routeName)
 }

--- a/src/guards/routes.ts
+++ b/src/guards/routes.ts
@@ -1,5 +1,4 @@
 import { RouterRoute, isRouterRoute } from '@/services/createRouterRoute'
-import { CreateRouteOptionsMatched } from '@/types'
 import { RegisteredRouterRoute, RegisteredRoutesName } from '@/types/register'
 
 export type IsRouteOptions = {

--- a/src/guards/routes.ts
+++ b/src/guards/routes.ts
@@ -6,14 +6,12 @@ export type IsRouteOptions = {
   exact?: boolean,
 }
 
-type RouteNamesInMatches<
+type RouteWithMatch<
   TRoute extends RouterRoute,
-  TRouteName extends TRoute['name'],
-> = TRoute['matches'] extends (infer U)[]
-  ? U extends CreateRouteOptionsMatched<infer TNames>
-    ? TRouteName extends TNames
-      ? TNames
-      : never
+  TRouteName extends TRoute['name']
+> = TRoute extends RouterRoute
+  ? TRouteName extends TRoute['matches'][number]['name']
+    ? TRoute
     : never
   : never
 
@@ -27,7 +25,7 @@ export function isRoute<
 export function isRoute<
   TRoute extends RouterRoute,
   TRouteName extends TRoute['name']
->(route: TRoute, routeName: TRouteName, options?: IsRouteOptions): route is TRoute & {name: RouteNamesInMatches<typeof route, TRouteName>}
+>(route: TRoute, routeName: TRouteName, options?: IsRouteOptions): route is RouteWithMatch<typeof route, TRouteName>
 
 export function isRoute<
   TRouteName extends RegisteredRoutesName
@@ -35,7 +33,7 @@ export function isRoute<
 
 export function isRoute<
   TRouteName extends RegisteredRoutesName
->(route: unknown, routeName: TRouteName, options?: IsRouteOptions): route is RegisteredRouterRoute & {name: RouteNamesInMatches<RegisteredRouterRoute, TRouteName>}
+>(route: unknown, routeName: TRouteName, options?: IsRouteOptions): route is RouteWithMatch<RegisteredRouterRoute, TRouteName>
 
 export function isRoute(route: unknown, routeName?: string, options?: IsRouteOptions): boolean
 

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -15,7 +15,7 @@ export type Routes = readonly Route[]
 /**
  * The Route properties originally provided to `createRoute`. The only change is normalizing meta to always default to an empty object.
  */
-type CreateRouteOptionsMatched<TName extends string | undefined = string | undefined> = CreateRouteOptions<TName> & WithHooks & (WithHost | WithoutHost) & (WithComponent | WithComponents | WithoutComponents) & (WithParent | WithoutParent) & (WithState | WithoutState) & { id: string, meta: RouteMeta }
+export type CreateRouteOptionsMatched<TName extends string | undefined = string | undefined> = CreateRouteOptions<TName> & WithHooks & (WithHost | WithoutHost) & (WithComponent | WithComponents | WithoutComponents) & (WithParent | WithoutParent) & (WithState | WithoutState) & { id: string, meta: RouteMeta }
 
 /**
  * Represents the structure of a route within the application. Return value of `createRoute`

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -15,7 +15,7 @@ export type Routes = readonly Route[]
 /**
  * The Route properties originally provided to `createRoute`. The only change is normalizing meta to always default to an empty object.
  */
-export type CreateRouteOptionsMatched<TName extends string | undefined = string | undefined> = CreateRouteOptions<TName> & WithHooks & (WithHost | WithoutHost) & (WithComponent | WithComponents | WithoutComponents) & (WithParent | WithoutParent) & (WithState | WithoutState) & { id: string, meta: RouteMeta }
+type CreateRouteOptionsMatched<TName extends string | undefined = string | undefined> = CreateRouteOptions<TName> & WithHooks & (WithHost | WithoutHost) & (WithComponent | WithComponents | WithoutComponents) & (WithParent | WithoutParent) & (WithState | WithoutState) & { id: string, meta: RouteMeta }
 
 /**
  * Represents the structure of a route within the application. Return value of `createRoute`


### PR DESCRIPTION
# Description
Fixes a bug with the `isRoute` type guard where non exact matches were not being correctly narrowed. 