### PR TITLE
remove plugin from Router, add Register tests

### DIFF
--- a/src/types/register.spec.ts
+++ b/src/types/register.spec.ts
@@ -1,0 +1,33 @@
+import { expectTypeOf, test } from 'vitest'
+import { createRouter } from '@/services/createRouter'
+import { component, routes } from '@/utilities'
+import { RegisteredRejectionType, RegisteredRoutes, RouteMeta } from './register'
+
+test('given routes, RegisteredRoutes is correct', () => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const router = createRouter(routes, { initialUrl: '/' })
+
+  type Routes = RegisteredRoutes<{ router: typeof router }>
+
+  expectTypeOf<Routes>().toMatchTypeOf<typeof routes>()
+})
+
+test('given rejections in router options, RegisteredRejectionType is correct', () => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const router = createRouter([], {
+    initialUrl: '/',
+    rejections: {
+      AuthNeeded: component,
+    },
+  })
+
+  type Rejections = RegisteredRejectionType<{ router: typeof router }>
+
+  expectTypeOf<Rejections>().toMatchTypeOf<'AuthNeeded' | 'NotFound'>()
+})
+
+test('given route meta in router options, RouteMeta is correct', () => {
+  type Meta = RouteMeta<{ routeMeta: { zoo: number } }>
+
+  expectTypeOf<Meta>().toMatchTypeOf<{ zoo: number }>()
+})

--- a/src/types/register.ts
+++ b/src/types/register.ts
@@ -24,28 +24,28 @@ export interface Register {}
 /**
  * Represents the Router property within {@link Register}
  */
-export type RegisteredRouter = Register extends { router: infer TRouter }
+export type RegisteredRouter<T = Register> = T extends { router: infer TRouter }
   ? TRouter
   : Router
 
 /**
  * Represents the Router routes property within {@link Register}
  */
-export type RegisteredRoutes = Register extends { router: Router<infer TRoutes extends Routes> }
+export type RegisteredRoutes<T = Register> = T extends { router: Router<infer TRoutes extends Routes> }
   ? TRoutes
   : Route[]
 
 /**
  * Represents the possible Rejections registered within {@link Register}
  */
-export type RegisteredRejectionType = Register extends { router: Router<infer __TRoutes extends Routes, infer TOptions extends RouterOptions> }
+export type RegisteredRejectionType<T = Register> = T extends { router: Router<Routes, infer TOptions extends RouterOptions> }
   ? keyof TOptions['rejections'] | BuiltInRejectionType
   : BuiltInRejectionType
 
 /**
  * Represents additional metadata associated with a route, customizable via declaration merging.
  */
-export type RouteMeta = Register extends { routeMeta: infer RouteMeta extends Record<string, unknown> }
+export type RouteMeta<T = Register> = T extends { routeMeta: infer RouteMeta extends Record<string, unknown> }
   ? RouteMeta
   : Record<string, unknown>
 

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -48,6 +48,10 @@ export type Router<
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   __TOptions extends RouterOptions = any
 > = {
+  /**
+   * Installs the router into a Vue application instance.
+   * @param app The Vue application instance to install the router into
+   */
   install: (app: App) => void,
   /**
    * Manages the current route state.

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -1,4 +1,4 @@
-import { Component, Plugin } from 'vue'
+import { App, Component } from 'vue'
 import { RouterHistoryMode } from '@/services/createRouterHistory'
 import { RouterRoute } from '@/services/createRouterRoute'
 import { AddAfterRouteHook, AddBeforeRouteHook } from '@/types/hooks'
@@ -47,7 +47,8 @@ export type Router<
   TRoutes extends Routes = any,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   __TOptions extends RouterOptions = any
-> = Plugin & {
+> = {
+  install: (app: App) => void,
   /**
    * Manages the current route state.
   */


### PR DESCRIPTION
We had reports of registered rejections having the wrong type in [Kitbag's Discord](https://discord.gg/zw7dpcc5HV). 

We've traced the type issue down to using Vue's `Plugin` type as part of the `Router` definition. This PR removes that (while still satisfying the ObjectPlugin syntax). This PR also adds some type tests around some of the common Register types used often.