### PR TITLE
Fix custom rejections not being inferred from the registered router

### DIFF
--- a/src/types/register.ts
+++ b/src/types/register.ts
@@ -38,7 +38,7 @@ export type RegisteredRoutes = Register extends { router: Router<infer TRoutes e
 /**
  * Represents the possible Rejections registered within {@link Register}
  */
-export type RegisteredRejectionType = Register extends { router: Router<Routes, infer TOptions extends RouterOptions> }
+export type RegisteredRejectionType = Register extends { router: Router<infer __TRoutes extends Routes, infer TOptions extends RouterOptions> }
   ? keyof TOptions['rejections'] | BuiltInRejectionType
   : BuiltInRejectionType
 


### PR DESCRIPTION
# Description
Fixes an issue where even though custom rejections were passed when creating a router, and then that router was registered, the custom rejections would not show up when using `router.reject`