### PR TITLE
simplify withState types

### DIFF
--- a/src/services/createRoute.ts
+++ b/src/services/createRoute.ts
@@ -6,7 +6,7 @@ import { CombineQuery } from '@/services/combineQuery'
 import { CombineState } from '@/services/combineState'
 import { createRouteId } from '@/services/createRouteId'
 import { host } from '@/services/host'
-import { CreateRouteOptions, WithComponent, WithComponents, WithParent, WithoutComponents, WithoutParent, combineRoutes, isWithParent, isWithState } from '@/types/createRouteOptions'
+import { CreateRouteOptions, WithComponent, WithComponents, WithParent, WithoutComponents, WithoutParent, combineRoutes, isWithParent } from '@/types/createRouteOptions'
 import { Hash, toHash, ToHash } from '@/types/hash'
 import { Host } from '@/types/host'
 import { toName, ToName } from '@/types/name'
@@ -169,7 +169,7 @@ export function createRoute(options: CreateRouteOptions): Route {
   const query = toQuery(options.query)
   const hash = toHash(options.hash)
   const meta = options.meta ?? {}
-  const state = isWithState(options) ? options.state : {}
+  const state = options.state ?? {}
   const rawRoute = markRaw({ id, meta: {}, state: {}, ...options })
 
   const route = {

--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -83,21 +83,6 @@ export function isWithComponents(options: CreateRouteOptions): options is Create
   return 'components' in options && Boolean(options.components)
 }
 
-export type WithState<TState extends Record<string, Param> = Record<string, Param>> = {
-  /**
-   * Type params for additional data intended to be stored in history state, all keys will be optional unless a default is provided.
-   */
-  state: TState,
-}
-
-export function isWithState(options: CreateRouteOptions): options is CreateRouteOptions & WithState {
-  return 'state' in options && Boolean(options.state)
-}
-
-export type WithoutState = {
-  state?: never,
-}
-
 export type CreateRouteOptions<
   TName extends string | undefined = string | undefined,
   TPath extends string | Path | undefined = string | Path | undefined,
@@ -130,9 +115,12 @@ export type CreateRouteOptions<
    * Determines what assets are prefetched when router-link is rendered for this route. Overrides router level prefetch.
    */
   prefetch?: PrefetchConfig,
+  /**
+   * Type params for additional data intended to be stored in history state, all keys will be optional unless a default is provided.
+   */
+  state?: TState,
 }
 & WithHooks
-& (WithState<TState> | WithoutState)
 
 export function combineRoutes(parent: Route, child: Route): Route {
   return {


### PR DESCRIPTION
while working on https://github.com/kitbagjs/router/pull/407, we noticed that the types for `withState` were over-complicated. The types were built to behave like `withParent` and `withComponent`, but unlike those types we didn't actually benefit from the complexity because there are no overloads of `createRoute` that leverage `withState` vs `withoutState`.