### PR TITLE
add "href" property to ResolvedRoute

### DIFF
--- a/docs/advanced-concepts/transitions.md
+++ b/docs/advanced-concepts/transitions.md
@@ -7,7 +7,7 @@ The `RouterView` component provides a default slot to support layering in a [Vue
   <template #default={ component }>
     <transition name="fade">
       <component :is="Component" />
-    </transition>G
+    </transition>
   </template>
 </router-view>
 ```G

--- a/docs/advanced-concepts/transitions.md
+++ b/docs/advanced-concepts/transitions.md
@@ -7,19 +7,19 @@ The `RouterView` component provides a default slot to support layering in a [Vue
   <template #default={ component }>
     <transition name="fade">
       <component :is="Component" />
-    </transition>
+    </transition>G
   </template>
 </router-view>
-```
+```G
 
 ## Avoid Reusing Components
 
-Vue will occasionally reuse components if a route change ends up rendering the same underlying component. You avoid this by [using the `key` attribute](https://vuejs.org/api/built-in-special-attributes.html#key).
+Vue will occasionally reuse components if a route change ends up rendering the same underlying component. You can avoid this by [using the `key` attribute](https://vuejs.org/api/built-in-special-attributes.html#key).
 
 ```html{3}
 <router-view>
   <template #default={ component, route }>
-    <transition name="fade" :key="route.key">
+    <transition name="fade" :key="route.href">
       <component :is="Component" />
     </transition>
   </template>

--- a/src/services/createRouterReject.ts
+++ b/src/services/createRouterReject.ts
@@ -46,7 +46,7 @@ export function createRouterReject({
       state: {},
     }
 
-    const resolved = {
+    return {
       id: route.id,
       matched: route,
       matches: [route],
@@ -54,10 +54,9 @@ export function createRouterReject({
       query: createResolvedRouteQuery(''),
       params: {},
       state: {},
+      href: '/',
       [isRejectionRouteSymbol]: true,
     }
-
-    return resolved
   }
 
   const setRejection: RouterSetReject = (type) => {

--- a/src/services/createRouterRoute.ts
+++ b/src/services/createRouterRoute.ts
@@ -14,6 +14,7 @@ export type RouterRoute<TRoute extends ResolvedRoute = ResolvedRoute> = {
   readonly matches: TRoute['matches'],
   readonly hash: TRoute['hash'],
   readonly update: RouteUpdate<TRoute>,
+  readonly href: TRoute['href'],
 
   params: TRoute['params'],
   state: TRoute['state'],
@@ -66,7 +67,7 @@ export function createRouterRoute<TRoute extends ResolvedRoute>(route: TRoute, p
     update({}, { query })
   }
 
-  const { id, matched, matches, name, hash } = toRefs(route)
+  const { id, matched, matches, name, hash, href } = toRefs(route)
 
   const params = computed({
     get() {
@@ -129,6 +130,7 @@ export function createRouterRoute<TRoute extends ResolvedRoute>(route: TRoute, p
     hash,
     params,
     name,
+    href,
     update,
     [isRouterRouteSymbol]: true,
   })

--- a/src/services/getResolvedRouteForUrl.ts
+++ b/src/services/getResolvedRouteForUrl.ts
@@ -7,6 +7,7 @@ import { getStateValues } from '@/services/state'
 import { ResolvedRoute } from '@/types/resolved'
 import { Routes } from '@/types/route'
 import { RouteMatchRule } from '@/types/routeMatchRule'
+import { asUrl } from '@/types'
 
 const rules: RouteMatchRule[] = [
   isNamedRoute,
@@ -39,5 +40,6 @@ export function getResolvedRouteForUrl(routes: Routes, url: string, state?: unkn
     params: getRouteParamValues(route, url),
     state: getStateValues(route.state, state),
     hash,
+    href: asUrl(url)
   }
 }

--- a/src/services/hooks.spec.ts
+++ b/src/services/hooks.spec.ts
@@ -28,6 +28,7 @@ test('calls hook with correct routes', () => {
     query: createResolvedRouteQuery(),
     params: {},
     state: {},
+    href: '/',
   }
 
   const fromOptions = {
@@ -46,6 +47,7 @@ test('calls hook with correct routes', () => {
     query: createResolvedRouteQuery(),
     params: {},
     state: {},
+    href: '/',
   }
 
   runBeforeRouteHooks({
@@ -98,6 +100,7 @@ test.each<{ type: string, status: string, hook: BeforeRouteHook }>([
     query: createResolvedRouteQuery(),
     params: {},
     state: {},
+    href: '/',
   }
 
   const fromOptions = {
@@ -116,6 +119,7 @@ test.each<{ type: string, status: string, hook: BeforeRouteHook }>([
     query: createResolvedRouteQuery(),
     params: {},
     state: {},
+    href: '/',
   }
 
   const response = await runBeforeRouteHooks({
@@ -151,6 +155,7 @@ test('hook is called in order', async () => {
     query: createResolvedRouteQuery(),
     params: {},
     state: {},
+    href: '/',
   }
 
   const fromOptions = {
@@ -169,6 +174,7 @@ test('hook is called in order', async () => {
     query: createResolvedRouteQuery(),
     params: {},
     state: {},
+    href: '/',
   }
 
   await runBeforeRouteHooks({

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -2,6 +2,7 @@ import { ExtractRouteParamTypes } from '@/types/params'
 import { ResolvedRouteQuery } from '@/types/resolvedQuery'
 import { Route } from '@/types/route'
 import { ExtractRouteStateParamsAsOptional } from '@/types/state'
+import { Url } from '@/types/url'
 
 /**
  * Represents a route that the router has matched to current browser location.
@@ -41,4 +42,8 @@ export type ResolvedRoute<TRoute extends Route = Route> = Readonly<{
    * Type for additional data intended to be stored in history state.
    */
   state: ExtractRouteStateParamsAsOptional<TRoute['state']>,
+  /**
+   * String value of the resolved URL.
+   */
+  href: Url,
 }>

--- a/src/utilities/testHelpers.ts
+++ b/src/utilities/testHelpers.ts
@@ -94,5 +94,6 @@ export function mockResolvedRoute(matched: ResolvedRoute['matched'], matches: Re
     query: createResolvedRouteQuery(),
     params: {},
     state: {},
+    href: '/',
   }
 }


### PR DESCRIPTION
this is step 1 of a couple different initiatives.

1.) we need a key that's unique to handle transitions when params change, currently using `route.id` but that won't change when params change. With this new `href` property, we will have a better candidate. (this is really just a 1 line docs change, so I decided to commit it here)


2.) we want to avoid "widening" the route inside of RouterLink, currently users might use an explicit route name as part of the `ToCallback` which uses RouterResolve and returns a Url. Once we "widen" from an explicit route name to a Url, we've found that will sometimes actually point to a different route now, causing a bad DX and confusion.