### PR TITLE
Add `parent` context with name and prop values to the callback context of route props

### DIFF
--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -127,13 +127,13 @@ export function createPropStore(): PropStore {
         get props() {
           return getParentProps(parent, 'default', route, prefetch)
         },
-      } as PropsCallbackParent
+      }
     }
 
     if (isWithComponentPropsRecord(parent)) {
       return {
         name: parent.name ?? '',
-        props: new Proxy({} as any, {
+        props: new Proxy({}, {
           get(target, name) {
             if (typeof name !== 'string') {
               return Reflect.get(target, name)

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -116,7 +116,6 @@ export function createPropStore(): PropStore {
     return store.get(key)
   }
 
-  // todo: account for prefetching
   function getParentContext(parent: Route['matched'] | undefined, route: ResolvedRoute, prefetch: boolean = false): PropsCallbackParent {
     if (!parent) {
       return
@@ -146,7 +145,10 @@ export function createPropStore(): PropStore {
       }
     }
 
-    return
+    return {
+      name: parent.name ?? '',
+      props: undefined,
+    }
   }
 
   function getParentProps(parent: Route['matched'], name: string, route: ResolvedRoute, prefetch: boolean = false): unknown {

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -127,13 +127,13 @@ export function createPropStore(): PropStore {
         get props() {
           return getParentProps(parent, 'default', route, prefetch)
         },
-      }
+      } as PropsCallbackParent
     }
 
     if (isWithComponentPropsRecord(parent)) {
       return {
         name: parent.name ?? '',
-        props: new Proxy({}, {
+        props: new Proxy({} as any, {
           get(target, name) {
             if (typeof name !== 'string') {
               return Reflect.get(target, name)

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -35,13 +35,12 @@ export function createPropStore(): PropStore {
           return response
         }
 
-        const parent = route.matches.at(-2)
         const key = getPropKey(id, name, route)
         const value = getPropsValue(() => props(route, {
           push,
           replace,
           reject,
-          parent: getParentContext(parent, route, true),
+          parent: getParentContext(route, true),
         }))
 
         response[key] = value
@@ -71,12 +70,11 @@ export function createPropStore(): PropStore {
       keys.push(key)
 
       if (!store.has(key)) {
-        const parent = route.matches.at(-2)
         const value = getPropsValue(() => props(route, {
           push,
           replace,
           reject,
-          parent: getParentContext(parent, route),
+          parent: getParentContext(route),
         }))
 
         store.set(key, value)
@@ -116,7 +114,9 @@ export function createPropStore(): PropStore {
     return store.get(key)
   }
 
-  function getParentContext(parent: Route['matched'] | undefined, route: ResolvedRoute, prefetch: boolean = false): PropsCallbackParent {
+  function getParentContext(route: ResolvedRoute, prefetch: boolean = false): PropsCallbackParent {
+    const parent = route.matches.at(-2)
+
     if (!parent) {
       return
     }

--- a/src/services/createRoute.spec-d.ts
+++ b/src/services/createRoute.spec-d.ts
@@ -407,6 +407,22 @@ test('undefined is not a valid value for 2nd argument of createRoute', () => {
   expectTypeOf<Source>().toEqualTypeOf<Expect>()
 })
 
+test('parent props are undefined when parent has no props', () => {
+  const parent = createRoute({
+    name: 'parent',
+  })
+
+  createRoute({
+    name: 'child',
+    parent: parent,
+  }, (__, { parent }) => {
+    expectTypeOf(parent.props).toEqualTypeOf<undefined>()
+    expectTypeOf(parent.name).toEqualTypeOf<'parent'>()
+
+    return {}
+  })
+})
+
 test('sync parent props are passed to child props', () => {
   const parent = createRoute({
     name: 'parent',

--- a/src/services/createRoute.spec-d.ts
+++ b/src/services/createRoute.spec-d.ts
@@ -406,3 +406,89 @@ test('undefined is not a valid value for 2nd argument of createRoute', () => {
 
   expectTypeOf<Source>().toEqualTypeOf<Expect>()
 })
+
+test('sync parent props are passed to child props', () => {
+  const parent = createRoute({
+    name: 'parent',
+  }, () => ({ foo: 123 }))
+
+  createRoute({
+    name: 'child',
+    parent: parent,
+  }, (__, { parent }) => {
+    expectTypeOf(parent.props).toEqualTypeOf<{ foo: number }>()
+    expectTypeOf(parent.name).toEqualTypeOf<'parent'>()
+
+    return {}
+  })
+})
+
+test('async parent props are passed to child props', () => {
+  const parent = createRoute({
+    name: 'parent',
+  }, async () => ({ foo: 123 }))
+
+  createRoute({
+    name: 'child',
+    parent: parent,
+  }, (__, { parent }) => {
+    expectTypeOf(parent.props).toEqualTypeOf<Promise<{ foo: number }>>()
+    expectTypeOf(parent.name).toEqualTypeOf<'parent'>()
+
+    return {}
+  })
+})
+
+test('parent props are passed to child props when multiple parent components are used', () => {
+  const parent = createRoute({
+    name: 'parent',
+    components: {
+      one: component,
+      two: component,
+    },
+  }, {
+    one: () => ({ foo: 123 }),
+    two: async () => ({ foo: 456 }),
+  })
+
+  createRoute({
+    name: 'child',
+    parent: parent,
+  }, (__, { parent }) => {
+    expectTypeOf(parent.props).toEqualTypeOf<{
+      one: { foo: number },
+      two: Promise<{ foo: number }>,
+    }>()
+    expectTypeOf(parent.name).toEqualTypeOf<'parent'>()
+
+    return {}
+  })
+})
+
+test('parent props are passed to child props when multiple child components are used', () => {
+  const parent = createRoute({
+    name: 'parent',
+  }, async () => ({ foo: 123 }))
+
+  createRoute({
+    name: 'child',
+    parent: parent,
+    components: {
+      one: component,
+      two: component,
+    },
+  }, {
+    one: (__, { parent }) => {
+      expectTypeOf(parent.props).toEqualTypeOf<Promise<{ foo: number }>>()
+      expectTypeOf(parent.name).toEqualTypeOf<'parent'>()
+
+      return {}
+    },
+    two: (__, { parent }) => {
+      expectTypeOf(parent.props).toEqualTypeOf<Promise<{ foo: number }>>()
+      expectTypeOf(parent.name).toEqualTypeOf<'parent'>()
+
+      return {}
+    },
+  })
+})

--- a/src/services/createRoute.spec.ts
+++ b/src/services/createRoute.spec.ts
@@ -3,7 +3,6 @@ import { createRoute } from '@/services/createRoute'
 import { path } from '@/services/path'
 import { query } from '@/services/query'
 import { createRouter } from '@/main'
-import echo from '@/components/echo'
 import { component } from '@/utilities/testHelpers'
 
 test('given parent, path is combined', () => {
@@ -112,6 +111,29 @@ test('given parent and child without meta, meta matches parent', () => {
   expect(child.meta).toMatchObject({
     foo: 123,
   })
+})
+
+test('parent context is passed to child props', async () => {
+  const spy = vi.fn()
+  const parent = createRoute({
+    name: 'parent',
+  })
+
+  const child = createRoute({
+    name: 'child',
+    parent: parent,
+    path: '/child',
+  }, (_, { parent }) => {
+    return spy(parent)
+  })
+
+  const router = createRouter([parent, child], {
+    initialUrl: '/child',
+  })
+
+  await router.start()
+
+  expect(spy).toHaveBeenCalledWith({ name: 'parent', props: undefined })
 })
 
 test('sync parent props are passed to child props', async () => {

--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -129,7 +129,7 @@ export type CreateRouteOptions<
 export type PropsGetter<
   TOptions extends CreateRouteOptions = CreateRouteOptions,
   TComponent extends Component = Component
-> = (route: ResolvedRoute<ToRoute<TOptions, undefined>>, context: PropsCallbackContext) => MaybePromise<ComponentProps<TComponent>>
+> = (route: ResolvedRoute<ToRoute<TOptions, undefined>>, context: PropsCallbackContext<TOptions['parent']>) => MaybePromise<ComponentProps<TComponent>>
 
 type ComponentPropsAreOptional<
   TComponent extends Component

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -28,5 +28,5 @@ type GetParentPropsReturnType<
     ? ReturnType<TParent['matched']['props']>
     : TParent['matched']['props'] extends Record<string, PropsGetter>
       ? { [K in keyof TParent['matched']['props']]: ReturnType<TParent['matched']['props'][K]> }
-      : undefined
+      : unknown
   : undefined

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -22,11 +22,11 @@ export type PropsCallbackParent<
 } : undefined
 
 type GetParentPropsReturnType<
-  TParent extends Route | undefined = undefined
+  TParent extends Route | undefined = Route | undefined
 > = TParent extends Route
   ? TParent['matched']['props'] extends PropsGetter
     ? ReturnType<TParent['matched']['props']>
     : TParent['matched']['props'] extends Record<string, PropsGetter>
       ? { [K in keyof TParent['matched']['props']]: ReturnType<TParent['matched']['props'][K]> }
-      : never
-  : never
+      : undefined
+  : undefined

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -1,10 +1,32 @@
+import { Route } from '@/main'
 import { CallbackContext } from '@/services/createCallbackContext'
+import { PropsGetter } from './createRouteOptions'
 
 /**
  * Context provided to props callback functions
  */
-export type PropsCallbackContext = {
+export type PropsCallbackContext<
+  TParent extends Route | undefined = undefined
+> = {
   push: CallbackContext['push'],
   replace: CallbackContext['replace'],
   reject: CallbackContext['reject'],
+  parent: PropsCallbackParent<TParent>,
 }
+
+export type PropsCallbackParent<
+  TParent extends Route | undefined = undefined
+> = TParent extends Route ? {
+  name: TParent['name'],
+  props: GetParentPropsReturnType<TParent>,
+} : undefined
+
+type GetParentPropsReturnType<
+  TParent extends Route | undefined = undefined
+> = TParent extends Route
+  ? TParent['matched']['props'] extends PropsGetter
+    ? ReturnType<TParent['matched']['props']>
+    : TParent['matched']['props'] extends Record<string, PropsGetter>
+      ? { [K in keyof TParent['matched']['props']]: ReturnType<TParent['matched']['props'][K]> }
+      : never
+  : never

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -15,7 +15,7 @@ export type PropsCallbackContext<
 }
 
 export type PropsCallbackParent<
-  TParent extends Route | undefined = undefined
+  TParent extends Route | undefined = Route | undefined
 > = TParent extends Route ? {
   name: TParent['name'],
   props: GetParentPropsReturnType<TParent>,

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -6,7 +6,7 @@ import { PropsGetter } from './createRouteOptions'
  * Context provided to props callback functions
  */
 export type PropsCallbackContext<
-  TParent extends Route | undefined = undefined
+  TParent extends Route | undefined = Route | undefined
 > = {
   push: CallbackContext['push'],
   replace: CallbackContext['replace'],
@@ -16,10 +16,11 @@ export type PropsCallbackContext<
 
 export type PropsCallbackParent<
   TParent extends Route | undefined = Route | undefined
-> = TParent extends Route ? {
-  name: TParent['name'],
-  props: GetParentPropsReturnType<TParent>,
-} : undefined
+> = Route | undefined extends TParent
+  ? undefined | { name: string, props: unknown }
+  : TParent extends Route
+    ? { name: TParent['name'], props: GetParentPropsReturnType<TParent> }
+    : undefined
 
 type GetParentPropsReturnType<
   TParent extends Route | undefined = Route | undefined
@@ -28,5 +29,5 @@ type GetParentPropsReturnType<
     ? ReturnType<TParent['matched']['props']>
     : TParent['matched']['props'] extends Record<string, PropsGetter>
       ? { [K in keyof TParent['matched']['props']]: ReturnType<TParent['matched']['props'][K]> }
-      : unknown
+      : undefined
   : undefined


### PR DESCRIPTION
# Description
When parent routes have props, it can sometimes be useful to reuse one or more values in the props of the child route. This allows for sharing values across routes without duplicating the logic and also enables data dependent props where the child determines its props based the props value(s) from the parent. 

**sync props**
```ts
  const parent = createRoute({
    name: 'parent',
  }, () => ({ foo: 123 }))

  const child = createRoute({
    name: 'child',
    parent: parent,
    path: '/child',
  }, (__, { parent }) => ({
      propFromParent: parent.props.foo
  }))
```

**async props**
```ts
  const parent = createRoute({
    name: 'parent',
  }, async () => ({ foo: 123 }))

  const child = createRoute({
    name: 'child',
    parent: parent,
    path: '/child',
  }, async (__, { parent }) => {
      const { foo } = await parent.props

      return {
        propFromParent: parent.props.foo
      }
  }))
```
Note: Awaiting parent props creates waterfalls. 