### PR TITLE
Fix route props not clearing after navigation happens

### DIFF
--- a/src/routeProps.spec.ts
+++ b/src/routeProps.spec.ts
@@ -1,0 +1,30 @@
+import { expect, test, vi } from 'vitest'
+import { createRoute } from './services/createRoute'
+import { createRouter } from './services/createRouter'
+
+test('props are called each time the route is matched', async () => {
+  const props = vi.fn()
+
+  const route = createRoute({
+    name: 'test',
+    path: '/[param]',
+  }, props)
+
+  const router = createRouter([route], {
+    initialUrl: '/',
+  })
+
+  await router.start()
+
+  await router.push('test', { param: 'foo' })
+
+  expect(props).toHaveBeenCalledTimes(1)
+
+  await router.push('test', { param: 'bar' })
+
+  expect(props).toHaveBeenCalledTimes(2)
+
+  await router.push('test', { param: 'foo' })
+
+  expect(props).toHaveBeenCalledTimes(3)
+})

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -134,7 +134,7 @@ export function createPropStore(): PropStore {
   }
 
   function clearUnusedStoreEntries(keysToKeep: string[]): void {
-    for (const key in store.keys()) {
+    for (const key of store.keys()) {
       if (keysToKeep.includes(key)) {
         continue
       }


### PR DESCRIPTION
# Description
Because of a bad for loop the props store wasn't actually clearing out props from previous navigations. This meant that if you re-navigated to the same route the props wouldn't be run again. 