### PR TITLE
Fix prefetching components with strategy `lazy` throwing component context error

### DIFF
--- a/src/compositions/usePrefetching.ts
+++ b/src/compositions/usePrefetching.ts
@@ -96,13 +96,13 @@ function prefetchComponentsForRoute(strategy: PrefetchStrategy, route: ResolvedR
     }
 
     if (isWithComponent(route) && isAsyncComponent(route.component)) {
-      route.component.setup()
+      route.component.__asyncLoader()
     }
 
     if (isWithComponents(route)) {
       Object.values(route.components).forEach((component) => {
         if (isAsyncComponent(component)) {
-          component.setup()
+          component.__asyncLoader()
         }
       })
     }

--- a/src/utilities/components.ts
+++ b/src/utilities/components.ts
@@ -10,8 +10,8 @@ const asyncComponent = defineAsyncComponent<Component>(() => {
   })
 })
 
-type ComponentWithSetup = Component & { setup: () => void }
+type ComponentWithAsyncLoader = Component & { __asyncLoader: () => void }
 
-export function isAsyncComponent(component: Component): component is ComponentWithSetup {
-  return component.name === asyncComponent.name && 'setup' in component
+export function isAsyncComponent(component: Component): component is ComponentWithAsyncLoader {
+  return component.name === asyncComponent.name && '__asyncLoader' in component
 }


### PR DESCRIPTION
# Description
Prefetching components using a `lazy` strategy was throwing this error
```
TypeError: Cannot read properties of null (reading 'ids'
```
This was because to prefetch components we had been calling `setup` manually on vue's AsyncComponentWrapper component. However the setup for AsyncComponentWrapper requires a component context to hook up suspense functionality. So calling setup outside the router link's component setup (when the lazy strategy is executed) there was no instance. 

Fixing this by calling the [loader function](https://github.com/vuejs/core/blob/201936f9a3909ae9dca4e131e1f5ad5a1c0feb77/packages/runtime-core/src/apiAsyncComponent.ts#L121) directly. 