### PR TITLE
Add route change hooks

### DIFF
--- a/src/models/RouteHooks.ts
+++ b/src/models/RouteHooks.ts
@@ -4,7 +4,9 @@ export class RouteHooks {
   public onBeforeRouteEnter = new Set<BeforeRouteHook>()
   public onBeforeRouteUpdate = new Set<BeforeRouteHook>()
   public onBeforeRouteLeave = new Set<BeforeRouteHook>()
+  public onBeforeRouteChange = new Set<BeforeRouteHook>()
   public onAfterRouteEnter = new Set<AfterRouteHook>()
   public onAfterRouteUpdate = new Set<AfterRouteHook>()
   public onAfterRouteLeave = new Set<AfterRouteHook>()
+  public onAfterRouteChange = new Set<AfterRouteHook>()
 }

--- a/src/services/createRouteHookStore.ts
+++ b/src/services/createRouteHookStore.ts
@@ -1,19 +1,19 @@
 import { RouteHooks } from '@/models/RouteHooks'
 import { getRouteHookCondition } from '@/services/hooks'
-import { AfterRouteHook, BeforeRouteHook, RouteHookRemove } from '@/types/hooks'
+import { AfterRouteHook, AfterRouteHookLifecycle, BeforeRouteHook, BeforeRouteHookLifecycle, RouteHookRemove } from '@/types/hooks'
 
 type RouteHookTiming = 'global' | 'component'
 
 type BeforeRouteHookRegistration = {
   timing: RouteHookTiming,
-  lifecycle: 'onBeforeRouteEnter' | 'onBeforeRouteUpdate' | 'onBeforeRouteLeave',
+  lifecycle: BeforeRouteHookLifecycle,
   hook: BeforeRouteHook,
   depth: number,
 }
 
 type AfterRouteHookRegistration = {
   timing: RouteHookTiming,
-  lifecycle: 'onAfterRouteEnter' | 'onAfterRouteUpdate' | 'onAfterRouteLeave',
+  lifecycle: AfterRouteHookLifecycle,
   hook: AfterRouteHook,
   depth: number,
 }

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -89,6 +89,8 @@ export function createRouter<const TRoutes extends Routes, const TOptions extend
     onAfterRouteEnter,
     onBeforeRouteUpdate,
     onAfterRouteLeave,
+    onBeforeRouteChange,
+    onAfterRouteChange,
   } = createRouterHooks()
 
   function find(url: string, options: RouterResolveOptions = {}): ResolvedRoute | undefined {
@@ -318,6 +320,8 @@ export function createRouter<const TRoutes extends Routes, const TOptions extend
     onAfterRouteEnter,
     onBeforeRouteUpdate,
     onAfterRouteLeave,
+    onBeforeRouteChange,
+    onAfterRouteChange,
     prefetch: options?.prefetch,
     start,
   }

--- a/src/services/createRouterHooks.ts
+++ b/src/services/createRouterHooks.ts
@@ -8,9 +8,11 @@ export type RouterHooks = {
   onBeforeRouteEnter: AddBeforeRouteHook,
   onBeforeRouteUpdate: AddBeforeRouteHook,
   onBeforeRouteLeave: AddBeforeRouteHook,
+  onBeforeRouteChange: AddBeforeRouteHook,
   onAfterRouteEnter: AddAfterRouteHook,
   onAfterRouteUpdate: AddAfterRouteHook,
   onAfterRouteLeave: AddAfterRouteHook,
+  onAfterRouteChange: AddAfterRouteHook,
   hooks: RouteHookStore,
 }
 
@@ -25,6 +27,10 @@ export function createRouterHooks(): RouterHooks {
     return hooks.addBeforeRouteHook({ lifecycle: 'onBeforeRouteUpdate', hook, timing: 'global', depth: 0 })
   }
 
+  const onBeforeRouteChange: AddBeforeRouteHook = (hook) => {
+    return hooks.addBeforeRouteHook({ lifecycle: 'onBeforeRouteChange', hook, timing: 'global', depth: 0 })
+  }
+
   const onBeforeRouteLeave: AddBeforeRouteHook = (hook) => {
     return hooks.addBeforeRouteHook({ lifecycle: 'onBeforeRouteLeave', hook, timing: 'global', depth: 0 })
   }
@@ -37,6 +43,10 @@ export function createRouterHooks(): RouterHooks {
     return hooks.addAfterRouteHook({ lifecycle: 'onAfterRouteUpdate', hook, timing: 'global', depth: 0 })
   }
 
+  const onAfterRouteChange: AddAfterRouteHook = (hook) => {
+    return hooks.addAfterRouteHook({ lifecycle: 'onAfterRouteChange', hook, timing: 'global', depth: 0 })
+  }
+
   const onAfterRouteLeave: AddAfterRouteHook = (hook) => {
     return hooks.addAfterRouteHook({ lifecycle: 'onAfterRouteLeave', hook, timing: 'global', depth: 0 })
   }
@@ -45,9 +55,11 @@ export function createRouterHooks(): RouterHooks {
     onBeforeRouteEnter,
     onBeforeRouteUpdate,
     onBeforeRouteLeave,
+    onBeforeRouteChange,
     onAfterRouteEnter,
     onAfterRouteUpdate,
     onAfterRouteLeave,
+    onAfterRouteChange,
     hooks,
   }
 }

--- a/src/services/getRouteHooks.spec.ts
+++ b/src/services/getRouteHooks.spec.ts
@@ -16,5 +16,6 @@ test('given two ResolvedRoutes returns before timing hooks in correct order', ()
 
   expect(Array.from(hooks.onBeforeRouteEnter)).toMatchObject([childA.onBeforeRouteEnter, grandchildA.onBeforeRouteEnter])
   expect(Array.from(hooks.onBeforeRouteUpdate)).toMatchObject([parent.onBeforeRouteUpdate])
+  expect(Array.from(hooks.onBeforeRouteChange)).toMatchObject([parent.onBeforeRouteChange, childA.onBeforeRouteChange, grandchildA.onBeforeRouteChange])
   expect(Array.from(hooks.onBeforeRouteLeave)).toMatchObject([childB.onBeforeRouteLeave, grandchildB.onBeforeRouteLeave])
 })

--- a/src/services/getRouteHooks.ts
+++ b/src/services/getRouteHooks.ts
@@ -1,5 +1,5 @@
 import { RouteHooks } from '@/models/RouteHooks'
-import { isRouteEnter, isRouteLeave, isRouteUpdate } from '@/services/hooks'
+import { isRouteChange, isRouteEnter, isRouteLeave, isRouteUpdate } from '@/services/hooks'
 import { ResolvedRoute } from '@/types/resolved'
 import { asArray } from '@/utilities/array'
 
@@ -13,6 +13,10 @@ export function getBeforeRouteHooksFromRoutes(to: ResolvedRoute, from: ResolvedR
 
     if (route.onBeforeRouteUpdate && isRouteUpdate(to, from, depth)) {
       asArray(route.onBeforeRouteUpdate).forEach((hook) => hooks.onBeforeRouteUpdate.add(hook))
+    }
+
+    if (route.onBeforeRouteChange && isRouteChange(to, from, depth)) {
+      asArray(route.onBeforeRouteChange).forEach((hook) => hooks.onBeforeRouteChange.add(hook))
     }
   })
 
@@ -35,6 +39,10 @@ export function getAfterRouteHooksFromRoutes(to: ResolvedRoute, from: ResolvedRo
 
     if (route.onAfterRouteUpdate && isRouteUpdate(to, from, depth)) {
       asArray(route.onAfterRouteUpdate).forEach((hook) => hooks.onAfterRouteUpdate.add(hook))
+    }
+
+    if (route.onAfterRouteChange && isRouteChange(to, from, depth)) {
+      asArray(route.onAfterRouteChange).forEach((hook) => hooks.onAfterRouteChange.add(hook))
     }
   })
 

--- a/src/services/hooks.ts
+++ b/src/services/hooks.ts
@@ -41,6 +41,9 @@ export function createRouteHookRunners(): RouteHookRunners {
       ...global.onBeforeRouteUpdate,
       ...route.onBeforeRouteUpdate,
       ...component.onBeforeRouteUpdate,
+      ...global.onBeforeRouteChange,
+      ...route.onBeforeRouteChange,
+      ...component.onBeforeRouteChange,
       ...global.onBeforeRouteLeave,
       ...route.onBeforeRouteLeave,
       ...component.onBeforeRouteLeave,
@@ -88,6 +91,9 @@ export function createRouteHookRunners(): RouteHookRunners {
       ...component.onAfterRouteUpdate,
       ...route.onAfterRouteUpdate,
       ...global.onAfterRouteUpdate,
+      ...component.onAfterRouteChange,
+      ...route.onAfterRouteChange,
+      ...global.onAfterRouteChange,
       ...component.onAfterRouteEnter,
       ...route.onAfterRouteEnter,
       ...global.onAfterRouteEnter,
@@ -145,6 +151,10 @@ export const isRouteUpdate: RouteHookCondition = (to, from, depth) => {
   return to.matches[depth].id === from?.matches[depth]?.id
 }
 
+export const isRouteChange: RouteHookCondition = (to, from, depth) => {
+  return isRouteEnter(to, from, depth) || isRouteUpdate(to, from, depth)
+}
+
 export function getRouteHookCondition(lifecycle: RouteHookLifecycle): RouteHookCondition {
   switch (lifecycle) {
     case 'onBeforeRouteEnter':
@@ -156,6 +166,9 @@ export function getRouteHookCondition(lifecycle: RouteHookLifecycle): RouteHookC
     case 'onBeforeRouteLeave':
     case 'onAfterRouteLeave':
       return isRouteLeave
+    case 'onBeforeRouteChange':
+    case 'onAfterRouteChange':
+      return isRouteChange
     default:
       throw new Error(`Switch is not exhaustive for lifecycle: ${lifecycle satisfies never}`)
   }

--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -25,9 +25,11 @@ export type WithHooks = {
   onBeforeRouteEnter?: MaybeArray<BeforeRouteHook>,
   onBeforeRouteUpdate?: MaybeArray<BeforeRouteHook>,
   onBeforeRouteLeave?: MaybeArray<BeforeRouteHook>,
+  onBeforeRouteChange?: MaybeArray<BeforeRouteHook>,
   onAfterRouteEnter?: MaybeArray<AfterRouteHook>,
   onAfterRouteUpdate?: MaybeArray<AfterRouteHook>,
   onAfterRouteLeave?: MaybeArray<AfterRouteHook>,
+  onAfterRouteChange?: MaybeArray<AfterRouteHook>,
 }
 
 export type WithHost<THost extends string | Host = string | Host> = {

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -68,12 +68,12 @@ export type RouteHookRemove = () => void
 /**
  * Enumerates the lifecycle events for before route hooks.
  */
-export type BeforeRouteHookLifecycle = 'onBeforeRouteEnter' | 'onBeforeRouteUpdate' | 'onBeforeRouteLeave'
+export type BeforeRouteHookLifecycle = 'onBeforeRouteEnter' | 'onBeforeRouteUpdate' | 'onBeforeRouteLeave' | 'onBeforeRouteChange'
 
 /**
  * Enumerates the lifecycle events for after route hooks.
  */
-export type AfterRouteHookLifecycle = 'onAfterRouteEnter' | 'onAfterRouteUpdate' | 'onAfterRouteLeave'
+export type AfterRouteHookLifecycle = 'onAfterRouteEnter' | 'onAfterRouteUpdate' | 'onAfterRouteLeave' | 'onAfterRouteChange'
 
 /**
  * Union type for all route hook lifecycle events.

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -106,6 +106,10 @@ export type Router<
    */
   onBeforeRouteUpdate: AddBeforeRouteHook,
   /**
+   * Registers a hook to be called before a route is entered or updated.
+   */
+  onBeforeRouteChange: AddBeforeRouteHook,
+  /**
    * Registers a hook to be called after a route is entered.
    */
   onAfterRouteEnter: AddAfterRouteHook,
@@ -117,6 +121,10 @@ export type Router<
    * Registers a hook to be called after a route is updated.
    */
   onAfterRouteUpdate: AddAfterRouteHook,
+  /**
+   * Registers a hook to be called after a route is entered or updated.
+   */
+  onAfterRouteChange: AddAfterRouteHook,
   /**
   * Given a URL, returns true if host does not match host stored on router instance
   */

--- a/src/utilities/testHelpers.ts
+++ b/src/utilities/testHelpers.ts
@@ -76,6 +76,7 @@ export function mockRoute(name: string): ResolvedRoute['matched'] {
     onBeforeRouteEnter: vi.fn(),
     onBeforeRouteUpdate: vi.fn(),
     onBeforeRouteLeave: vi.fn(),
+    onBeforeRouteChange: vi.fn(),
     meta: {},
     state: {},
   }


### PR DESCRIPTION
# Description
There has been a bit of confusion about the `onBeforeRouteEnter` hook when it pertains to parent routes. Specifically when going from a rejection back to a route (the route hasn't actually changed, so an update hook is called). And when navigating from siblingA to siblingB (again, an update hook is called). 

This PR adds `onBeforeRouteChange` and `onAfterRouteChange` hooks which are called on both enter and update. This allows a single hook to be used whenever a navigation happens. 

Putting this up as a draft because I'm not 100% sold on this. I THINK it makes sense. But the terminology of "change" vs "update" isn't very clear. They seem synonymous at first glance. I also considered something like "onBeforeLocationUpdate" to distinguish between a hook based on what was happening to the route vs what was happening to the location. But considering these new hooks work exactly the same as the other hooks, introduction the "location" keyword seemed heavy handed. 

I think this closes https://github.com/kitbagjs/router/issues/244