### PR TITLE
add support for literals as param types

### DIFF
--- a/src/services/host.ts
+++ b/src/services/host.ts
@@ -1,7 +1,6 @@
 import { getParamsForString } from '@/services/getParamsForString'
 import { Host, HostParamsWithParamNameExtracted } from '@/types/host'
 import { Param } from '@/types/paramTypes'
-import { Identity } from '@/types/utilities'
 
 /**
  * Constructs a Host object, which enables assigning types for params. Note, the host should not include protocol.
@@ -24,7 +23,10 @@ import { Identity } from '@/types/utilities'
  * })
  * ```
  */
-export function host<THost extends string, TParams extends HostParamsWithParamNameExtracted<THost>>(value: THost, params: Identity<TParams>): Host<THost, TParams>
+export function host<
+  const THost extends string,
+  const TParams extends HostParamsWithParamNameExtracted<THost>
+>(value: THost, params: TParams): Host<THost, TParams>
 export function host(value: string, params: Record<string, Param | undefined>): Host {
   return {
     value,

--- a/src/services/params.spec.ts
+++ b/src/services/params.spec.ts
@@ -36,6 +36,18 @@ describe('getParamValue', () => {
     expect(() => getParamValue('foo', param)).toThrow(InvalidRouteParamValueError)
   })
 
+  test('given  Literal Param, with matching value, returns value', () => {
+    expect(getParamValue('foo', 'foo')).toBe('foo')
+    expect(getParamValue('1', 1)).toBe(1)
+    expect(getParamValue('true', true)).toBe(true)
+  })
+
+  test('given Literal Param, with non-matching value, throws InvalidRouteParamValueError', () => {
+    expect(() => getParamValue('foo', 'bar')).toThrow(InvalidRouteParamValueError)
+    expect(() => getParamValue('1', 2)).toThrow(InvalidRouteParamValueError)
+    expect(() => getParamValue('true', false)).toThrow(InvalidRouteParamValueError)
+  })
+
   test.each([
     [undefined],
     [''],
@@ -122,6 +134,18 @@ describe('setParamValue', () => {
     const param = /yes/
 
     expect(setParamValue('yes', param)).toBe('yes')
+  })
+
+  test('Given Literal Param, with matching value, returns value', () => {
+    expect(setParamValue('foo', 'foo')).toBe('foo')
+    expect(setParamValue(1, 1)).toBe('1')
+    expect(setParamValue(true, true)).toBe('true')
+  })
+
+  test('Given Literal Param, with non-matching value, throws InvalidRouteParamValueError', () => {
+    expect(() => setParamValue('foo', 'bar')).toThrow(InvalidRouteParamValueError)
+    expect(() => setParamValue(1, 2)).toThrow(InvalidRouteParamValueError)
+    expect(() => setParamValue(true, false)).toThrow(InvalidRouteParamValueError)
   })
 
   test('Given Optional Param and value undefined, assigns empty string', () => {

--- a/src/services/path.ts
+++ b/src/services/path.ts
@@ -1,7 +1,6 @@
 import { getParamsForString } from '@/services/getParamsForString'
 import { Param } from '@/types/paramTypes'
 import { Path, PathParamsWithParamNameExtracted } from '@/types/path'
-import { Identity } from '@/types/utilities'
 
 /**
  * Constructs a Path object, which enables assigning types for params.
@@ -24,7 +23,10 @@ import { Identity } from '@/types/utilities'
  * })
  * ```
  */
-export function path<TPath extends string, TParams extends PathParamsWithParamNameExtracted<TPath>>(value: TPath, params: Identity<TParams>): Path<TPath, TParams>
+export function path<
+  const TPath extends string,
+  const TParams extends PathParamsWithParamNameExtracted<TPath>
+>(value: TPath, params: TParams): Path<TPath, TParams>
 export function path(value: string, params: Record<string, Param | undefined>): Path {
   return {
     value,

--- a/src/services/query.ts
+++ b/src/services/query.ts
@@ -1,7 +1,6 @@
 import { getParamsForString } from '@/services/getParamsForString'
 import { Param } from '@/types/paramTypes'
 import { Query, QueryParamsWithParamNameExtracted } from '@/types/query'
-import { Identity } from '@/types/utilities'
 
 /**
  * Constructs a Query object, which enables assigning types for params.
@@ -24,7 +23,10 @@ import { Identity } from '@/types/utilities'
  * })
  * ```
  */
-export function query<TQuery extends string, TParams extends QueryParamsWithParamNameExtracted<TQuery>>(value: TQuery, params: Identity<TParams>): Query<TQuery, TParams>
+export function query<
+  const TQuery extends string,
+  const TParams extends QueryParamsWithParamNameExtracted<TQuery>
+>(value: TQuery, params: TParams): Query<TQuery, TParams>
 export function query(value: string, params: Record<string, Param | undefined>): Query {
   return {
     value,

--- a/src/tests/routeProps.spec.ts
+++ b/src/tests/routeProps.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test, vi } from 'vitest'
-import { createRoute } from './services/createRoute'
-import { createRouter } from './services/createRouter'
+import { createRoute } from '@/services/createRoute'
+import { createRouter } from '@/services/createRouter'
 
 test('props are called each time the route is matched', async () => {
   const props = vi.fn()

--- a/src/types/paramTypes.ts
+++ b/src/types/paramTypes.ts
@@ -11,4 +11,15 @@ export type ParamGetSet<T = any> = {
   defaultValue?: T,
 }
 
-export type Param = ParamGetter | ParamGetSet | RegExp | BooleanConstructor | NumberConstructor | StringConstructor | DateConstructor | JSON
+export type LiteralParam = string | number | boolean
+
+export type Param =
+  | ParamGetter
+  | ParamGetSet
+  | RegExp
+  | BooleanConstructor
+  | NumberConstructor
+  | StringConstructor
+  | DateConstructor
+  | JSON
+  | LiteralParam

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -1,5 +1,5 @@
 import { ParamWithDefault } from '@/services/withDefault'
-import { Param, ParamGetSet, ParamGetter } from '@/types/paramTypes'
+import { LiteralParam, Param, ParamGetSet, ParamGetter } from '@/types/paramTypes'
 import { Identity } from '@/types/utilities'
 import { MakeOptional } from '@/utilities/makeOptional'
 
@@ -37,6 +37,15 @@ export function isParamGetSet(value: Param): value is ParamGetSet {
     && typeof value.get === 'function'
     && 'set' in value
     && typeof value.set === 'function'
+}
+
+/**
+ * Type guard to check if a value conforms to the LiteralParam type.
+ * @param value - The value to check.
+ * @returns True if the value is a string, number, or boolean.
+ */
+export function isLiteralParam(value: Param): value is LiteralParam {
+  return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean'
 }
 
 /**

--- a/src/types/routeWithParams.ts
+++ b/src/types/routeWithParams.ts
@@ -1,5 +1,5 @@
 import { ExtractParamName } from '@/types/params'
-import { Param, ParamGetSet, ParamGetter } from '@/types/paramTypes'
+import { LiteralParam, Param, ParamGetSet, ParamGetter } from '@/types/paramTypes'
 import { Routes } from '@/types/route'
 import { RoutesName, RoutesMap } from '@/types/routesMap'
 import { Identity } from '@/types/utilities'
@@ -24,14 +24,19 @@ type ExtractParamTypesWithoutLosingOptional<TParams extends Record<string, Param
   [K in keyof TParams as ExtractParamName<K>]: ExtractParamTypeWithoutLosingOptional<TParams[K], K>
 }>>
 
-type ExtractParamTypeWithoutLosingOptional<TParam extends Param, TParamKey extends PropertyKey> = TParam extends ParamGetSet<infer Type>
-  ? TParamKey extends `?${string}`
-    ? Type | undefined
-    : Type
-  : TParam extends ParamGetter
+type ExtractParamTypeWithoutLosingOptional<TParam extends Param, TParamKey extends PropertyKey> =
+  TParam extends ParamGetSet<infer Type>
     ? TParamKey extends `?${string}`
-      ? ReturnType<TParam> | undefined
-      : ReturnType<TParam>
-    : TParamKey extends `?${string}`
-      ? string | undefined
-      : string
+      ? Type | undefined
+      : Type
+    : TParam extends ParamGetter
+      ? TParamKey extends `?${string}`
+        ? ReturnType<TParam> | undefined
+        : ReturnType<TParam>
+      : TParam extends LiteralParam
+        ? TParamKey extends `?${string}`
+          ? TParam | undefined
+          : TParam
+        : TParamKey extends `?${string}`
+          ? string | undefined
+          : string


### PR DESCRIPTION
With this PR we're extending the possible param types to include literal values for `string | number | boolean`.

## Example

```ts
const example = createRoute({
  name: 'example',
  path: path('/[foo]' { foo: 14 })
})
```

This means when you supply a value for the `foo` param, it must be exactly the literal number `14`. The same works for literal strings and booleans.

## But Why

By itself, this feature doesn't provide much real world value to users.  If you had a literal value in mind for a param it's not exactly dynamic, which is the whole point of params in your url. However, we're collaborating on some exciting new utilities for `oneOf`, `anyOf`, and `allOf` which will expect an array of `Param`.