### PR TITLE
URLSearchParams constructor does not require toString be called

### DIFF
--- a/src/compositions/useQueryValue.ts
+++ b/src/compositions/useQueryValue.ts
@@ -49,7 +49,7 @@ export function useQueryValue(
         .filter((value) => value !== null)
     },
     set(values) {
-      const query = new URLSearchParams(route.query.toString())
+      const query = new URLSearchParams(route.query)
 
       query.delete(toValue(key))
 

--- a/src/services/createRouterRoute.ts
+++ b/src/services/createRouterRoute.ts
@@ -46,21 +46,21 @@ export function createRouterRoute<TRoute extends ResolvedRoute>(route: TRoute, p
   }
 
   const querySet: URLSearchParams['set'] = (...parameters) => {
-    const query = new URLSearchParams(route.query.toString())
+    const query = new URLSearchParams(route.query)
     query.set(...parameters)
 
     update({}, { query })
   }
 
   const queryAppend: URLSearchParams['append'] = (...parameters) => {
-    const query = new URLSearchParams(route.query.toString())
+    const query = new URLSearchParams(route.query)
     query.append(...parameters)
 
     update({}, { query })
   }
 
   const queryDelete: URLSearchParams['delete'] = (...parameters) => {
-    const query = new URLSearchParams(route.query.toString())
+    const query = new URLSearchParams(route.query)
     query.delete(...parameters)
 
     update({}, { query })


### PR DESCRIPTION
insignificant change pulled off of https://github.com/kitbagjs/router/pull/371