### PR TITLE
fix bug with get query params with different keys

### DIFF
--- a/src/services/paramValidation.spec.ts
+++ b/src/services/paramValidation.spec.ts
@@ -195,4 +195,17 @@ describe('getRouteParamValues', () => {
     expect(response.inPath).toBe(output)
     expect(response.inQuery).toBe(output)
   })
+
+  test('given route with query param that has a different param name than query key, still works as expected', () => {
+    const route = createRoute({
+      name: 'test',
+      path: '/',
+      query: 's=[?search]',
+      component,
+    })
+
+    const response = getRouteParamValues(route, '/?s=foo')
+
+    expect(response.search).toBe('foo')
+  })
 })

--- a/src/services/urlAssembly.spec.ts
+++ b/src/services/urlAssembly.spec.ts
@@ -267,6 +267,18 @@ describe('query params', () => {
 
     expect(url).toBe('/')
   })
+
+  test('given route with query params with different param names than query keys, still works as expected', () => {
+    const route = createRoute({
+      name: 'query-keys',
+      path: '/',
+      query: 's=[?search]',
+    })
+
+    const url = assembleUrl(route, { params: { search: 'foo' } })
+
+    expect(url).toBe('/?s=foo')
+  })
 })
 
 describe('static query', () => {


### PR DESCRIPTION
closes #415 

First thought was this was probably related to recent change to [urlAssembly](https://github.com/kitbagjs/router/pull/412/files). I wrote a test that asserts expected behavior when param name is different from query key.

```ts
// src/services/urlAssembly.spec.ts

test('given route with query params with different param names than query keys, still works as expected', () => {
  const route = createRoute({
    name: 'query-keys',
    path: '/',
    query: 's=[?search]',
  })

  const url = assembleUrl(route, { params: { search: 'foo' } })

  expect(url).toBe('/?s=foo')
})
```

That test already passes in main, but I included in this PR to ensure expected behavior moving forward.

urlAssembly is looking for params and calling `setParamValue`. This lead me to paramValidation which is the inverse, it looks through params and calls `getParamValue`. All I had to do is apply the logic from urlAssembly over in paramValidation, those functions are much more similar now.