### PR TITLE
coalescing around "wrapper" for mounted const in tests

### DIFF
--- a/src/components/routerLink.browser.spec.ts
+++ b/src/components/routerLink.browser.spec.ts
@@ -73,13 +73,13 @@ test.each([
     template: '<RouterView />',
   }
 
-  const app = mount(root, {
+  const wrapper = mount(root, {
     global: {
       plugins: [router],
     },
   })
 
-  app.find('a').trigger('click')
+  wrapper.find('a').trigger('click')
 
   const [, options] = spy.mock.lastCall ?? []
 
@@ -127,7 +127,7 @@ test('to prop as string renders and routes correctly', () => {
 
 test.each<{ to: Url, match: boolean, exactMatch: boolean }>([
   { to: '/parent-route', match: true, exactMatch: false },
-  { to: '/parent-route/child-route', match: true, exactMatch: true},
+  { to: '/parent-route/child-route', match: true, exactMatch: true },
   { to: '/other-route', match: false, exactMatch: false },
 ])('isMatch and isExactMatch classes and slot props works as expected', async ({ to, match, exactMatch }) => {
   const parentRoute = createRoute({
@@ -187,43 +187,42 @@ test('isMatch correctly matches parent when sibling has the same url', async () 
   const parentRoute = createRoute({
     name: 'parent',
     path: '/parent',
-  });
+  })
 
   const siblingRoute = createRoute({
     parent: parentRoute,
     name: 'sibling',
     component,
-  });
+  })
 
   const childRoute = createRoute({
     parent: parentRoute,
     name: 'child',
     path: '/child',
     component: () => h(routerLink, { to: (resolve) => resolve('parent') }, 'parent'),
-  });
+  })
 
   const router = createRouter([parentRoute, siblingRoute, childRoute], {
     initialUrl: '/parent/child',
-  });
+  })
 
   const root = {
     template: '<RouterView />',
   }
 
-  const app = mount(root, {
+  const wrapper = mount(root, {
     global: {
       plugins: [router],
     },
-  });
+  })
 
   await router.start()
 
-  const link = app.find('a')
+  const link = wrapper.find('a')
 
   expect(link.classes()).toContain('router-link--match')
   expect(link.classes()).not.toContain('router-link--exact-match')
-});
-
+})
 
 test.each([
   [true],
@@ -574,7 +573,7 @@ describe('prefetch props', () => {
       template: '<RouterView />',
     }
 
-    const app = mount(root, {
+    const wrapper = mount(root, {
       global: {
         plugins: [router],
       },
@@ -582,13 +581,13 @@ describe('prefetch props', () => {
 
     expect(props).toHaveBeenCalledOnce()
 
-    await app.find('a').trigger('click')
+    await wrapper.find('a').trigger('click')
 
     await flushPromises()
 
     expect(router.route.name).toBe('echo')
     expect(props).toHaveBeenCalledOnce()
-    expect(app.text()).toBe(value)
+    expect(wrapper.text()).toBe(value)
   })
 
   test('parent routes that should not prefetch props are not prefetched', async () => {
@@ -662,7 +661,7 @@ describe('prefetch props', () => {
     await router.start()
 
     const visible = ref(false)
-    
+
     const root = {
       template: '<RouterView />',
       provide: {
@@ -684,7 +683,7 @@ describe('prefetch props', () => {
     expect(callback).not.toHaveBeenCalled()
 
     visible.value = true
-    
+
     await nextTick()
 
     expect(callback).toHaveBeenCalled()
@@ -718,7 +717,7 @@ describe('prefetch props', () => {
     await router.start()
 
     const visible = ref(false)
-    
+
     const root = {
       template: '<RouterView />',
       provide: {
@@ -740,7 +739,7 @@ describe('prefetch props', () => {
     expect(loaded).toBe(false)
 
     visible.value = true
-    
+
     await nextTick()
 
     expect(loaded).toBe(true)

--- a/src/components/routerView.browser.spec.ts
+++ b/src/components/routerView.browser.spec.ts
@@ -28,13 +28,13 @@ test('renders component for initial route', async () => {
     template: '<RouterView/>',
   }
 
-  const app = mount(root, {
+  const wrapper = mount(root, {
     global: {
       plugins: [router],
     },
   })
 
-  expect(app.html()).toBe('hello world')
+  expect(wrapper.html()).toBe('hello world')
 })
 
 test('renders components for initial route', async () => {
@@ -60,13 +60,13 @@ test('renders components for initial route', async () => {
     template: '<RouterView />',
   }
 
-  const app = mount(root, {
+  const wrapper = mount(root, {
     global: {
       plugins: [router],
     },
   })
 
-  expect(app.html()).toBe('Child')
+  expect(wrapper.html()).toBe('Child')
 })
 
 test('updates components when route changes', async () => {
@@ -96,7 +96,7 @@ test('updates components when route changes', async () => {
     template: '<RouterView />',
   }
 
-  const app = mount(root, {
+  const wrapper = mount(root, {
     global: {
       plugins: [router],
     },
@@ -104,19 +104,19 @@ test('updates components when route changes', async () => {
 
   await router.start()
 
-  expect(app.html()).toBe('Foo')
+  expect(wrapper.html()).toBe('Foo')
 
   await router.push('/bar')
 
-  expect(app.html()).toBe('Bar')
+  expect(wrapper.html()).toBe('Bar')
 
   await router.push('/zoo')
 
-  expect(app.html()).toBe('Zoo')
+  expect(wrapper.html()).toBe('Zoo')
 
   await router.push('/foo')
 
-  expect(app.html()).toBe('Foo')
+  expect(wrapper.html()).toBe('Foo')
 })
 
 test('resolves async components', async () => {
@@ -134,7 +134,7 @@ test('resolves async components', async () => {
     template: '<RouterView/>',
   }
 
-  const app = mount(root, {
+  const wrapper = mount(root, {
     global: {
       plugins: [router],
     },
@@ -143,7 +143,7 @@ test('resolves async components', async () => {
   await router.start()
   await flushPromises()
 
-  expect(app.html()).toBe(helloWorld.template)
+  expect(wrapper.html()).toBe(helloWorld.template)
 })
 
 test('Renders the genericRejection component when the initialUrl does not match', async () => {
@@ -157,13 +157,13 @@ test('Renders the genericRejection component when the initialUrl does not match'
     template: '<RouterView/>',
   }
 
-  const app = mount(root, {
+  const wrapper = mount(root, {
     global: {
       plugins: [router],
     },
   })
 
-  expect(app.text()).toBe('NotFound')
+  expect(wrapper.text()).toBe('NotFound')
 })
 
 test('Renders custom genericRejection component when the initialUrl does not match', async () => {
@@ -181,7 +181,7 @@ test('Renders custom genericRejection component when the initialUrl does not mat
     template: '<RouterView/>',
   }
 
-  const app = mount(root, {
+  const wrapper = mount(root, {
     global: {
       plugins: [router],
     },
@@ -193,7 +193,7 @@ test('Renders custom genericRejection component when the initialUrl does not mat
 
   const route = mount(router.route.matched.component)
 
-  expect(app.text()).toBe(NotFound.template)
+  expect(wrapper.text()).toBe(NotFound.template)
   expect(route.text()).toBe(NotFound.template)
 })
 
@@ -214,7 +214,7 @@ test('Renders the NotFound component when the router.push does not match', async
     template: '<RouterView/>',
   }
 
-  const app = mount(root, {
+  const wrapper = mount(root, {
     global: {
       plugins: [router],
     },
@@ -222,7 +222,7 @@ test('Renders the NotFound component when the router.push does not match', async
 
   await router.push('/does-not-exist')
 
-  expect(app.text()).toBe('NotFound')
+  expect(wrapper.text()).toBe('NotFound')
 })
 
 test('Renders the route component when the router.push does match after a rejection', async () => {
@@ -242,17 +242,17 @@ test('Renders the route component when the router.push does match after a reject
     template: '<RouterView/>',
   }
 
-  const app = mount(root, {
+  const wrapper = mount(root, {
     global: {
       plugins: [router],
     },
   })
 
-  expect(app.text()).toBe('NotFound')
+  expect(wrapper.text()).toBe('NotFound')
 
   await router.push('/')
 
-  expect(app.text()).toBe('hello world')
+  expect(wrapper.text()).toBe('hello world')
 })
 
 test('Renders the multiple components when using named route views', async () => {
@@ -280,13 +280,13 @@ test('Renders the multiple components when using named route views', async () =>
     `,
   }
 
-  const app = mount(root, {
+  const wrapper = mount(root, {
     global: {
       plugins: [router],
     },
   })
 
-  expect(app.text()).toBe('_one__default__two_')
+  expect(wrapper.text()).toBe('_one__default__two_')
 })
 
 test('Binds props and attrs from route', async () => {
@@ -316,7 +316,7 @@ test('Binds props and attrs from route', async () => {
     template: '<RouterView/>',
   }
 
-  const app = mount(root, {
+  const wrapper = mount(root, {
     global: {
       plugins: [router],
     },
@@ -324,11 +324,11 @@ test('Binds props and attrs from route', async () => {
 
   await router.push('/routeA/hello')
 
-  expect(app.html()).toBe('hello')
+  expect(wrapper.html()).toBe('hello')
 
   await router.push('/routeB/world')
 
-  expect(app.html()).toBe('world')
+  expect(wrapper.html()).toBe('world')
 })
 
 test('Updates props and attrs when route params change', async () => {
@@ -358,7 +358,7 @@ test('Updates props and attrs when route params change', async () => {
     template: '<RouterView/>',
   }
 
-  const app = mount(root, {
+  const wrapper = mount(root, {
     global: {
       plugins: [router],
     },
@@ -366,23 +366,23 @@ test('Updates props and attrs when route params change', async () => {
 
   await router.push('sync', { param: 'foo' })
 
-  expect(app.html()).toBe('foo')
+  expect(wrapper.html()).toBe('foo')
 
   await router.push('sync', { param: 'bar' })
 
-  expect(app.html()).toBe('bar')
+  expect(wrapper.html()).toBe('bar')
 
   await router.push('async', { param: 'async-foo' })
 
   await flushPromises()
 
-  expect(app.html()).toBe('async-foo')
+  expect(wrapper.html()).toBe('async-foo')
 
   await router.push('async', { param: 'async-bar' })
 
   await flushPromises()
 
-  expect(app.html()).toBe('async-bar')
+  expect(wrapper.html()).toBe('async-bar')
 })
 
 test('Props from route can trigger push', async () => {
@@ -414,7 +414,7 @@ test('Props from route can trigger push', async () => {
     template: '<RouterView/>',
   }
 
-  const app = mount(root, {
+  const wrapper = mount(root, {
     global: {
       plugins: [router],
     },
@@ -424,7 +424,7 @@ test('Props from route can trigger push', async () => {
 
   await flushPromises()
 
-  expect(app.html()).toBe('routeB')
+  expect(wrapper.html()).toBe('routeB')
 })
 
 test('Props from route can trigger reject', async () => {
@@ -447,7 +447,7 @@ test('Props from route can trigger reject', async () => {
     template: '<RouterView/>',
   }
 
-  const app = mount(root, {
+  const wrapper = mount(root, {
     global: {
       plugins: [router],
     },
@@ -457,7 +457,7 @@ test('Props from route can trigger reject', async () => {
 
   await flushPromises()
 
-  expect(app.html()).toBe('<h1>NotFound</h1>')
+  expect(wrapper.html()).toBe('<h1>NotFound</h1>')
 })
 
 test('prefetched props trigger push when navigation is initiated', async () => {
@@ -496,19 +496,19 @@ test('prefetched props trigger push when navigation is initiated', async () => {
     template: '<RouterView/>',
   }
 
-  const app = mount(root, {
+  const wrapper = mount(root, {
     global: {
       plugins: [router],
     },
   })
 
-  expect(app.text()).toBe('routeB')
+  expect(wrapper.text()).toBe('routeB')
 
-  app.find('a').trigger('click')
+  wrapper.find('a').trigger('click')
 
   await flushPromises()
 
-  expect(app.text()).toBe('routeC')
+  expect(wrapper.text()).toBe('routeC')
 })
 
 test('prefetched async props trigger push when navigation is initiated', async () => {
@@ -547,17 +547,17 @@ test('prefetched async props trigger push when navigation is initiated', async (
     template: '<RouterView/>',
   }
 
-  const app = mount(root, {
+  const wrapper = mount(root, {
     global: {
       plugins: [router],
     },
   })
 
-  expect(app.text()).toBe('routeB')
+  expect(wrapper.text()).toBe('routeB')
 
-  app.find('a').trigger('click')
+  wrapper.find('a').trigger('click')
 
   await flushPromises()
 
-  expect(app.text()).toBe('routeC')
+  expect(wrapper.text()).toBe('routeC')
 })

--- a/src/services/component.browser.spec.ts
+++ b/src/services/component.browser.spec.ts
@@ -23,7 +23,7 @@ test('renders component with sync props', async () => {
     template: '<RouterView/>',
   }
 
-  const app = mount(root, {
+  const wrapper = mount(root, {
     global: {
       plugins: [router],
     },
@@ -31,7 +31,7 @@ test('renders component with sync props', async () => {
 
   await router.push('echo')
 
-  expect(app.html()).toBe('echo')
+  expect(wrapper.html()).toBe('echo')
 })
 
 test('renders component with async props', async () => {
@@ -53,7 +53,7 @@ test('renders component with async props', async () => {
     template: '<RouterView/>',
   }
 
-  const app = mount(root, {
+  const wrapper = mount(root, {
     global: {
       plugins: [router],
     },
@@ -64,7 +64,7 @@ test('renders component with async props', async () => {
   // needed for async props
   await flushPromises()
 
-  expect(app.html()).toBe('echo')
+  expect(wrapper.html()).toBe('echo')
 })
 
 test('component instance has suspense property when suspense is used', async () => {
@@ -129,7 +129,7 @@ test('renders component with async props using suspense', async () => {
     `,
   }
 
-  const app = mount(root, {
+  const wrapper = mount(root, {
     global: {
       plugins: [router],
     },
@@ -137,11 +137,11 @@ test('renders component with async props using suspense', async () => {
 
   await router.push('home')
 
-  expect(app.text()).toBe(fallback)
+  expect(wrapper.text()).toBe(fallback)
 
   resolve({ value: 'hello world' })
 
   await flushPromises()
 
-  expect(app.html()).toBe('hello world')
+  expect(wrapper.html()).toBe('hello world')
 })


### PR DESCRIPTION
normalize to `wrapper` > `app`