### PR TITLE
add ResolvedRouteQuery to QuerySource union

### DIFF
--- a/src/services/createResolvedRouteQuery.ts
+++ b/src/services/createResolvedRouteQuery.ts
@@ -1,4 +1,4 @@
-import { ResolvedRouteQuery } from '@/types/resolvedQuery'
+import { isResolvedRouteQuerySymbol, ResolvedRouteQuery } from '@/types/resolvedQuery'
 
 /**
  * Creates a dumb wrapper around URLSearchParams because URLSearchParams cannot be correctly be proxied to support writing params to the RouterRoute
@@ -26,5 +26,6 @@ export function createResolvedRouteQuery(query?: string): ResolvedRouteQuery {
     keys: (...args) => params.keys(...args),
     values: (...args) => params.values(...args),
     has: (...args) => params.has(...args),
+    [isResolvedRouteQuerySymbol]: true,
   }
 }

--- a/src/types/query.ts
+++ b/src/types/query.ts
@@ -3,8 +3,9 @@ import { ExtractParamName, ExtractPathParamType, ParamEnd, ParamStart } from '@/
 import { Param } from '@/types/paramTypes'
 import { Identity } from '@/types/utilities'
 import { isRecord } from '@/utilities/guards'
+import { ResolvedRouteQuery } from '@/types/resolvedQuery'
 
-export type QuerySource = ConstructorParameters<typeof URLSearchParams>[0]
+export type QuerySource = ConstructorParameters<typeof URLSearchParams>[0] | ResolvedRouteQuery
 
 type ExtractQueryParamsFromQueryString<
   TQuery extends string,

--- a/src/types/resolvedQuery.ts
+++ b/src/types/resolvedQuery.ts
@@ -1,3 +1,5 @@
+export const isResolvedRouteQuerySymbol = Symbol('isResolvedRouteQuerySymbol')
+
 export type ResolvedRouteQuery = {
   append: URLSearchParams['append'],
   delete: URLSearchParams['delete'],
@@ -10,4 +12,9 @@ export type ResolvedRouteQuery = {
   set: URLSearchParams['set'],
   toString: URLSearchParams['toString'],
   values: URLSearchParams['values'],
+  [isResolvedRouteQuerySymbol]: true,
+}
+
+export function isResolvedRouteQuery(value: unknown): value is ResolvedRouteQuery {
+  return typeof value === 'object' && value !== null && isResolvedRouteQuerySymbol in value
 }

--- a/src/utilities/urlSearchParams.ts
+++ b/src/utilities/urlSearchParams.ts
@@ -1,11 +1,12 @@
 import { createUrl } from '@/services/urlCreator'
 import { parseUrl } from '@/services/urlParser'
 import { QuerySource } from '@/types/query'
+import { isResolvedRouteQuery } from '@/types/resolvedQuery'
 import { Url } from '@/types/url'
 
 export function combineUrlSearchParams(aParams: URLSearchParams | QuerySource, bParams: URLSearchParams | QuerySource): URLSearchParams {
-  const combinedParams = new URLSearchParams(aParams)
-  const paramsToAdd = new URLSearchParams(bParams)
+  const combinedParams = createUrlSearchParams(aParams)
+  const paramsToAdd = createUrlSearchParams(bParams)
 
   for (const [key, value] of paramsToAdd.entries()) {
     combinedParams.append(key, value)
@@ -18,4 +19,12 @@ export function appendQuery(url: Url, query: QuerySource): Url {
   const { searchParams, ...parts } = parseUrl(url)
 
   return createUrl({ ...parts, searchParams: combineUrlSearchParams(searchParams, query) })
+}
+
+function createUrlSearchParams(query: QuerySource): URLSearchParams {
+  if (isResolvedRouteQuery(query)) {
+    return new URLSearchParams(query.toString())
+  }
+
+  return new URLSearchParams(query)
 }


### PR DESCRIPTION
closes #372

This approach might be too heavy handed as it adds a private symbol to our `ResolvedQuery` type to so that we can discriminate it from the `URLSearchParams` it's intended to mirror.

This means we can continue to pass `QuerySource` args into `new URLSearchParams()` constructor and only call `toString()` if we know it's our `ResolvedQuery`