### PR TITLE
Make sure start cannot be called multiple times

### DIFF
--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -269,16 +269,19 @@ export function createRouter<const TRoutes extends Routes, const TOptions extend
   const { host } = parseUrl(initialUrl)
   const isExternal = createIsExternal(host)
 
-  let initialized = false
+  let initializing = false
+  const { promise: initialize, resolve: initialized } = Promise.withResolvers<void>()
 
   async function start(): Promise<void> {
-    if (initialized) {
-      return
+    if (initializing) {
+      return initialize
     }
+
+    initializing = true
 
     await set(initialUrl, { replace: true, state: initialState })
 
-    initialized = true
+    initialized()
   }
 
   function install(app: App): void {


### PR DESCRIPTION
# Description
This was how I originally intended to write this but at the time `Promise.withResolvers` wasn't working because of a missing ts lib. That has since been fixed so fixing this up so even if you call `start(); start()` it won't actually execute twice. 