### PR TITLE
fix bug with getStateValue

### DIFF
--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -14,6 +14,8 @@ export function getStateValue(state: unknown, key: string, param: Param): unknow
     if (typeof value === 'string') {
       return getParamValue(value, param, isOptional)
     }
+
+    return value
   }
 
   return getParamValue(undefined, param, isOptional)
@@ -31,6 +33,9 @@ export function getStateValues(params: Record<string, Param>, state: unknown): R
   return values
 }
 
+/**
+ * This function is used to get the values inside the state converted from string values into the correct type.
+ */
 export function setStateValue(state: unknown, key: string, param: Param): string | undefined {
   if (stateIsRecord(state) && key in state) {
     const value = state[key]
@@ -41,6 +46,9 @@ export function setStateValue(state: unknown, key: string, param: Param): string
   return setParamValue(undefined, param, isOptional)
 }
 
+/**
+ * This function is used to set the values inside the state to have string values, stored in history.
+ */
 export const setStateValues = (params: Record<string, Param>, state: unknown): Record<string, string | undefined> => {
   const values: Record<string, string | undefined> = {}
 


### PR DESCRIPTION
ran into this issue while working on https://github.com/kitbagjs/router/pull/371

There was nothing handling `getStateValue` when `state` is a record, and the value at `key` is not a string. I'm pretty sure this happens when we call `createResolvedRoute` and the state we provide is already in the type the state expects like `zoo: 123`.