### PR TITLE
Update `useVisibilityObserver` to be reactive to ref changes

### DIFF
--- a/src/compositions/usePrefetching.ts
+++ b/src/compositions/usePrefetching.ts
@@ -20,7 +20,7 @@ export function usePrefetching(config: MaybeRefOrGetter<UsePrefetchingConfig>): 
   const element = ref<HTMLElement>()
 
   const { getPrefetchProps, setPrefetchProps } = usePropStore()
-  const { observe, unobserve, isElementVisible } = useVisibilityObserver()
+  const { isElementVisible } = useVisibilityObserver(element)
 
   const commit: UsePrefetching['commit'] = () => {
     const props = Array.from(prefetchedProps.values()).reduce((accumulator, value) => {
@@ -32,23 +32,6 @@ export function usePrefetching(config: MaybeRefOrGetter<UsePrefetchingConfig>): 
     setPrefetchProps(props)
   }
 
-  onMounted(() => {
-    if (!element.value) {
-      console.warn('The usePrefetching composition will not work correctly if the element ref is not bound.')
-      return
-    }
-
-    observe(element.value)
-  })
-
-  onBeforeUnmount(() => {
-    if (!element.value) {
-      return
-    }
-
-    unobserve(element.value)
-  })
-
   watch(() => toValue(config), ({ route, ...configs }) => {
     prefetchedProps.clear()
 
@@ -59,7 +42,7 @@ export function usePrefetching(config: MaybeRefOrGetter<UsePrefetchingConfig>): 
     doPrefetchingForStrategy('eager', route, configs)
   }, { immediate: true })
 
-  watch(() => Boolean(element.value && isElementVisible(element.value)), (isVisible) => {
+  watch(isElementVisible, (isVisible) => {
     const { route, ...configs } = toValue(config)
 
     if (!route || !isVisible) {

--- a/src/compositions/usePrefetching.ts
+++ b/src/compositions/usePrefetching.ts
@@ -1,4 +1,4 @@
-import { MaybeRefOrGetter, onBeforeUnmount, onMounted, ref, Ref, toValue, watch } from 'vue'
+import { MaybeRefOrGetter, ref, Ref, toValue, watch } from 'vue'
 import { usePropStore } from '@/compositions/usePropStore'
 import { isWithComponent, isWithComponents } from '@/types/createRouteOptions'
 import { getPrefetchOption, PrefetchConfigs, PrefetchStrategy } from '@/types/prefetch'

--- a/src/compositions/useVisibilityObserver.ts
+++ b/src/compositions/useVisibilityObserver.ts
@@ -1,15 +1,39 @@
 import { RouterNotInstalledError } from "@/errors/routerNotInstalledError"
 import { VisibilityObserver } from "@/services/createVisibilityObserver"
-import { inject, InjectionKey } from "vue"
+import { computed, inject, InjectionKey, Ref, watch } from "vue"
+
+type UseVisibilityObserver = {
+  isElementVisible: Ref<boolean>
+}
 
 export const visibilityObserverKey: InjectionKey<VisibilityObserver> = Symbol('visibilityObserver')
 
-export function useVisibilityObserver(): VisibilityObserver {
+export function useVisibilityObserver(element: Ref<Element | undefined>): UseVisibilityObserver {
   const observer = inject(visibilityObserverKey)
 
   if (!observer) {
     throw new RouterNotInstalledError()
   }
 
-  return observer
+  watch(element, (element, previousElement) => {
+    if (element) {
+      observer.observe(element)
+    }
+
+    if (previousElement) {
+      observer.unobserve(previousElement)
+    }
+  }, { immediate: true })
+
+  const isElementVisible = computed(() => {
+    if (!element.value) {
+      return false
+    }
+
+    return observer.isElementVisible(element.value)
+  })
+
+  return {
+    isElementVisible,
+  }
 }


### PR DESCRIPTION
# Description
Since `useLink` can be used to create custom link elements, its possible the element template ref won't be available on mount or that it might be dynamic. Updating `useVisibilityObserver` to be more resilient to changes to the element template ref