### PR TITLE
Update global hooks to not be based on root routes and fix `from` on router start

### DIFF
--- a/src/compositions/hooks.ts
+++ b/src/compositions/hooks.ts
@@ -2,7 +2,7 @@ import { inject, onUnmounted } from 'vue'
 import { useRouterDepth } from '@/compositions/useRouterDepth'
 import { RouterNotInstalledError } from '@/errors'
 import { routerHooksKey, RouterHooks } from '@/services/createRouterHooks'
-import { RegisterAfterRouteHook, RegisterBeforeRouteHook, AfterRouteHook, AfterRouteHookLifecycle, BeforeRouteHook, BeforeRouteHookLifecycle } from '@/types/hooks'
+import { AddAfterRouteHook, AddBeforeRouteHook, AfterRouteHook, AfterRouteHookLifecycle, BeforeRouteHook, BeforeRouteHookLifecycle } from '@/types/hooks'
 
 function useRouterHooks(): RouterHooks {
   const hooks = inject(routerHooksKey)
@@ -48,7 +48,7 @@ function afterComponentHookFactory(lifecycle: AfterRouteHookLifecycle) {
  * @returns {RouteHookRemove} A function that removes the added hook.
  * @group Hooks
  */
-export const onBeforeRouteLeave: RegisterBeforeRouteHook = beforeComponentHookFactory('onBeforeRouteUpdate')
+export const onBeforeRouteLeave: AddBeforeRouteHook = beforeComponentHookFactory('onBeforeRouteUpdate')
 
 /**
  * Registers a hook that is called before a route is updated. Must be called from setup.
@@ -58,7 +58,7 @@ export const onBeforeRouteLeave: RegisterBeforeRouteHook = beforeComponentHookFa
  * @returns {RouteHookRemove} A function that removes the added hook.
  * @group Hooks
  */
-export const onBeforeRouteUpdate: RegisterBeforeRouteHook = beforeComponentHookFactory('onBeforeRouteLeave')
+export const onBeforeRouteUpdate: AddBeforeRouteHook = beforeComponentHookFactory('onBeforeRouteLeave')
 
 /**
  * Registers a hook that is called after a route has been entered. Must be called during setup.
@@ -68,7 +68,7 @@ export const onBeforeRouteUpdate: RegisterBeforeRouteHook = beforeComponentHookF
  * @returns {RouteHookRemove} A function that removes the added hook.
  * @group Hooks
  */
-export const onAfterRouteEnter: RegisterAfterRouteHook = afterComponentHookFactory('onAfterRouteEnter')
+export const onAfterRouteEnter: AddAfterRouteHook = afterComponentHookFactory('onAfterRouteEnter')
 
 /**
  * Registers a hook that is called after a route has been left. Must be called during setup.
@@ -78,7 +78,7 @@ export const onAfterRouteEnter: RegisterAfterRouteHook = afterComponentHookFacto
  * @returns {RouteHookRemove} A function that removes the added hook.
  * @group Hooks
  */
-export const onAfterRouteLeave: RegisterAfterRouteHook = afterComponentHookFactory('onAfterRouteUpdate')
+export const onAfterRouteLeave: AddAfterRouteHook = afterComponentHookFactory('onAfterRouteUpdate')
 
 /**
  * Registers a hook that is called after a route has been updated. Must be called during setup.
@@ -88,4 +88,4 @@ export const onAfterRouteLeave: RegisterAfterRouteHook = afterComponentHookFacto
  * @returns {RouteHookRemove} A function that removes the added hook.
  * @group Hooks
  */
-export const onAfterRouteUpdate: RegisterAfterRouteHook = afterComponentHookFactory('onAfterRouteLeave')
+export const onAfterRouteUpdate: AddAfterRouteHook = afterComponentHookFactory('onAfterRouteLeave')

--- a/src/compositions/hooks.ts
+++ b/src/compositions/hooks.ts
@@ -2,7 +2,7 @@ import { inject, onUnmounted } from 'vue'
 import { useRouterDepth } from '@/compositions/useRouterDepth'
 import { RouterNotInstalledError } from '@/errors'
 import { routerHooksKey, RouterHooks } from '@/services/createRouterHooks'
-import { AddAfterRouteHook, AddBeforeRouteHook, AfterRouteHook, AfterRouteHookLifecycle, BeforeRouteHook, BeforeRouteHookLifecycle } from '@/types/hooks'
+import { RegisterAfterRouteHook, RegisterBeforeRouteHook, AfterRouteHook, AfterRouteHookLifecycle, BeforeRouteHook, BeforeRouteHookLifecycle } from '@/types/hooks'
 
 function useRouterHooks(): RouterHooks {
   const hooks = inject(routerHooksKey)
@@ -19,7 +19,7 @@ function beforeComponentHookFactory(lifecycle: BeforeRouteHookLifecycle) {
     const depth = useRouterDepth()
     const hooks = useRouterHooks()
 
-    const remove = hooks.addBeforeRouteHook({ lifecycle, hook, depth, timing: 'component' })
+    const remove = hooks.addComponentBeforeRouteHook({ lifecycle, hook, depth, timing: 'component' })
 
     onUnmounted(remove)
 
@@ -32,7 +32,7 @@ function afterComponentHookFactory(lifecycle: AfterRouteHookLifecycle) {
     const depth = useRouterDepth()
     const store = useRouterHooks()
 
-    const remove = store.addAfterRouteHook({ lifecycle, hook, depth, timing: 'component' })
+    const remove = store.addComponentAfterRouteHook({ lifecycle, hook, depth, timing: 'component' })
 
     onUnmounted(remove)
 
@@ -48,7 +48,7 @@ function afterComponentHookFactory(lifecycle: AfterRouteHookLifecycle) {
  * @returns {RouteHookRemove} A function that removes the added hook.
  * @group Hooks
  */
-export const onBeforeRouteLeave: AddBeforeRouteHook = beforeComponentHookFactory('onBeforeRouteUpdate')
+export const onBeforeRouteLeave: RegisterBeforeRouteHook = beforeComponentHookFactory('onBeforeRouteUpdate')
 
 /**
  * Registers a hook that is called before a route is updated. Must be called from setup.
@@ -58,7 +58,7 @@ export const onBeforeRouteLeave: AddBeforeRouteHook = beforeComponentHookFactory
  * @returns {RouteHookRemove} A function that removes the added hook.
  * @group Hooks
  */
-export const onBeforeRouteUpdate: AddBeforeRouteHook = beforeComponentHookFactory('onBeforeRouteLeave')
+export const onBeforeRouteUpdate: RegisterBeforeRouteHook = beforeComponentHookFactory('onBeforeRouteLeave')
 
 /**
  * Registers a hook that is called after a route has been entered. Must be called during setup.
@@ -68,7 +68,7 @@ export const onBeforeRouteUpdate: AddBeforeRouteHook = beforeComponentHookFactor
  * @returns {RouteHookRemove} A function that removes the added hook.
  * @group Hooks
  */
-export const onAfterRouteEnter: AddAfterRouteHook = afterComponentHookFactory('onAfterRouteEnter')
+export const onAfterRouteEnter: RegisterAfterRouteHook = afterComponentHookFactory('onAfterRouteEnter')
 
 /**
  * Registers a hook that is called after a route has been left. Must be called during setup.
@@ -78,7 +78,7 @@ export const onAfterRouteEnter: AddAfterRouteHook = afterComponentHookFactory('o
  * @returns {RouteHookRemove} A function that removes the added hook.
  * @group Hooks
  */
-export const onAfterRouteLeave: AddAfterRouteHook = afterComponentHookFactory('onAfterRouteUpdate')
+export const onAfterRouteLeave: RegisterAfterRouteHook = afterComponentHookFactory('onAfterRouteUpdate')
 
 /**
  * Registers a hook that is called after a route has been updated. Must be called during setup.
@@ -88,4 +88,4 @@ export const onAfterRouteLeave: AddAfterRouteHook = afterComponentHookFactory('o
  * @returns {RouteHookRemove} A function that removes the added hook.
  * @group Hooks
  */
-export const onAfterRouteUpdate: AddAfterRouteHook = afterComponentHookFactory('onAfterRouteLeave')
+export const onAfterRouteUpdate: RegisterAfterRouteHook = afterComponentHookFactory('onAfterRouteLeave')

--- a/src/compositions/hooks.ts
+++ b/src/compositions/hooks.ts
@@ -19,7 +19,7 @@ function beforeComponentHookFactory(lifecycle: BeforeRouteHookLifecycle) {
     const depth = useRouterDepth()
     const hooks = useRouterHooks()
 
-    const remove = hooks.addComponentBeforeRouteHook({ lifecycle, hook, depth, timing: 'component' })
+    const remove = hooks.addComponentBeforeRouteHook({ lifecycle, hook, depth })
 
     onUnmounted(remove)
 
@@ -32,7 +32,7 @@ function afterComponentHookFactory(lifecycle: AfterRouteHookLifecycle) {
     const depth = useRouterDepth()
     const store = useRouterHooks()
 
-    const remove = store.addComponentAfterRouteHook({ lifecycle, hook, depth, timing: 'component' })
+    const remove = store.addComponentAfterRouteHook({ lifecycle, hook, depth })
 
     onUnmounted(remove)
 

--- a/src/compositions/useRoute.browser.spec.ts
+++ b/src/compositions/useRoute.browser.spec.ts
@@ -57,7 +57,7 @@ test('when given a routeKey that matches the current route returns the router ro
 
 test('when given a routeKey that matches exactly the current route returns the router route', async () => {
   const router = createRouter(routes, {
-    initialUrl: '/parentA/parentAParam/childAParam',
+    initialUrl: '/parentA/parentAParam/childA/childAParam',
   })
 
   await router.start()
@@ -109,7 +109,7 @@ test('when given a routeKey that does not match the current route, throws UseRou
 
 test('when given a routeKey that does not match exactly the current route, throws UseRouteInvalidError', async () => {
   const router = createRouter(routes, {
-    initialUrl: '/parentA/parentAParam/childAParam',
+    initialUrl: '/parentA/parentAParam/childA/childAParam',
   })
 
   await router.start()

--- a/src/services/createRouter.spec.ts
+++ b/src/services/createRouter.spec.ts
@@ -695,8 +695,8 @@ describe('hooks', () => {
 
     expect(onBeforeRouteEnter).toHaveBeenCalledTimes(1)
     expect(onBeforeRouteUpdate).toHaveBeenCalledTimes(0)
-    expect(onBeforeRouteLeave).toHaveBeenCalledTimes(1)
-    expect(onAfterRouteLeave).toHaveBeenCalledTimes(1)
+    expect(onBeforeRouteLeave).toHaveBeenCalledTimes(0)
+    expect(onAfterRouteLeave).toHaveBeenCalledTimes(0)
     expect(onAfterRouteUpdate).toHaveBeenCalledTimes(0)
     expect(onAfterRouteEnter).toHaveBeenCalledTimes(1)
 
@@ -704,8 +704,8 @@ describe('hooks', () => {
 
     expect(onBeforeRouteEnter).toHaveBeenCalledTimes(2)
     expect(onBeforeRouteUpdate).toHaveBeenCalledTimes(1)
-    expect(onBeforeRouteLeave).toHaveBeenCalledTimes(1)
-    expect(onAfterRouteLeave).toHaveBeenCalledTimes(1)
+    expect(onBeforeRouteLeave).toHaveBeenCalledTimes(0)
+    expect(onAfterRouteLeave).toHaveBeenCalledTimes(0)
     expect(onAfterRouteUpdate).toHaveBeenCalledTimes(1)
     expect(onAfterRouteEnter).toHaveBeenCalledTimes(2)
 
@@ -713,8 +713,8 @@ describe('hooks', () => {
 
     expect(onBeforeRouteEnter).toHaveBeenCalledTimes(3)
     expect(onBeforeRouteUpdate).toHaveBeenCalledTimes(2)
-    expect(onBeforeRouteLeave).toHaveBeenCalledTimes(2)
-    expect(onAfterRouteLeave).toHaveBeenCalledTimes(2)
+    expect(onBeforeRouteLeave).toHaveBeenCalledTimes(1)
+    expect(onAfterRouteLeave).toHaveBeenCalledTimes(1)
     expect(onAfterRouteUpdate).toHaveBeenCalledTimes(2)
     expect(onAfterRouteEnter).toHaveBeenCalledTimes(3)
 
@@ -722,8 +722,8 @@ describe('hooks', () => {
 
     expect(onBeforeRouteEnter).toHaveBeenCalledTimes(4)
     expect(onBeforeRouteUpdate).toHaveBeenCalledTimes(2)
-    expect(onBeforeRouteLeave).toHaveBeenCalledTimes(3)
-    expect(onAfterRouteLeave).toHaveBeenCalledTimes(3)
+    expect(onBeforeRouteLeave).toHaveBeenCalledTimes(2)
+    expect(onAfterRouteLeave).toHaveBeenCalledTimes(2)
     expect(onAfterRouteUpdate).toHaveBeenCalledTimes(2)
     expect(onAfterRouteEnter).toHaveBeenCalledTimes(4)
   })
@@ -749,8 +749,8 @@ describe('hooks', () => {
 
     expect(onBeforeRouteEnter).toHaveBeenCalledTimes(1)
     expect(onBeforeRouteUpdate).toHaveBeenCalledTimes(0)
-    expect(onBeforeRouteLeave).toHaveBeenCalledTimes(1)
-    expect(onAfterRouteLeave).toHaveBeenCalledTimes(1)
+    expect(onBeforeRouteLeave).toHaveBeenCalledTimes(0)
+    expect(onAfterRouteLeave).toHaveBeenCalledTimes(0)
     expect(onAfterRouteUpdate).toHaveBeenCalledTimes(0)
     expect(onAfterRouteEnter).toHaveBeenCalledTimes(1)
 
@@ -758,8 +758,8 @@ describe('hooks', () => {
 
     expect(onBeforeRouteEnter).toHaveBeenCalledTimes(2)
     expect(onBeforeRouteUpdate).toHaveBeenCalledTimes(1)
-    expect(onBeforeRouteLeave).toHaveBeenCalledTimes(1)
-    expect(onAfterRouteLeave).toHaveBeenCalledTimes(1)
+    expect(onBeforeRouteLeave).toHaveBeenCalledTimes(0)
+    expect(onAfterRouteLeave).toHaveBeenCalledTimes(0)
     expect(onAfterRouteUpdate).toHaveBeenCalledTimes(1)
     expect(onAfterRouteEnter).toHaveBeenCalledTimes(2)
 
@@ -767,8 +767,8 @@ describe('hooks', () => {
 
     expect(onBeforeRouteEnter).toHaveBeenCalledTimes(3)
     expect(onBeforeRouteUpdate).toHaveBeenCalledTimes(2)
-    expect(onBeforeRouteLeave).toHaveBeenCalledTimes(2)
-    expect(onAfterRouteLeave).toHaveBeenCalledTimes(2)
+    expect(onBeforeRouteLeave).toHaveBeenCalledTimes(1)
+    expect(onAfterRouteLeave).toHaveBeenCalledTimes(1)
     expect(onAfterRouteUpdate).toHaveBeenCalledTimes(2)
     expect(onAfterRouteEnter).toHaveBeenCalledTimes(3)
 
@@ -776,8 +776,8 @@ describe('hooks', () => {
 
     expect(onBeforeRouteEnter).toHaveBeenCalledTimes(4)
     expect(onBeforeRouteUpdate).toHaveBeenCalledTimes(2)
-    expect(onBeforeRouteLeave).toHaveBeenCalledTimes(3)
-    expect(onAfterRouteLeave).toHaveBeenCalledTimes(3)
+    expect(onBeforeRouteLeave).toHaveBeenCalledTimes(2)
+    expect(onAfterRouteLeave).toHaveBeenCalledTimes(2)
     expect(onAfterRouteUpdate).toHaveBeenCalledTimes(2)
     expect(onAfterRouteEnter).toHaveBeenCalledTimes(4)
   })

--- a/src/services/createRouter.spec.ts
+++ b/src/services/createRouter.spec.ts
@@ -702,30 +702,30 @@ describe('hooks', () => {
 
     await router.push('parentA.childA', { paramA: 'valueA', paramB: 'valueB' })
 
-    expect(onBeforeRouteEnter).toHaveBeenCalledTimes(1)
+    expect(onBeforeRouteEnter).toHaveBeenCalledTimes(2)
     expect(onBeforeRouteUpdate).toHaveBeenCalledTimes(1)
     expect(onBeforeRouteLeave).toHaveBeenCalledTimes(1)
     expect(onAfterRouteLeave).toHaveBeenCalledTimes(1)
     expect(onAfterRouteUpdate).toHaveBeenCalledTimes(1)
-    expect(onAfterRouteEnter).toHaveBeenCalledTimes(1)
+    expect(onAfterRouteEnter).toHaveBeenCalledTimes(2)
 
     await router.push('parentA.childB', { paramA: 'valueB', paramD: 'valueD' })
 
-    expect(onBeforeRouteEnter).toHaveBeenCalledTimes(1)
-    expect(onBeforeRouteUpdate).toHaveBeenCalledTimes(2)
-    expect(onBeforeRouteLeave).toHaveBeenCalledTimes(1)
-    expect(onAfterRouteLeave).toHaveBeenCalledTimes(1)
-    expect(onAfterRouteUpdate).toHaveBeenCalledTimes(2)
-    expect(onAfterRouteEnter).toHaveBeenCalledTimes(1)
-
-    await router.push('parentB')
-
-    expect(onBeforeRouteEnter).toHaveBeenCalledTimes(2)
+    expect(onBeforeRouteEnter).toHaveBeenCalledTimes(3)
     expect(onBeforeRouteUpdate).toHaveBeenCalledTimes(2)
     expect(onBeforeRouteLeave).toHaveBeenCalledTimes(2)
     expect(onAfterRouteLeave).toHaveBeenCalledTimes(2)
     expect(onAfterRouteUpdate).toHaveBeenCalledTimes(2)
-    expect(onAfterRouteEnter).toHaveBeenCalledTimes(2)
+    expect(onAfterRouteEnter).toHaveBeenCalledTimes(3)
+
+    await router.push('parentB')
+
+    expect(onBeforeRouteEnter).toHaveBeenCalledTimes(4)
+    expect(onBeforeRouteUpdate).toHaveBeenCalledTimes(2)
+    expect(onBeforeRouteLeave).toHaveBeenCalledTimes(3)
+    expect(onAfterRouteLeave).toHaveBeenCalledTimes(3)
+    expect(onAfterRouteUpdate).toHaveBeenCalledTimes(2)
+    expect(onAfterRouteEnter).toHaveBeenCalledTimes(4)
   })
 
   test('global hooks registered manually are called correctly', async () => {
@@ -756,29 +756,29 @@ describe('hooks', () => {
 
     await router.push('parentA.childA', { paramA: 'valueA', paramB: 'valueB' })
 
-    expect(onBeforeRouteEnter).toHaveBeenCalledTimes(1)
+    expect(onBeforeRouteEnter).toHaveBeenCalledTimes(2)
     expect(onBeforeRouteUpdate).toHaveBeenCalledTimes(1)
     expect(onBeforeRouteLeave).toHaveBeenCalledTimes(1)
     expect(onAfterRouteLeave).toHaveBeenCalledTimes(1)
     expect(onAfterRouteUpdate).toHaveBeenCalledTimes(1)
-    expect(onAfterRouteEnter).toHaveBeenCalledTimes(1)
+    expect(onAfterRouteEnter).toHaveBeenCalledTimes(2)
 
     await router.push('parentA.childB', { paramA: 'valueB', paramD: 'valueD' })
 
-    expect(onBeforeRouteEnter).toHaveBeenCalledTimes(1)
-    expect(onBeforeRouteUpdate).toHaveBeenCalledTimes(2)
-    expect(onBeforeRouteLeave).toHaveBeenCalledTimes(1)
-    expect(onAfterRouteLeave).toHaveBeenCalledTimes(1)
-    expect(onAfterRouteUpdate).toHaveBeenCalledTimes(2)
-    expect(onAfterRouteEnter).toHaveBeenCalledTimes(1)
-
-    await router.push('parentB')
-
-    expect(onBeforeRouteEnter).toHaveBeenCalledTimes(2)
+    expect(onBeforeRouteEnter).toHaveBeenCalledTimes(3)
     expect(onBeforeRouteUpdate).toHaveBeenCalledTimes(2)
     expect(onBeforeRouteLeave).toHaveBeenCalledTimes(2)
     expect(onAfterRouteLeave).toHaveBeenCalledTimes(2)
     expect(onAfterRouteUpdate).toHaveBeenCalledTimes(2)
-    expect(onAfterRouteEnter).toHaveBeenCalledTimes(2)
+    expect(onAfterRouteEnter).toHaveBeenCalledTimes(3)
+
+    await router.push('parentB')
+
+    expect(onBeforeRouteEnter).toHaveBeenCalledTimes(4)
+    expect(onBeforeRouteUpdate).toHaveBeenCalledTimes(2)
+    expect(onBeforeRouteLeave).toHaveBeenCalledTimes(3)
+    expect(onAfterRouteLeave).toHaveBeenCalledTimes(3)
+    expect(onAfterRouteUpdate).toHaveBeenCalledTimes(2)
+    expect(onAfterRouteEnter).toHaveBeenCalledTimes(4)
   })
 })

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -18,7 +18,7 @@ import { RouterPush, RouterPushOptions } from '@/types/routerPush'
 import { RouterReplace, RouterReplaceOptions } from '@/types/routerReplace'
 import { RoutesName } from '@/types/routesMap'
 import { Url, isUrl } from '@/types/url'
-import { createUniqueIdSequence } from '@/services/createUniqueIdSequence'
+import { createUniqueIdSequence, isFirstUniqueSequenceId } from '@/services/createUniqueIdSequence'
 import { createVisibilityObserver } from './createVisibilityObserver'
 import { visibilityObserverKey } from '@/compositions/useVisibilityObserver'
 import { RouterResolve, RouterResolveOptions } from '../types/RouterResolve'
@@ -109,7 +109,7 @@ export function createRouter<
     }
 
     const to = find(url, options) ?? getRejectionRoute('NotFound')
-    const from = { ...currentRoute }
+    const from = getFromRouteForHooks(navigationId)
 
     const beforeResponse = await hooks.runBeforeRouteHooks({ to, from })
 
@@ -300,6 +300,10 @@ export function createRouter<
 
   function stop(): void {
     history.stopListening()
+  }
+
+  function getFromRouteForHooks(navigationId: string): ResolvedRoute | null {
+    return isFirstUniqueSequenceId(navigationId) ? null : { ...currentRoute }
   }
 
   function install(app: App): void {

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -80,7 +80,7 @@ export function createRouter<
   const routes = getRoutesForRouter(routesOrArrayOfRoutes, plugins, options?.base)
   const hooks = createRouterHooks()
 
-  hooks.addRouteHooks(getGlobalHooksForRouter(options, plugins))
+  hooks.addGlobalRouteHooks(getGlobalHooksForRouter(options, plugins))
 
   const getNavigationId = createUniqueIdSequence()
   const propStore = createPropStore()

--- a/src/services/createRouterHooks.ts
+++ b/src/services/createRouterHooks.ts
@@ -1,5 +1,5 @@
 import { InjectionKey } from 'vue'
-import { AddAfterRouteHook, AddBeforeRouteHook, AddGlobalRouteHooks, AfterHookContext, AfterRouteHook, AfterRouteHookResponse, BeforeHookContext, BeforeRouteHook, BeforeRouteHookResponse, AddComponentAfterRouteHook, ComponentBeforeRouteHook, RouteHookAfterRunner, RouteHookBeforeRunner } from '@/types/hooks'
+import { AddAfterRouteHook, AddBeforeRouteHook, AddGlobalRouteHooks, AfterHookContext, AfterRouteHook, AfterRouteHookResponse, BeforeHookContext, BeforeRouteHook, BeforeRouteHookResponse, AddComponentAfterRouteHook, AddComponentBeforeRouteHook, RouteHookAfterRunner, RouteHookBeforeRunner } from '@/types/hooks'
 import { createCallbackContext } from './createCallbackContext'
 import { RouteHooks } from '@/models/RouteHooks'
 import { getRouteHookCondition } from './hooks'
@@ -14,7 +14,7 @@ export const routerHooksKey: InjectionKey<RouterHooks> = Symbol()
 export type RouterHooks = {
   runBeforeRouteHooks: RouteHookBeforeRunner,
   runAfterRouteHooks: RouteHookAfterRunner,
-  addComponentBeforeRouteHook: ComponentBeforeRouteHook,
+  addComponentBeforeRouteHook: AddComponentBeforeRouteHook,
   addComponentAfterRouteHook: AddComponentAfterRouteHook,
   addGlobalRouteHooks: AddGlobalRouteHooks,
   onBeforeRouteEnter: AddBeforeRouteHook,
@@ -159,7 +159,7 @@ export function createRouterHooks(): RouterHooks {
     }
   }
 
-  const addComponentBeforeRouteHook: ComponentBeforeRouteHook = ({ lifecycle, depth, hook }) => {
+  const addComponentBeforeRouteHook: AddComponentBeforeRouteHook = ({ lifecycle, depth, hook }) => {
     const condition = getRouteHookCondition(lifecycle)
     const hooks = store.component[lifecycle]
 

--- a/src/services/createRouterHooks.ts
+++ b/src/services/createRouterHooks.ts
@@ -1,5 +1,5 @@
 import { InjectionKey } from 'vue'
-import { RegisterAfterRouteHook, RegisterBeforeRouteHook, RegisterGlobalRouteHooks, AfterHookContext, AfterRouteHook, AfterRouteHookResponse, BeforeHookContext, BeforeRouteHook, BeforeRouteHookResponse, RegisterComponentAfterRouteHook, RegisterComponentBeforeRouteHook, RouteHookAfterRunner, RouteHookBeforeRunner } from '@/types/hooks'
+import { AddAfterRouteHook, AddBeforeRouteHook, AddGlobalRouteHooks, AfterHookContext, AfterRouteHook, AfterRouteHookResponse, BeforeHookContext, BeforeRouteHook, BeforeRouteHookResponse, AddComponentAfterRouteHook, ComponentBeforeRouteHook, RouteHookAfterRunner, RouteHookBeforeRunner } from '@/types/hooks'
 import { createCallbackContext } from './createCallbackContext'
 import { RouteHooks } from '@/models/RouteHooks'
 import { getRouteHookCondition } from './hooks'
@@ -14,15 +14,15 @@ export const routerHooksKey: InjectionKey<RouterHooks> = Symbol()
 export type RouterHooks = {
   runBeforeRouteHooks: RouteHookBeforeRunner,
   runAfterRouteHooks: RouteHookAfterRunner,
-  addComponentBeforeRouteHook: RegisterComponentBeforeRouteHook,
-  addComponentAfterRouteHook: RegisterComponentAfterRouteHook,
-  addGlobalRouteHooks: RegisterGlobalRouteHooks,
-  onBeforeRouteEnter: RegisterBeforeRouteHook,
-  onBeforeRouteUpdate: RegisterBeforeRouteHook,
-  onBeforeRouteLeave: RegisterBeforeRouteHook,
-  onAfterRouteEnter: RegisterAfterRouteHook,
-  onAfterRouteUpdate: RegisterAfterRouteHook,
-  onAfterRouteLeave: RegisterAfterRouteHook,
+  addComponentBeforeRouteHook: ComponentBeforeRouteHook,
+  addComponentAfterRouteHook: AddComponentAfterRouteHook,
+  addGlobalRouteHooks: AddGlobalRouteHooks,
+  onBeforeRouteEnter: AddBeforeRouteHook,
+  onBeforeRouteUpdate: AddBeforeRouteHook,
+  onBeforeRouteLeave: AddBeforeRouteHook,
+  onAfterRouteEnter: AddAfterRouteHook,
+  onAfterRouteUpdate: AddAfterRouteHook,
+  onAfterRouteLeave: AddAfterRouteHook,
 }
 
 export function createRouterHooks(): RouterHooks {
@@ -33,37 +33,37 @@ export function createRouterHooks(): RouterHooks {
 
   const { reject, push, replace, abort } = createCallbackContext()
 
-  const onBeforeRouteEnter: RegisterBeforeRouteHook = (hook) => {
+  const onBeforeRouteEnter: AddBeforeRouteHook = (hook) => {
     store.global.onBeforeRouteEnter.add(hook)
 
     return () => store.global.onBeforeRouteEnter.delete(hook)
   }
 
-  const onBeforeRouteUpdate: RegisterBeforeRouteHook = (hook) => {
+  const onBeforeRouteUpdate: AddBeforeRouteHook = (hook) => {
     store.global.onBeforeRouteUpdate.add(hook)
 
     return () => store.global.onBeforeRouteUpdate.delete(hook)
   }
 
-  const onBeforeRouteLeave: RegisterBeforeRouteHook = (hook) => {
+  const onBeforeRouteLeave: AddBeforeRouteHook = (hook) => {
     store.global.onBeforeRouteLeave.add(hook)
 
     return () => store.global.onBeforeRouteLeave.delete(hook)
   }
 
-  const onAfterRouteEnter: RegisterAfterRouteHook = (hook) => {
+  const onAfterRouteEnter: AddAfterRouteHook = (hook) => {
     store.global.onAfterRouteEnter.add(hook)
 
     return () => store.global.onAfterRouteEnter.delete(hook)
   }
 
-  const onAfterRouteUpdate: RegisterAfterRouteHook = (hook) => {
+  const onAfterRouteUpdate: AddAfterRouteHook = (hook) => {
     store.global.onAfterRouteUpdate.add(hook)
 
     return () => store.global.onAfterRouteUpdate.delete(hook)
   }
 
-  const onAfterRouteLeave: RegisterAfterRouteHook = (hook) => {
+  const onAfterRouteLeave: AddAfterRouteHook = (hook) => {
     store.global.onAfterRouteLeave.add(hook)
 
     return () => store.global.onAfterRouteLeave.delete(hook)
@@ -159,7 +159,7 @@ export function createRouterHooks(): RouterHooks {
     }
   }
 
-  const addComponentBeforeRouteHook: RegisterComponentBeforeRouteHook = ({ lifecycle, depth, hook }) => {
+  const addComponentBeforeRouteHook: ComponentBeforeRouteHook = ({ lifecycle, depth, hook }) => {
     const condition = getRouteHookCondition(lifecycle)
     const hooks = store.component[lifecycle]
 
@@ -176,7 +176,7 @@ export function createRouterHooks(): RouterHooks {
     return () => hooks.delete(wrapped)
   }
 
-  const addComponentAfterRouteHook: RegisterComponentAfterRouteHook = ({ lifecycle, depth, hook }) => {
+  const addComponentAfterRouteHook: AddComponentAfterRouteHook = ({ lifecycle, depth, hook }) => {
     const condition = getRouteHookCondition(lifecycle)
     const hooks = store.component[lifecycle]
 
@@ -193,7 +193,7 @@ export function createRouterHooks(): RouterHooks {
     return () => hooks.delete(wrapped)
   }
 
-  const addGlobalRouteHooks: RegisterGlobalRouteHooks = (hooks) => {
+  const addGlobalRouteHooks: AddGlobalRouteHooks = (hooks) => {
     hooks.onBeforeRouteEnter.forEach((hook) => onBeforeRouteEnter(hook))
     hooks.onBeforeRouteUpdate.forEach((hook) => onBeforeRouteUpdate(hook))
     hooks.onBeforeRouteLeave.forEach((hook) => onBeforeRouteLeave(hook))

--- a/src/services/createRouterPlugin.browser.spec.ts
+++ b/src/services/createRouterPlugin.browser.spec.ts
@@ -3,8 +3,7 @@ import { createRoute } from './createRoute'
 import { createRouter } from './createRouter'
 import { createRouterPlugin } from './createRouterPlugin'
 import { component, routes } from '@/utilities/testHelpers'
-import { flushPromises } from '@vue/test-utils'
-import { mount } from '@vue/test-utils'
+import { mount, flushPromises } from '@vue/test-utils'
 
 test('given a plugin, adds the routes to the router', async () => {
   const plugin = createRouterPlugin({
@@ -42,7 +41,7 @@ test('given a plugin, adds the rejections to the router', async () => {
     },
   })
 
-  await router.reject('plugin')
+  router.reject('plugin')
 
   await flushPromises()
 
@@ -79,28 +78,28 @@ test('given a plugin, adds the hooks to the router', async () => {
 
   await router.push('parentA.childA', { paramA: 'valueA', paramB: 'valueB' })
 
-  expect(plugin.onBeforeRouteEnter).toHaveBeenCalledTimes(1)
+  expect(plugin.onBeforeRouteEnter).toHaveBeenCalledTimes(2)
   expect(plugin.onBeforeRouteUpdate).toHaveBeenCalledTimes(1)
   expect(plugin.onBeforeRouteLeave).toHaveBeenCalledTimes(1)
   expect(plugin.onAfterRouteLeave).toHaveBeenCalledTimes(1)
   expect(plugin.onAfterRouteUpdate).toHaveBeenCalledTimes(1)
-  expect(plugin.onAfterRouteEnter).toHaveBeenCalledTimes(1)
+  expect(plugin.onAfterRouteEnter).toHaveBeenCalledTimes(2)
 
   await router.push('parentA.childB', { paramA: 'valueB', paramD: 'valueD' })
 
-  expect(plugin.onBeforeRouteEnter).toHaveBeenCalledTimes(1)
-  expect(plugin.onBeforeRouteUpdate).toHaveBeenCalledTimes(2)
-  expect(plugin.onBeforeRouteLeave).toHaveBeenCalledTimes(1)
-  expect(plugin.onAfterRouteLeave).toHaveBeenCalledTimes(1)
-  expect(plugin.onAfterRouteUpdate).toHaveBeenCalledTimes(2)
-  expect(plugin.onAfterRouteEnter).toHaveBeenCalledTimes(1)
-
-  await router.push('parentB')
-
-  expect(plugin.onBeforeRouteEnter).toHaveBeenCalledTimes(2)
+  expect(plugin.onBeforeRouteEnter).toHaveBeenCalledTimes(3)
   expect(plugin.onBeforeRouteUpdate).toHaveBeenCalledTimes(2)
   expect(plugin.onBeforeRouteLeave).toHaveBeenCalledTimes(2)
   expect(plugin.onAfterRouteLeave).toHaveBeenCalledTimes(2)
   expect(plugin.onAfterRouteUpdate).toHaveBeenCalledTimes(2)
-  expect(plugin.onAfterRouteEnter).toHaveBeenCalledTimes(2)
+  expect(plugin.onAfterRouteEnter).toHaveBeenCalledTimes(3)
+
+  await router.push('parentB')
+
+  expect(plugin.onBeforeRouteEnter).toHaveBeenCalledTimes(4)
+  expect(plugin.onBeforeRouteUpdate).toHaveBeenCalledTimes(2)
+  expect(plugin.onBeforeRouteLeave).toHaveBeenCalledTimes(3)
+  expect(plugin.onAfterRouteLeave).toHaveBeenCalledTimes(3)
+  expect(plugin.onAfterRouteUpdate).toHaveBeenCalledTimes(2)
+  expect(plugin.onAfterRouteEnter).toHaveBeenCalledTimes(4)
 })

--- a/src/services/createRouterPlugin.browser.spec.ts
+++ b/src/services/createRouterPlugin.browser.spec.ts
@@ -71,8 +71,8 @@ test('given a plugin, adds the hooks to the router', async () => {
 
   expect(plugin.onBeforeRouteEnter).toHaveBeenCalledTimes(1)
   expect(plugin.onBeforeRouteUpdate).toHaveBeenCalledTimes(0)
-  expect(plugin.onBeforeRouteLeave).toHaveBeenCalledTimes(1)
-  expect(plugin.onAfterRouteLeave).toHaveBeenCalledTimes(1)
+  expect(plugin.onBeforeRouteLeave).toHaveBeenCalledTimes(0)
+  expect(plugin.onAfterRouteLeave).toHaveBeenCalledTimes(0)
   expect(plugin.onAfterRouteUpdate).toHaveBeenCalledTimes(0)
   expect(plugin.onAfterRouteEnter).toHaveBeenCalledTimes(1)
 
@@ -80,8 +80,8 @@ test('given a plugin, adds the hooks to the router', async () => {
 
   expect(plugin.onBeforeRouteEnter).toHaveBeenCalledTimes(2)
   expect(plugin.onBeforeRouteUpdate).toHaveBeenCalledTimes(1)
-  expect(plugin.onBeforeRouteLeave).toHaveBeenCalledTimes(1)
-  expect(plugin.onAfterRouteLeave).toHaveBeenCalledTimes(1)
+  expect(plugin.onBeforeRouteLeave).toHaveBeenCalledTimes(0)
+  expect(plugin.onAfterRouteLeave).toHaveBeenCalledTimes(0)
   expect(plugin.onAfterRouteUpdate).toHaveBeenCalledTimes(1)
   expect(plugin.onAfterRouteEnter).toHaveBeenCalledTimes(2)
 
@@ -89,8 +89,8 @@ test('given a plugin, adds the hooks to the router', async () => {
 
   expect(plugin.onBeforeRouteEnter).toHaveBeenCalledTimes(3)
   expect(plugin.onBeforeRouteUpdate).toHaveBeenCalledTimes(2)
-  expect(plugin.onBeforeRouteLeave).toHaveBeenCalledTimes(2)
-  expect(plugin.onAfterRouteLeave).toHaveBeenCalledTimes(2)
+  expect(plugin.onBeforeRouteLeave).toHaveBeenCalledTimes(1)
+  expect(plugin.onAfterRouteLeave).toHaveBeenCalledTimes(1)
   expect(plugin.onAfterRouteUpdate).toHaveBeenCalledTimes(2)
   expect(plugin.onAfterRouteEnter).toHaveBeenCalledTimes(3)
 
@@ -98,8 +98,8 @@ test('given a plugin, adds the hooks to the router', async () => {
 
   expect(plugin.onBeforeRouteEnter).toHaveBeenCalledTimes(4)
   expect(plugin.onBeforeRouteUpdate).toHaveBeenCalledTimes(2)
-  expect(plugin.onBeforeRouteLeave).toHaveBeenCalledTimes(3)
-  expect(plugin.onAfterRouteLeave).toHaveBeenCalledTimes(3)
+  expect(plugin.onBeforeRouteLeave).toHaveBeenCalledTimes(2)
+  expect(plugin.onAfterRouteLeave).toHaveBeenCalledTimes(2)
   expect(plugin.onAfterRouteUpdate).toHaveBeenCalledTimes(2)
   expect(plugin.onAfterRouteEnter).toHaveBeenCalledTimes(4)
 })

--- a/src/services/createUniqueIdSequence.ts
+++ b/src/services/createUniqueIdSequence.ts
@@ -3,3 +3,9 @@ export function createUniqueIdSequence(): () => string {
 
   return () => (++currentId).toString()
 }
+
+export const FIRST_SEQUENCE_ID = createUniqueIdSequence()()
+
+export function isFirstUniqueSequenceId(id: string): boolean {
+  return id === FIRST_SEQUENCE_ID
+}

--- a/src/services/getGlobalHooksForRouter.ts
+++ b/src/services/getGlobalHooksForRouter.ts
@@ -1,19 +1,23 @@
-import { AfterRouteHookLifecycle, BeforeRouteHookLifecycle, Hooks } from '@/types/hooks'
+import { RouteHooks } from '@/models/RouteHooks'
+import { AfterRouteHookLifecycle, BeforeRouteHookLifecycle } from '@/types/hooks'
 import { RouterOptions } from '@/types/router'
 import { RouterPlugin } from '@/types/routerPlugin'
-import { AsArray } from '@/types/utilities'
 
-export function getGlobalHooksForRouter(options: RouterOptions = {}, plugins: RouterPlugin[] = []): Hooks {
-  return {
-    onBeforeRouteEnter: getHooksForLifecycle('onBeforeRouteEnter', options, plugins),
-    onBeforeRouteUpdate: getHooksForLifecycle('onBeforeRouteUpdate', options, plugins),
-    onBeforeRouteLeave: getHooksForLifecycle('onBeforeRouteLeave', options, plugins),
-    onAfterRouteEnter: getHooksForLifecycle('onAfterRouteEnter', options, plugins),
-    onAfterRouteUpdate: getHooksForLifecycle('onAfterRouteUpdate', options, plugins),
-    onAfterRouteLeave: getHooksForLifecycle('onAfterRouteLeave', options, plugins),
-  }
+export function getGlobalHooksForRouter(options: RouterOptions = {}, plugins: RouterPlugin[] = []): RouteHooks {
+  const hooks = new RouteHooks()
+
+  getHooksForLifecycle('onBeforeRouteEnter', options, plugins).forEach((hook) => hooks.onBeforeRouteEnter.add(hook))
+  getHooksForLifecycle('onBeforeRouteUpdate', options, plugins).forEach((hook) => hooks.onBeforeRouteUpdate.add(hook))
+  getHooksForLifecycle('onBeforeRouteLeave', options, plugins).forEach((hook) => hooks.onBeforeRouteLeave.add(hook))
+  getHooksForLifecycle('onAfterRouteEnter', options, plugins).forEach((hook) => hooks.onAfterRouteEnter.add(hook))
+  getHooksForLifecycle('onAfterRouteUpdate', options, plugins).forEach((hook) => hooks.onAfterRouteUpdate.add(hook))
+  getHooksForLifecycle('onAfterRouteLeave', options, plugins).forEach((hook) => hooks.onAfterRouteLeave.add(hook))
+
+  return hooks
 }
 
-function getHooksForLifecycle<T extends BeforeRouteHookLifecycle | AfterRouteHookLifecycle>(lifecycle: T, options: RouterOptions, plugins: RouterPlugin[]): AsArray<Hooks[T]> {
-  return [options[lifecycle], ...plugins.map((plugin) => plugin[lifecycle])].flat().filter((hook) => hook !== undefined) as AsArray<Hooks[T]>
+// This is more accurate to just let typescript infer the type
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+function getHooksForLifecycle<T extends BeforeRouteHookLifecycle | AfterRouteHookLifecycle>(lifecycle: T, options: RouterOptions, plugins: RouterPlugin[]) {
+  return [options[lifecycle], ...plugins.map((plugin) => plugin[lifecycle])].flat().filter((hook) => hook !== undefined)
 }

--- a/src/services/getGlobalRouteHooks.ts
+++ b/src/services/getGlobalRouteHooks.ts
@@ -1,0 +1,47 @@
+import { RouteHooks } from '@/models/RouteHooks'
+import { ResolvedRoute } from '@/types/resolved'
+import { isRouteEnter, isRouteLeave, isRouteUpdate } from './hooks'
+
+export function getGlobalBeforeRouteHooks(to: ResolvedRoute, from: ResolvedRoute, globalHooks: RouteHooks): RouteHooks {
+  const hooks = new RouteHooks()
+
+  to.matches.forEach((_route, depth) => {
+    if (isRouteEnter(to, from, depth)) {
+      globalHooks.onBeforeRouteEnter.forEach((hook) => hooks.onBeforeRouteEnter.add(hook))
+    }
+
+    if (isRouteUpdate(to, from, depth)) {
+      globalHooks.onBeforeRouteUpdate.forEach((hook) => hooks.onBeforeRouteUpdate.add(hook))
+    }
+  })
+
+  from.matches.forEach((_route, depth) => {
+    if (isRouteLeave(to, from, depth)) {
+      globalHooks.onBeforeRouteLeave.forEach((hook) => hooks.onBeforeRouteLeave.add(hook))
+    }
+  })
+
+  return hooks
+}
+
+export function getGlobalAfterRouteHooks(to: ResolvedRoute, from: ResolvedRoute, globalHooks: RouteHooks): RouteHooks {
+  const hooks = new RouteHooks()
+
+  to.matches.forEach((_route, depth) => {
+    if (isRouteEnter(to, from, depth)) {
+      globalHooks.onAfterRouteEnter.forEach((hook) => hooks.onAfterRouteEnter.add(hook))
+    }
+
+    if (isRouteUpdate(to, from, depth)) {
+      globalHooks.onAfterRouteUpdate.forEach((hook) => hooks.onAfterRouteUpdate.add(hook))
+    }
+  })
+
+  from.matches.forEach((_route, depth) => {
+    if (isRouteLeave(to, from, depth)) {
+      globalHooks.onAfterRouteLeave.forEach((hook) => hooks.onAfterRouteLeave.add(hook))
+    }
+  })
+
+  return hooks
+}

--- a/src/services/getGlobalRouteHooks.ts
+++ b/src/services/getGlobalRouteHooks.ts
@@ -2,7 +2,7 @@ import { RouteHooks } from '@/models/RouteHooks'
 import { ResolvedRoute } from '@/types/resolved'
 import { isRouteEnter, isRouteLeave, isRouteUpdate } from './hooks'
 
-export function getGlobalBeforeRouteHooks(to: ResolvedRoute, from: ResolvedRoute, globalHooks: RouteHooks): RouteHooks {
+export function getGlobalBeforeRouteHooks(to: ResolvedRoute, from: ResolvedRoute | null, globalHooks: RouteHooks): RouteHooks {
   const hooks = new RouteHooks()
 
   to.matches.forEach((_route, depth) => {
@@ -15,7 +15,7 @@ export function getGlobalBeforeRouteHooks(to: ResolvedRoute, from: ResolvedRoute
     }
   })
 
-  from.matches.forEach((_route, depth) => {
+  from?.matches.forEach((_route, depth) => {
     if (isRouteLeave(to, from, depth)) {
       globalHooks.onBeforeRouteLeave.forEach((hook) => hooks.onBeforeRouteLeave.add(hook))
     }
@@ -24,7 +24,7 @@ export function getGlobalBeforeRouteHooks(to: ResolvedRoute, from: ResolvedRoute
   return hooks
 }
 
-export function getGlobalAfterRouteHooks(to: ResolvedRoute, from: ResolvedRoute, globalHooks: RouteHooks): RouteHooks {
+export function getGlobalAfterRouteHooks(to: ResolvedRoute, from: ResolvedRoute | null, globalHooks: RouteHooks): RouteHooks {
   const hooks = new RouteHooks()
 
   to.matches.forEach((_route, depth) => {
@@ -37,7 +37,7 @@ export function getGlobalAfterRouteHooks(to: ResolvedRoute, from: ResolvedRoute,
     }
   })
 
-  from.matches.forEach((_route, depth) => {
+  from?.matches.forEach((_route, depth) => {
     if (isRouteLeave(to, from, depth)) {
       globalHooks.onAfterRouteLeave.forEach((hook) => hooks.onAfterRouteLeave.add(hook))
     }

--- a/src/services/getRouteHooks.ts
+++ b/src/services/getRouteHooks.ts
@@ -3,7 +3,7 @@ import { isRouteEnter, isRouteLeave, isRouteUpdate } from '@/services/hooks'
 import { ResolvedRoute } from '@/types/resolved'
 import { asArray } from '@/utilities/array'
 
-export function getBeforeRouteHooksFromRoutes(to: ResolvedRoute, from: ResolvedRoute): RouteHooks {
+export function getBeforeRouteHooksFromRoutes(to: ResolvedRoute, from: ResolvedRoute | null): RouteHooks {
   const hooks = new RouteHooks()
 
   to.matches.forEach((route, depth) => {
@@ -16,7 +16,7 @@ export function getBeforeRouteHooksFromRoutes(to: ResolvedRoute, from: ResolvedR
     }
   })
 
-  from.matches.forEach((route, depth) => {
+  from?.matches.forEach((route, depth) => {
     if (route.onBeforeRouteLeave && isRouteLeave(to, from, depth)) {
       asArray(route.onBeforeRouteLeave).forEach((hook) => hooks.onBeforeRouteLeave.add(hook))
     }
@@ -25,7 +25,7 @@ export function getBeforeRouteHooksFromRoutes(to: ResolvedRoute, from: ResolvedR
   return hooks
 }
 
-export function getAfterRouteHooksFromRoutes(to: ResolvedRoute, from: ResolvedRoute): RouteHooks {
+export function getAfterRouteHooksFromRoutes(to: ResolvedRoute, from: ResolvedRoute | null): RouteHooks {
   const hooks = new RouteHooks()
 
   to.matches.forEach((route, depth) => {
@@ -38,7 +38,7 @@ export function getAfterRouteHooksFromRoutes(to: ResolvedRoute, from: ResolvedRo
     }
   })
 
-  from.matches.forEach((route, depth) => {
+  from?.matches.forEach((route, depth) => {
     if (route.onAfterRouteLeave && isRouteLeave(to, from, depth)) {
       asArray(route.onAfterRouteLeave).forEach((hook) => hooks.onAfterRouteLeave.add(hook))
     }

--- a/src/services/hooks.ts
+++ b/src/services/hooks.ts
@@ -7,18 +7,18 @@ export const isRouteEnter: RouteHookCondition = (to, from, depth) => {
   const toMatches = to.matches
   const fromMatches = from?.matches ?? []
 
-  return toMatches.length < depth || toMatches[depth].id !== fromMatches[depth]?.id
+  return toMatches.length < depth || toMatches.at(depth)?.id !== fromMatches.at(depth)?.id
 }
 
 export const isRouteLeave: RouteHookCondition = (to, from, depth) => {
   const toMatches = to.matches
   const fromMatches = from?.matches ?? []
 
-  return toMatches.length < depth || toMatches[depth].id !== fromMatches[depth]?.id
+  return toMatches.length < depth || toMatches.at(depth)?.id !== fromMatches.at(depth)?.id
 }
 
 export const isRouteUpdate: RouteHookCondition = (to, from, depth) => {
-  return to.matches[depth].id === from?.matches[depth]?.id
+  return to.matches.at(depth)?.id === from?.matches.at(depth)?.id
 }
 
 export function getRouteHookCondition(lifecycle: RouteHookLifecycle): RouteHookCondition {

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -37,7 +37,7 @@ export type BeforeRouteHookRegistration = {
   depth: number,
 }
 
-export type RegisterComponentBeforeRouteHook = (hook: BeforeRouteHookRegistration) => RouteHookRemove
+export type ComponentBeforeRouteHook = (hook: BeforeRouteHookRegistration) => RouteHookRemove
 
 export type AfterRouteHookRegistration = {
   lifecycle: 'onAfterRouteEnter' | 'onAfterRouteUpdate' | 'onAfterRouteLeave',
@@ -45,23 +45,23 @@ export type AfterRouteHookRegistration = {
   depth: number,
 }
 
-export type RegisterComponentAfterRouteHook = (hook: AfterRouteHookRegistration) => RouteHookRemove
+export type AddComponentAfterRouteHook = (hook: AfterRouteHookRegistration) => RouteHookRemove
 
-export type RegisterGlobalRouteHooks = (hooks: RouteHooks) => void
+export type AddGlobalRouteHooks = (hooks: RouteHooks) => void
 
 /**
  * Adds a hook that is called before a route change. Returns a function to remove the hook.
  * @param hook - {@link BeforeRouteHook} The hook function to add.
  * @returns {RouteHookRemove} A function that removes the added hook.
  */
-export type RegisterBeforeRouteHook = (hook: BeforeRouteHook) => RouteHookRemove
+export type AddBeforeRouteHook = (hook: BeforeRouteHook) => RouteHookRemove
 
 /**
  * Adds a hook that is called after a route change. Returns a function to remove the hook.
  * @param hook - {@link AfterRouteHook} The hook function to add.
  * @returns {RouteHookRemove} A function that removes the added hook.
  */
-export type RegisterAfterRouteHook = (hook: AfterRouteHook) => RouteHookRemove
+export type AddAfterRouteHook = (hook: AfterRouteHook) => RouteHookRemove
 
 /**
  * Context provided to route hooks, containing context of previous route and functions for triggering rejections and push/replace to another route.

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -37,7 +37,7 @@ export type BeforeRouteHookRegistration = {
   depth: number,
 }
 
-export type ComponentBeforeRouteHook = (hook: BeforeRouteHookRegistration) => RouteHookRemove
+export type AddComponentBeforeRouteHook = (hook: BeforeRouteHookRegistration) => RouteHookRemove
 
 export type AfterRouteHookRegistration = {
   lifecycle: 'onAfterRouteEnter' | 'onAfterRouteUpdate' | 'onAfterRouteLeave',

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -40,38 +40,36 @@ export type RouteHookAfterRunner = (context: AfterHookContext) => Promise<AfterR
 export type RouteHookTiming = 'global' | 'component'
 
 export type BeforeRouteHookRegistration = {
-  timing: RouteHookTiming,
   lifecycle: 'onBeforeRouteEnter' | 'onBeforeRouteUpdate' | 'onBeforeRouteLeave',
   hook: BeforeRouteHook,
   depth: number,
 }
 
-export type RegisterBeforeRouteHook = (hook: BeforeRouteHookRegistration) => RouteHookRemove
+export type RegisterComponentBeforeRouteHook = (hook: BeforeRouteHookRegistration) => RouteHookRemove
 
 export type AfterRouteHookRegistration = {
-  timing: RouteHookTiming,
   lifecycle: 'onAfterRouteEnter' | 'onAfterRouteUpdate' | 'onAfterRouteLeave',
   hook: AfterRouteHook,
   depth: number,
 }
 
-export type RegisterAfterRouteHook = (hook: AfterRouteHookRegistration) => RouteHookRemove
+export type RegisterComponentAfterRouteHook = (hook: AfterRouteHookRegistration) => RouteHookRemove
 
-export type AddRouteHooks = (hooks: Hooks) => void
+export type RegisterGlobalRouteHooks = (hooks: Hooks) => void
 
 /**
  * Adds a hook that is called before a route change. Returns a function to remove the hook.
  * @param hook - {@link BeforeRouteHook} The hook function to add.
  * @returns {RouteHookRemove} A function that removes the added hook.
  */
-export type AddBeforeRouteHook = (hook: BeforeRouteHook) => RouteHookRemove
+export type RegisterBeforeRouteHook = (hook: BeforeRouteHook) => RouteHookRemove
 
 /**
  * Adds a hook that is called after a route change. Returns a function to remove the hook.
  * @param hook - {@link AfterRouteHook} The hook function to add.
  * @returns {RouteHookRemove} A function that removes the added hook.
  */
-export type AddAfterRouteHook = (hook: AfterRouteHook) => RouteHookRemove
+export type RegisterAfterRouteHook = (hook: AfterRouteHook) => RouteHookRemove
 
 /**
  * Context provided to route hooks, containing context of previous route and functions for triggering rejections and push/replace to another route.

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -17,14 +17,14 @@ export type WithHooks = {
 
 export type BeforeHookContext = {
   to: ResolvedRoute,
-  from: ResolvedRoute,
+  from: ResolvedRoute | null,
 }
 
 export type RouteHookBeforeRunner = (context: BeforeHookContext) => Promise<BeforeRouteHookResponse>
 
 export type AfterHookContext = {
   to: ResolvedRoute,
-  from: ResolvedRoute,
+  from: ResolvedRoute | null,
 }
 
 export type RouteHookAfterRunner = (context: AfterHookContext) => Promise<AfterRouteHookResponse>

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,15 +1,7 @@
+import { RouteHooks } from '@/models/RouteHooks'
 import { CallbackAbortResponse, CallbackContext, CallbackContextAbort, CallbackPushResponse, CallbackRejectResponse, CallbackSuccessResponse } from '@/services/createCallbackContext'
 import { ResolvedRoute } from '@/types/resolved'
 import { MaybeArray, MaybePromise } from '@/types/utilities'
-
-export type Hooks = {
-  onBeforeRouteEnter: BeforeRouteHook[],
-  onBeforeRouteUpdate: BeforeRouteHook[],
-  onBeforeRouteLeave: BeforeRouteHook[],
-  onAfterRouteEnter: AfterRouteHook[],
-  onAfterRouteUpdate: AfterRouteHook[],
-  onAfterRouteLeave: AfterRouteHook[],
-}
 
 /**
  * Defines route hooks that can be applied before entering, updating, or leaving a route, as well as after these events.
@@ -55,7 +47,7 @@ export type AfterRouteHookRegistration = {
 
 export type RegisterComponentAfterRouteHook = (hook: AfterRouteHookRegistration) => RouteHookRemove
 
-export type RegisterGlobalRouteHooks = (hooks: Hooks) => void
+export type RegisterGlobalRouteHooks = (hooks: RouteHooks) => void
 
 /**
  * Adds a hook that is called before a route change. Returns a function to remove the hook.

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -1,7 +1,7 @@
 import { App, Component } from 'vue'
 import { RouterHistoryMode } from '@/services/createRouterHistory'
 import { RouterRoute } from '@/services/createRouterRoute'
-import { AddAfterRouteHook, AddBeforeRouteHook, WithHooks } from '@/types/hooks'
+import { RegisterAfterRouteHook, RegisterBeforeRouteHook, WithHooks } from '@/types/hooks'
 import { PrefetchConfig } from '@/types/prefetch'
 import { ResolvedRoute } from '@/types/resolved'
 import { Routes } from '@/types/route'
@@ -96,27 +96,27 @@ export type Router<
   /**
    * Registers a hook to be called before a route is entered.
    */
-  onBeforeRouteEnter: AddBeforeRouteHook,
+  onBeforeRouteEnter: RegisterBeforeRouteHook,
   /**
    * Registers a hook to be called before a route is left.
    */
-  onBeforeRouteLeave: AddBeforeRouteHook,
+  onBeforeRouteLeave: RegisterBeforeRouteHook,
   /**
    * Registers a hook to be called before a route is updated.
    */
-  onBeforeRouteUpdate: AddBeforeRouteHook,
+  onBeforeRouteUpdate: RegisterBeforeRouteHook,
   /**
    * Registers a hook to be called after a route is entered.
    */
-  onAfterRouteEnter: AddAfterRouteHook,
+  onAfterRouteEnter: RegisterAfterRouteHook,
   /**
    * Registers a hook to be called after a route is left.
    */
-  onAfterRouteLeave: AddAfterRouteHook,
+  onAfterRouteLeave: RegisterAfterRouteHook,
   /**
    * Registers a hook to be called after a route is updated.
    */
-  onAfterRouteUpdate: AddAfterRouteHook,
+  onAfterRouteUpdate: RegisterAfterRouteHook,
   /**
   * Given a URL, returns true if host does not match host stored on router instance
   */

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -1,7 +1,7 @@
 import { App, Component } from 'vue'
 import { RouterHistoryMode } from '@/services/createRouterHistory'
 import { RouterRoute } from '@/services/createRouterRoute'
-import { RegisterAfterRouteHook, RegisterBeforeRouteHook, WithHooks } from '@/types/hooks'
+import { AddAfterRouteHook, AddBeforeRouteHook, WithHooks } from '@/types/hooks'
 import { PrefetchConfig } from '@/types/prefetch'
 import { ResolvedRoute } from '@/types/resolved'
 import { Routes } from '@/types/route'
@@ -96,27 +96,27 @@ export type Router<
   /**
    * Registers a hook to be called before a route is entered.
    */
-  onBeforeRouteEnter: RegisterBeforeRouteHook,
+  onBeforeRouteEnter: AddBeforeRouteHook,
   /**
    * Registers a hook to be called before a route is left.
    */
-  onBeforeRouteLeave: RegisterBeforeRouteHook,
+  onBeforeRouteLeave: AddBeforeRouteHook,
   /**
    * Registers a hook to be called before a route is updated.
    */
-  onBeforeRouteUpdate: RegisterBeforeRouteHook,
+  onBeforeRouteUpdate: AddBeforeRouteHook,
   /**
    * Registers a hook to be called after a route is entered.
    */
-  onAfterRouteEnter: RegisterAfterRouteHook,
+  onAfterRouteEnter: AddAfterRouteHook,
   /**
    * Registers a hook to be called after a route is left.
    */
-  onAfterRouteLeave: RegisterAfterRouteHook,
+  onAfterRouteLeave: AddAfterRouteHook,
   /**
    * Registers a hook to be called after a route is updated.
    */
-  onAfterRouteUpdate: RegisterAfterRouteHook,
+  onAfterRouteUpdate: AddAfterRouteHook,
   /**
   * Given a URL, returns true if host does not match host stored on router instance
   */

--- a/src/utilities/testHelpers.ts
+++ b/src/utilities/testHelpers.ts
@@ -33,13 +33,13 @@ const parentA = createRoute({
 const childA = createRoute({
   parent: parentA,
   name: 'parentA.childA',
-  path: '/[?paramB]',
+  path: '/childA/[?paramB]',
 })
 
 const childB = createRoute({
   parent: parentA,
   name: 'parentA.childB',
-  path: '/[paramD]',
+  path: '/childB/[paramD]',
   component,
 })
 


### PR DESCRIPTION
# Description
This PR fixes both hooks related issues outlined in https://github.com/kitbagjs/router/issues/402

**Global Hooks**
Now when global hooks are registered they are registered without conditional wrappers based on depth. That way when hooks are gathered they can be gathered based on what route navigation is actually happening (enter, update, or leave) no matter at what level. 

This means that if any of the matches are an enter then each global route enter hook will be executed once. Same for update and leave. 

**Update hooks on first navigation**
Since the `NotFound` rejection route is always the starting point for the route, when hooks were executed for the first navigation (when the router was started) the `from` context would have a route. This would cause global `leave` hooks to be executed. 

The router now checks the navigation id when getting the `from` route. And if it is the first navigation it passes `null` instead of the `NotFound` rejection route. 