### PR TITLE
make sure we find corresponding param when setting query values

### DIFF
--- a/src/services/urlAssembly.spec.ts
+++ b/src/services/urlAssembly.spec.ts
@@ -232,7 +232,7 @@ describe('query params', () => {
     expect(url).toBe('/?simple=ABC')
   })
 
-  test.only('given route with optional custom param, finds and uses param to set value', () => {
+  test('given route with optional custom param, finds and uses param to set value', () => {
     const randomValue = Math.floor(Math.random() * 1000)
     const get = vi.fn()
     const set = vi.fn().mockReturnValue(randomValue.toString())

--- a/src/services/urlAssembly.spec.ts
+++ b/src/services/urlAssembly.spec.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
 import { InvalidRouteParamValueError } from '@/errors/invalidRouteParamValueError'
 import { createExternalRoute } from '@/services/createExternalRoute'
 import { createRoute } from '@/services/createRoute'
@@ -8,6 +8,7 @@ import { query } from '@/services/query'
 import { assembleUrl } from '@/services/urlAssembly'
 import { withDefault } from '@/services/withDefault'
 import { component } from '@/utilities/testHelpers'
+import { createParam } from './createParam'
 
 describe('path params', () => {
   test.each([
@@ -229,6 +230,24 @@ describe('query params', () => {
     })
 
     expect(url).toBe('/?simple=ABC')
+  })
+
+  test.only('given route with optional custom param, finds and uses param to set value', () => {
+    const randomValue = Math.floor(Math.random() * 1000)
+    const get = vi.fn()
+    const set = vi.fn().mockReturnValue(randomValue.toString())
+    const myParam = createParam({ get, set })
+
+    const route = createRoute({
+      name: 'simple',
+      path: '/',
+      query: query('sort=[?sort]', { sort: myParam }),
+      component,
+    })
+
+    const url = assembleUrl(route, { params: { sort: 'irrelevant' } })
+
+    expect(url).toBe(`/?sort=${randomValue}`)
   })
 
   test('given route with multiple empty and optional query params, removes both from url', () => {

--- a/src/services/urlAssembly.ts
+++ b/src/services/urlAssembly.ts
@@ -72,9 +72,11 @@ function assembleQueryParamValues(query: Query, paramValues: Record<string, unkn
       continue
     }
 
-    const paramValue = setParamValue(paramValues[paramName], query.params[paramName], isOptionalParamSyntax(value))
+    const isOptional = isOptionalParamSyntax(value)
+    const paramKey = isOptional ? `?${paramName}` : paramName
+    const paramValue = setParamValue(paramValues[paramName], query.params[paramKey], isOptional)
     const valueNotProvidedAndNoDefaultUsed = paramValues[paramName] === undefined && paramValue === ''
-    const shouldLeaveEmptyValueOut = isOptionalParamSyntax(value) && valueNotProvidedAndNoDefaultUsed
+    const shouldLeaveEmptyValueOut = isOptional && valueNotProvidedAndNoDefaultUsed
 
     if (shouldLeaveEmptyValueOut) {
       search.delete(key, value)


### PR DESCRIPTION
we store params as they're supplied by the user, so optional params will include the `?`.

```ts
query: {
  value: 'foo=[?foo]`,
  params: {
    '?foo': String
  }
}
```

When calling param setter while assembling a url, we were expecting to find the param by the `paramName` which does not include `?`. This was hard to notice before because when no param is found, the router falls back on `toString()` which was satisfying every test we had. (now we have a more specific test)

This was also only effecting query because path and host iterate via `Object.entries(path.params)`, so key includes `?`. Query is setup slightly differently because we build a new `URLSearchParams` object from scratch. This enables us to completely omit a search value if it's not provided and optional. 