### PR TITLE
Unify extract param type types

### DIFF
--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -1,7 +1,7 @@
-import { ParamWithDefault } from '@/services/withDefault'
 import { LiteralParam, Param, ParamGetSet, ParamGetter } from '@/types/paramTypes'
 import { Identity } from '@/types/utilities'
 import { MakeOptional } from '@/utilities/makeOptional'
+import { ExtractParamTypeWithoutLosingOptional } from '@/types/routeWithParams'
 
 export const paramStart = '['
 export type ParamStart = typeof paramStart
@@ -110,23 +110,9 @@ export type ExtractParamTypes<TParams extends Record<string, Param>> = Identity<
  * @returns The extracted type, or 'string' as a fallback.
  */
 export type ExtractParamType<TParam extends Param, TParamKey extends PropertyKey = string> =
-  TParam extends ParamGetSet<infer Type>
-    ? TParamKey extends `?${string}`
-      ? TParam extends ParamWithDefault
-        ? Type
-        : Type | undefined
-      : Type
-    : TParam extends ParamGetter
-      ? TParamKey extends `?${string}`
-        ? ReturnType<TParam> | undefined
-        : ReturnType<TParam>
-      : TParam extends LiteralParam
-        ? TParamKey extends `?${string}`
-          ? TParam | undefined
-          : TParam
-        : TParamKey extends `?${string}`
-          ? string | undefined
-          : string
+TParam extends Required<ParamGetSet>
+  ? Exclude<ExtractParamTypeWithoutLosingOptional<TParam, TParamKey>, undefined>
+  : ExtractParamTypeWithoutLosingOptional<TParam, TParamKey>
 
 type RemoveLeadingQuestionMark<T extends PropertyKey> = T extends `?${infer TRest extends string}` ? TRest : T
 export type RemoveLeadingQuestionMarkFromKeys<T extends Record<string, unknown>> = {

--- a/src/types/resolved.spec-d.ts
+++ b/src/types/resolved.spec-d.ts
@@ -7,7 +7,7 @@ import { ResolvedRoute } from '@/types/resolved'
 import { Route } from '@/types/route'
 
 test('given a specific Route, params are narrow', () => {
-    type TestRoute = Route<'parentA', Host, Path<'/[paramA]', {}>, Query<'foo=[paramB]&bar=[?paramC]', { paramB: BooleanConstructor }>>
+    type TestRoute = Route<'parentA', Host<'', {}>, Path<'/[paramA]', {}>, Query<'foo=[paramB]&bar=[?paramC]', { paramB: BooleanConstructor }>>
 
     type Source = RouterRoute<ResolvedRoute<TestRoute>>['params']
     type Expect = { paramA: string, paramB: boolean, paramC?: string | undefined }

--- a/src/types/routeWithParams.ts
+++ b/src/types/routeWithParams.ts
@@ -24,7 +24,7 @@ type ExtractParamTypesWithoutLosingOptional<TParams extends Record<string, Param
   [K in keyof TParams as ExtractParamName<K>]: ExtractParamTypeWithoutLosingOptional<TParams[K], K>
 }>>
 
-type ExtractParamTypeWithoutLosingOptional<TParam extends Param, TParamKey extends PropertyKey> =
+export type ExtractParamTypeWithoutLosingOptional<TParam extends Param, TParamKey extends PropertyKey> =
   TParam extends ParamGetSet<infer Type>
     ? TParamKey extends `?${string}`
       ? Type | undefined


### PR DESCRIPTION
when we introduced [Literal Types](https://github.com/kitbagjs/router/pull/434) we discovered 2 types that were almost identical. This PR cleans that up so 1 uses the other.

As a side question this PR also improves a test that had a super loose param type.