### PR TITLE
hash should always be populated in ResolvedRoute

### DIFF
--- a/src/services/createRouterReject.ts
+++ b/src/services/createRouterReject.ts
@@ -55,6 +55,7 @@ export function createRouterReject({
       params: {},
       state: {},
       href: '/',
+      hash: '',
       [isRejectionRouteSymbol]: true,
     }
   }

--- a/src/services/hooks.spec.ts
+++ b/src/services/hooks.spec.ts
@@ -29,6 +29,7 @@ test('calls hook with correct routes', () => {
     params: {},
     state: {},
     href: '/',
+    hash: '',
   }
 
   const fromOptions = {
@@ -48,6 +49,7 @@ test('calls hook with correct routes', () => {
     params: {},
     state: {},
     href: '/',
+    hash: '',
   }
 
   runBeforeRouteHooks({
@@ -101,6 +103,7 @@ test.each<{ type: string, status: string, hook: BeforeRouteHook }>([
     params: {},
     state: {},
     href: '/',
+    hash: '',
   }
 
   const fromOptions = {
@@ -120,6 +123,7 @@ test.each<{ type: string, status: string, hook: BeforeRouteHook }>([
     params: {},
     state: {},
     href: '/',
+    hash: '',
   }
 
   const response = await runBeforeRouteHooks({
@@ -156,6 +160,7 @@ test('hook is called in order', async () => {
     params: {},
     state: {},
     href: '/',
+    hash: '',
   }
 
   const fromOptions = {
@@ -175,6 +180,7 @@ test('hook is called in order', async () => {
     params: {},
     state: {},
     href: '/',
+    hash: '',
   }
 
   await runBeforeRouteHooks({

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -32,7 +32,7 @@ export type ResolvedRoute<TRoute extends Route = Route> = Readonly<{
   /**
    * Hash value of the route.
   */
-  hash?: string,
+  hash: string,
   /**
    * Key value pair for route params, values will be the user provided value from current browser location.
   */

--- a/src/utilities/testHelpers.ts
+++ b/src/utilities/testHelpers.ts
@@ -95,5 +95,6 @@ export function mockResolvedRoute(matched: ResolvedRoute['matched'], matches: Re
     params: {},
     state: {},
     href: '/',
+    hash: '',
   }
 }


### PR DESCRIPTION
this actually created an issue with reactivity inside `createCurrentRoute`, or at least that's my theory

we create our reactive with

```ts
  const route = reactive({ ...fallbackRoute })
```

which is later updated with

```ts
  const updateRoute: ResolvedRouteUpdate = (newRoute) => {
    Object.assign(route, {
      [isRejectionRouteSymbol]: false,
      ...newRoute,
    })
  }
```

when fallbackRoute doesn't have `hash`, calling updateRoute with a newRoute with a hash was NOT assigning hash to `router.route.hash`.