### PR TITLE
Make sure docs use `as const` when necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ const About = { template: '<div>About</div>' }
 export const routes = [
   createRoute({ name: 'home', path: '/', component: Home }),
   createRoute({ name: 'path', path: '/about', component: About }),
-]
+] as const
 ```
 
 ## Plugin

--- a/docs/advanced-concepts/hooks.md
+++ b/docs/advanced-concepts/hooks.md
@@ -64,14 +64,12 @@ router.onAfterRouteEnter((to, context) => {
 ### Route
 
 ```ts
-const routes = [
-  createRoute({
-    name: 'Home',
-    onAfterRouteEnter: (to, context) => {
-      ...
-    }
-  })
-]
+createRoute({
+  name: 'Home',
+  onAfterRouteEnter: (to, context) => {
+    ...
+  }
+})
 ```
 
 ### Component

--- a/docs/advanced-concepts/prefetching.md
+++ b/docs/advanced-concepts/prefetching.md
@@ -98,18 +98,17 @@ const router = createRouter({
 If you want to enable or disable prefetching for specific routes, you can do so by adding a prefetch property to your route definition.
 
 ```ts
-const routes = [
-  {
-    path: '/about',
-    component: () => import('./About.vue'),
-    prefetch: true, // enable prefetching for this route
-  },
-  {
-    path: '/contact',
-    component: () => import('./Contact.vue'),
-    prefetch: false, // disable prefetching for this route
-  },
-];
+const about = createRoute({
+  path: '/about',
+  component: () => import('./About.vue'),
+  prefetch: true, // enable prefetching for this route
+})
+
+const contact = createRoute({
+  path: '/contact',
+  component: () => import('./Contact.vue'),
+  prefetch: false, // disable prefetching for this route
+})
 ```
 
 ### Per-Link Configuration

--- a/docs/advanced-concepts/route-state.md
+++ b/docs/advanced-concepts/route-state.md
@@ -3,19 +3,15 @@
 It may be useful to store state for a given route to improve your user's experience. In situations like a form that a user might fill out, it might be useful to store form values in the [browser state](https://developer.mozilla.org/en-US/docs/Web/API/History/state) so that if the user navigates unexpectedly the values can be restored when going back. Kitbag Router extends this functionality by offering the same [param experience](/core-concepts/route-params#param-types) on `path`, `query`, etc on state as well.
 
 ```ts
-import { createRoute, createRouter } from '@kitbag/router'
+import { createRoute } from '@kitbag/router'
 
-const routes = [
-  createRoute({ 
-    name: 'example-form',
-    state: {
-      email: String,
-      active: Boolean,
-    }
-  }),
-]
-
-const router = createRouter(routes)
+const route = createRoute({ 
+  name: 'example-form',
+  state: {
+    email: String,
+    active: Boolean,
+  }
+})
 ```
 
 ## Always Optional
@@ -23,16 +19,14 @@ const router = createRouter(routes)
 State properties are always expected to be optional. The only exception to this is when your state property is defined with the `withDefault` utility.
 
 ```ts
-const routes = [
-  createRoute({ 
-    name: 'example-form',
-    state: {
-      email: String,
-      active: Boolean, // [!code --]
-      active: withDefault(Boolean, false), // [!code ++]
-    }
-  }),
-]
+const route = createRoute({ 
+  name: 'example-form',
+  state: {
+    email: String,
+    active: Boolean, // [!code --]
+    active: withDefault(Boolean, false), // [!code ++]
+  }
+})
 ```
 
 ## Reading State

--- a/docs/api/functions/createRouter.md
+++ b/docs/api/functions/createRouter.md
@@ -39,7 +39,7 @@ const About = { template: '<div>About</div>' }
 export const routes = [
   createRoute({ name: 'home', path: '/', component: Home }),
   createRoute({ name: 'path', path: '/about', component: About }),
-]
+] as const
 
 const router = createRouter(routes)
 ```
@@ -83,7 +83,7 @@ const About = { template: '<div>About</div>' }
 export const routes = [
   createRoute({ name: 'home', path: '/', component: Home }),
   createRoute({ name: 'path', path: '/about', component: About }),
-]
+] as const
 
 const router = createRouter(routes)
 ```

--- a/docs/core-concepts/defining-routes.md
+++ b/docs/core-concepts/defining-routes.md
@@ -10,7 +10,7 @@ import { createRoute } from '@kitbag/router'
 const routes = [
   createRoute({ name: 'home', path: '/', component: Home }),
   createRoute({ name: 'path', path: '/about', component: About }),
-]
+] as const
 
 const router = createRouter(routes)
 ```
@@ -105,7 +105,7 @@ const routerApiDocs = createExternalRoute({
   path: '/api/[topic]',
 })
 
-export const documentationRoutes = [routerDocs, routerApiDocs]
+export const documentationRoutes = [routerDocs, routerApiDocs] as const
 ```
 
 Now we can include these routes with all of the internal routes your app already uses.
@@ -122,7 +122,7 @@ export const routes = [
     component: defineAsyncComponent(() => import('@/views/HomeView.vue')),
   }),
   ...
-])
+] as const
 
 export const router = createRouter([routes, documentationRoutes])
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,7 +28,7 @@ const About = { template: '<div>About</div>' }
 export const routes = [
   createRoute({ name: 'home', path: '/', component: Home }),
   createRoute({ name: 'path', path: '/about', component: About }),
-]
+] as const
 ```
 
 :::


### PR DESCRIPTION
# Description
When defining an array of routes its important to use `as const` otherwise the type returned by `createRouter` won't be as useful