### PR TITLE
[1st Attempt] Fix route components remounting rather than being updated when props change

### DIFF
--- a/src/components/echo.ts
+++ b/src/components/echo.ts
@@ -1,7 +1,7 @@
 import { defineComponent } from 'vue'
 
-export default defineComponent(({ value }) => {
-  return () => value
+export default defineComponent((props) => {
+  return () => props.value
 }, {
   props: {
     value: {

--- a/src/services/component.browser.spec.ts
+++ b/src/services/component.browser.spec.ts
@@ -1,7 +1,6 @@
 import { flushPromises, mount } from '@vue/test-utils'
 import { expect, test } from 'vitest'
 import echo from '@/components/echo'
-import { component } from '@/services/component'
 import { createRoute } from '@/services/createRoute'
 import { createRouter } from '@/services/createRouter'
 import { h, defineComponent, getCurrentInstance } from 'vue'
@@ -10,8 +9,8 @@ test('renders component with sync props', async () => {
   const route = createRoute({
     name: 'echo',
     path: '/echo',
-    component: component(echo, () => ({ value: 'echo' })),
-  })
+    component: echo,
+  }, () => ({ value: 'echo' }))
 
   const router = createRouter([route], {
     initialUrl: '/',
@@ -38,9 +37,9 @@ test('renders component with async props', async () => {
   const route = createRoute({
     name: 'echo',
     path: '/echo',
-    component: component(echo, async () => {
-      return { value: 'echo' }
-    }),
+    component: echo,
+  }, async () => {
+    return { value: 'echo' }
   })
 
   const router = createRouter([route], {
@@ -109,8 +108,8 @@ test('renders component with async props using suspense', async () => {
   const route = createRoute({
     name: 'home',
     path: '/',
-    component: component(echo, () => promise),
-  })
+    component: echo,
+  }, () => promise)
 
   const router = createRouter([route], {
     initialUrl: '/',

--- a/src/services/component.ts
+++ b/src/services/component.ts
@@ -1,6 +1,6 @@
+/* eslint-disable vue/require-prop-types */
 /* eslint-disable vue/one-component-per-file */
-import { AsyncComponentLoader, Component, FunctionalComponent, defineComponent, getCurrentInstance, h, ref } from 'vue'
-import { MaybePromise } from '@/types/utilities'
+import { AsyncComponentLoader, Component, FunctionalComponent, defineComponent, getCurrentInstance, h, ref, watch } from 'vue'
 import { isPromise } from '@/utilities/promises'
 
 type Constructor = new (...args: any) => any
@@ -13,8 +13,6 @@ export type ComponentProps<TComponent extends Component> = TComponent extends Co
       ? T
       : {}
 
-type ComponentPropsGetter<TComponent extends Component> = () => MaybePromise<ComponentProps<TComponent>>
-
 /**
  * Creates a component wrapper which has no props itself but mounts another component within while binding its props
  *
@@ -22,74 +20,68 @@ type ComponentPropsGetter<TComponent extends Component> = () => MaybePromise<Com
  * @param props A callback that returns the props or attributes to bind to the component
  * @returns A component
  */
-export function component<TComponent extends Component>(component: TComponent, props: ComponentPropsGetter<TComponent>): Component {
-  return defineComponent({
-    name: 'PropsWrapper',
-    expose: [],
-    setup() {
-      const values = props()
-      const instance = getCurrentInstance()
 
-      return () => {
-        if (values instanceof Error) {
-          return ''
-        }
+export const ComponentPropsWrapper = defineComponent((input: { component: Component, props: unknown }) => {
+  const instance = getCurrentInstance()
 
-        if (isPromise(values)) {
-          // @ts-expect-error there isn't a way to check if suspense is used in the component without accessing a private property
-          if (instance?.suspense) {
-            return h(suspenseAsyncPropsWrapper(component, values))
-          }
+  return () => {
+    if (input.props instanceof Error) {
+      return ''
+    }
 
-          return h(asyncPropsWrapper(component, values))
-        }
-
-        return h(component, values)
+    if (isPromise(input.props)) {
+      // @ts-expect-error there isn't a way to check if suspense is used in the component without accessing a private property
+      if (instance?.suspense) {
+        return h(SuspenseAsyncComponentPropsWrapper, { component: input.component, props: input.props })
       }
-    },
-  })
-}
 
-/**
- * Creates a component wrapper that binds async props which does not require suspense
- */
-function asyncPropsWrapper<TComponent extends Component>(component: TComponent, props: Promise<ComponentProps<TComponent>>): Component {
-  return defineComponent({
-    name: 'AsyncPropsWrapper',
-    expose: [],
-    setup() {
-      const values = ref()
+      return h(AsyncComponentPropsWrapper, { component: input.component, props: input.props })
+    }
 
-      ;(async () => {
-        values.value = await props
-      })()
+    return h(input.component, input.props)
+  }
+}, {
+  props: ['component', 'props'],
+})
 
-      return () => {
-        if (values.value instanceof Error) {
-          return ''
-        }
+const AsyncComponentPropsWrapper = defineComponent((input: { component: Component, props: unknown }) => {
+  const values = ref()
 
-        if (values.value) {
-          return h(component, values.value)
-        }
+  watch(() => input.props, async (props) => {
+    values.value = await props
+  }, { immediate: true, deep: true })
 
-        return ''
-      }
-    },
-  })
-}
+  return () => {
+    if (values.value instanceof Error) {
+      return ''
+    }
 
-/**
- * Creates a component wrapper that binds async props which requires suspense
- */
-function suspenseAsyncPropsWrapper<TComponent extends Component>(component: TComponent, props: Promise<ComponentProps<TComponent>>): Component {
-  return defineComponent({
-    name: 'SuspenseAsyncPropsWrapper',
-    expose: [],
-    async setup() {
-      const values = await props
+    if (values.value) {
+      return h(input.component, values.value)
+    }
 
-      return () => h(component, values)
-    },
-  })
-}
+    return ''
+  }
+}, {
+  props: ['component', 'props'],
+})
+
+const SuspenseAsyncComponentPropsWrapper = defineComponent(async (input: { component: Component, props: unknown }) => {
+  const values = ref()
+
+  values.value = await input.props
+
+  watch(() => values.value, async (props) => {
+    values.value = await props
+  }, { deep: true })
+
+  return () => {
+    if (values.value) {
+      return h(input.component, values.value)
+    }
+
+    return ''
+  }
+}, {
+  props: ['component', 'props'],
+})

--- a/src/tests/routeProps.browser.spec.ts
+++ b/src/tests/routeProps.browser.spec.ts
@@ -1,0 +1,53 @@
+import { vi, test, expect } from 'vitest'
+import { createRoute } from '@/services/createRoute'
+import { createRouter } from '@/services/createRouter'
+import { defineComponent, h } from 'vue'
+import { mount } from '@vue/test-utils'
+
+test('components are not remounted when props change', async () => {
+  const props = vi.fn().mockImplementation(() => ({ prop: 'foo' }))
+  const setup = vi.fn()
+
+  const route = createRoute({
+    name: 'test',
+    path: '/[param]',
+    component: defineComponent({
+      setup() {
+        setup()
+
+        return { props }
+      },
+      render() {
+        return h('div', {}, 'test')
+      },
+    }),
+  }, props)
+
+  const router = createRouter([route], {
+    initialUrl: '/bar',
+  })
+
+  const root = {
+    template: '<RouterView />',
+  }
+
+  mount(root, {
+    global: {
+      plugins: [router],
+    },
+  })
+
+  await router.start()
+
+  await router.route.update({ param: 'foo' })
+
+  expect(setup).toHaveBeenCalledTimes(1)
+
+  await router.route.update({ param: 'bar' })
+
+  expect(setup).toHaveBeenCalledTimes(1)
+
+  await router.route.update({ param: 'foo' })
+
+  expect(setup).toHaveBeenCalledTimes(1)
+})

--- a/src/tests/routeProps.browser.spec.ts
+++ b/src/tests/routeProps.browser.spec.ts
@@ -5,23 +5,18 @@ import { defineComponent, h } from 'vue'
 import { mount } from '@vue/test-utils'
 
 test('components are not remounted when props change', async () => {
-  const props = vi.fn().mockImplementation(() => ({ prop: 'foo' }))
   const setup = vi.fn()
 
   const route = createRoute({
     name: 'test',
     path: '/[param]',
     component: defineComponent({
-      setup() {
-        setup()
-
-        return { props }
-      },
+      setup,
       render() {
         return h('div', {}, 'test')
       },
     }),
-  }, props)
+  }, () => ({ prop: 'foo' }))
 
   const router = createRouter([route], {
     initialUrl: '/bar',
@@ -47,7 +42,7 @@ test('components are not remounted when props change', async () => {
 
   expect(setup).toHaveBeenCalledTimes(1)
 
-  await router.route.update({ param: 'foo' })
+  await router.route.update({ param: 'baz' })
 
   expect(setup).toHaveBeenCalledTimes(1)
 })


### PR DESCRIPTION
# Description
When a route's props are updated the components should not be unmounted and recreated. This fixes an issue with how route components and props were combined that was causing new components to get mounted whenever the props changed. 

**Note**
In its current state this PR changes how the default slot of RouterView works. Which I'm hoping can be fixed so that users get the same functionality as before when using the default slot.