### PR TITLE
Run hooks and props within the context of the vue app

### DIFF
--- a/docs/advanced-concepts/hooks.md
+++ b/docs/advanced-concepts/hooks.md
@@ -95,7 +95,7 @@ Hooks are run within the context of the Vue app the router is installed. This me
 ```ts
 import { inject } from 'vue'
 
-router.onAfterRouteEnter((to, context) => {
+router.onAfterRouteEnter(() => {
   const value = inject('global')
 
   ...

--- a/docs/advanced-concepts/hooks.md
+++ b/docs/advanced-concepts/hooks.md
@@ -87,3 +87,17 @@ onAfterRouteEnter((to, context) => {
 :::warning
 You cannot register `onBeforeRouteEnter` or `onAfterRouteEnter` hooks from within a component, since the component must have been mounted to discover the hook.
 :::
+
+## Global Injection
+
+Hooks are run within the context of the Vue app the router is installed. This means you can use vue's `inject` function to access global values.
+
+```ts
+import { inject } from 'vue'
+
+router.onAfterRouteEnter((to, context) => {
+  const value = inject('global')
+
+  ...
+})
+```

--- a/docs/core-concepts/component-props.md
+++ b/docs/core-concepts/component-props.md
@@ -106,3 +106,19 @@ const user = createRoute({
   }
 }))
 ```
+
+## Global Injection
+
+Props are run within the context of the Vue app the router is installed. This means you can use vue's `inject` function to access global values.
+
+```ts
+import { inject } from 'vue'
+
+const route = createRoute({
+  ...
+}, async (route) => {
+  const value = inject('global')
+
+  return { value }
+})
+```

--- a/docs/core-concepts/component-props.md
+++ b/docs/core-concepts/component-props.md
@@ -116,7 +116,7 @@ import { inject } from 'vue'
 
 const route = createRoute({
   ...
-}, async (route) => {
+}, async () => {
   const value = inject('global')
 
   return { value }

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -1,4 +1,4 @@
-import { InjectionKey, reactive } from 'vue'
+import { App, InjectionKey, reactive } from 'vue'
 import { isWithComponentProps, isWithComponentPropsRecord, PropsGetter } from '@/types/createRouteOptions'
 import { getPrefetchOption, PrefetchConfigs, PrefetchStrategy } from '@/types/prefetch'
 import { ResolvedRoute } from '@/types/resolved'
@@ -20,9 +20,12 @@ export type PropStore = {
   setPrefetchProps: (props: Record<string, unknown>) => void,
   setProps: (route: ResolvedRoute) => Promise<SetPropsResponse>,
   getProps: (id: string, name: string, route: ResolvedRoute) => unknown,
+  setVueApp: (app: App) => void,
 }
 
 export function createPropStore(): PropStore {
+  let vueApp: App | null = null
+
   const store: Map<string, unknown> = reactive(new Map())
   const { push, replace, reject } = createCallbackContext()
 
@@ -41,7 +44,7 @@ export function createPropStore(): PropStore {
           replace,
           reject,
           parent: getParentContext(route, true),
-        }))
+        }), vueApp)
 
         response[key] = value
 
@@ -75,7 +78,7 @@ export function createPropStore(): PropStore {
           replace,
           reject,
           parent: getParentContext(route),
-        }))
+        }), vueApp)
 
         store.set(key, value)
       }
@@ -112,6 +115,10 @@ export function createPropStore(): PropStore {
     const key = getPropKey(id, name, route)
 
     return store.get(key)
+  }
+
+  const setVueApp: PropStore['setVueApp'] = (app) => {
+    vueApp = app
   }
 
   function getParentContext(route: ResolvedRoute, prefetch: boolean = false): PropsCallbackParent {
@@ -204,5 +211,6 @@ export function createPropStore(): PropStore {
     setPrefetchProps,
     getProps,
     setProps,
+    setVueApp,
   }
 }

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -78,6 +78,8 @@ export function createRouter<
   const TOptions extends RouterOptions,
   const TPlugin extends RouterPlugin = EmptyRouterPlugin
 >(routesOrArrayOfRoutes: TRoutes | TRoutes[], options?: TOptions, plugins: TPlugin[] = []): Router<TRoutes, TOptions, TPlugin> {
+  let vueApp: App | null = null
+
   const routes = getRoutesForRouter(routesOrArrayOfRoutes, plugins, options?.base)
   const hooks = createRouterHooks()
 
@@ -113,7 +115,7 @@ export function createRouter<
     const to = find(url, options) ?? getRejectionRoute('NotFound')
     const from = getFromRouteForHooks(navigationId)
 
-    const beforeResponse = await hooks.runBeforeRouteHooks({ to, from })
+    const beforeResponse = await hooks.runBeforeRouteHooks({ to, from, app: vueApp })
 
     switch (beforeResponse.status) {
       // On abort do nothing
@@ -169,7 +171,7 @@ export function createRouter<
 
     updateRoute(to)
 
-    const afterResponse = await hooks.runAfterRouteHooks({ to, from })
+    const afterResponse = await hooks.runAfterRouteHooks({ to, from, app: vueApp })
 
     switch (afterResponse.status) {
       case 'PUSH':
@@ -309,6 +311,8 @@ export function createRouter<
   }
 
   function install(app: App): void {
+    vueApp = app
+
     app.component('RouterView', RouterView)
     app.component('RouterLink', RouterLink)
     app.provide(routerRejectionKey, rejection)

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -313,6 +313,8 @@ export function createRouter<
   function install(app: App): void {
     vueApp = app
 
+    propStore.setVueApp(app)
+
     app.component('RouterView', RouterView)
     app.component('RouterLink', RouterLink)
     app.provide(routerRejectionKey, rejection)

--- a/src/services/createRouterHooks.ts
+++ b/src/services/createRouterHooks.ts
@@ -8,6 +8,7 @@ import { CallbackContextPushError } from '@/errors/callbackContextPushError'
 import { CallbackContextRejectionError } from '@/errors/callbackContextRejectionError'
 import { CallbackContextAbortError } from '@/errors/callbackContextAbortError'
 import { getGlobalAfterRouteHooks, getGlobalBeforeRouteHooks } from './getGlobalRouteHooks'
+import { runWithContext } from '@/utilities/runWithContext'
 
 export const routerHooksKey: InjectionKey<RouterHooks> = Symbol()
 
@@ -208,14 +209,6 @@ export function createRouterHooks(): RouterHooks {
     hooks.onAfterRouteEnter.forEach((hook) => onAfterRouteEnter(hook))
     hooks.onAfterRouteUpdate.forEach((hook) => onAfterRouteUpdate(hook))
     hooks.onAfterRouteLeave.forEach((hook) => onAfterRouteLeave(hook))
-  }
-
-  function runWithContext(callback: (...args: any[]) => any, app: App | null) {
-    if (!app) {
-      return callback()
-    }
-
-    return app.runWithContext(callback)
   }
 
   return {

--- a/src/services/createRouterHooks.ts
+++ b/src/services/createRouterHooks.ts
@@ -1,4 +1,4 @@
-import { App, InjectionKey } from 'vue'
+import { InjectionKey } from 'vue'
 import { AddAfterRouteHook, AddBeforeRouteHook, AddGlobalRouteHooks, AfterHookContext, AfterRouteHook, AfterRouteHookResponse, BeforeHookContext, BeforeRouteHook, BeforeRouteHookResponse, AddComponentAfterRouteHook, AddComponentBeforeRouteHook, RouteHookAfterRunner, RouteHookBeforeRunner } from '@/types/hooks'
 import { createCallbackContext } from './createCallbackContext'
 import { RouteHooks } from '@/models/RouteHooks'

--- a/src/services/hooks.spec.ts
+++ b/src/services/hooks.spec.ts
@@ -53,6 +53,7 @@ test('calls hook with correct routes', () => {
   runBeforeRouteHooks({
     to: toRoute,
     from: fromRoute,
+    app: null,
   })
 
   expect(hook).toHaveBeenCalledOnce()
@@ -125,6 +126,7 @@ test.each<{ type: string, status: string, hook: BeforeRouteHook }>([
   const response = await runBeforeRouteHooks({
     to,
     from,
+    app: null,
   })
 
   expect(response.status).toBe(status)
@@ -180,6 +182,7 @@ test('hook is called in order', async () => {
   await runBeforeRouteHooks({
     to,
     from,
+    app: null,
   })
 
   const [orderA] = hookA.mock.invocationCallOrder

--- a/src/tests/hooks.spec.ts
+++ b/src/tests/hooks.spec.ts
@@ -1,0 +1,55 @@
+import echo from "@/components/echo";
+import { createRoute } from "@/services/createRoute";
+import { createRouter } from "@/services/createRouter";
+import { component } from "@/utilities";
+import { expect, test, vi } from "vitest";
+import { createApp, inject } from "vue";
+
+test('hooks are run with the correct context', async () => {
+  const beforeRouteHook = vi.fn()
+  const afterRouteHook = vi.fn()
+  const beforeGlobalHook = vi.fn()
+  const afterGlobalHook = vi.fn()
+
+  const route = createRoute({
+    path: '/',
+    name: 'route',
+    component: echo,
+    onBeforeRouteEnter: () => {
+      const value = inject('global')
+
+      beforeRouteHook(value)
+    },
+    onAfterRouteEnter: () => {
+      const value = inject('global')
+
+      afterRouteHook(value)
+    }
+  }, () => ({ value: 'hello' }))
+
+  const router = createRouter([route], {
+    initialUrl: '/',
+    onBeforeRouteEnter: () => {
+      const value = inject('global')
+
+      beforeGlobalHook(value)
+    },
+    onAfterRouteEnter: () => {
+      const value = inject('global')
+
+      afterGlobalHook(value)
+    }
+  })
+
+  const app = createApp(component)
+
+  app.provide('global', 'hello world')
+  app.use(router)
+
+  await router.start()
+
+  expect(beforeRouteHook).toHaveBeenCalledWith('hello world')
+  expect(afterRouteHook).toHaveBeenCalledWith('hello world')
+  expect(beforeGlobalHook).toHaveBeenCalledWith('hello world')
+  expect(afterGlobalHook).toHaveBeenCalledWith('hello world')
+})

--- a/src/tests/routeProps.spec.ts
+++ b/src/tests/routeProps.spec.ts
@@ -1,6 +1,8 @@
 import { expect, test, vi } from 'vitest'
 import { createRoute } from '@/services/createRoute'
 import { createRouter } from '@/services/createRouter'
+import { createApp, inject } from 'vue'
+import { component } from '@/utilities/testHelpers'
 
 test('props are called each time the route is matched', async () => {
   const props = vi.fn()
@@ -27,4 +29,32 @@ test('props are called each time the route is matched', async () => {
   await router.push('test', { param: 'foo' })
 
   expect(props).toHaveBeenCalledTimes(3)
+})
+
+test('props are called with the correct context', async () => {
+  const props = vi.fn()
+
+  const route = createRoute({
+    name: 'route',
+    path: '/',
+  }, () => {
+    const value = inject('global')
+
+    props(value)
+
+    return {}
+  })
+
+  const router = createRouter([route], {
+    initialUrl: '/',
+  })
+
+  const app = createApp(component)
+
+  app.provide('global', 'hello world')
+  app.use(router)
+
+  await router.start()
+
+  expect(props).toHaveBeenCalledWith('hello world')
 })

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -2,6 +2,7 @@ import { RouteHooks } from '@/models/RouteHooks'
 import { CallbackAbortResponse, CallbackContext, CallbackContextAbort, CallbackPushResponse, CallbackRejectResponse, CallbackSuccessResponse } from '@/services/createCallbackContext'
 import { ResolvedRoute } from '@/types/resolved'
 import { MaybeArray, MaybePromise } from '@/types/utilities'
+import { App } from 'vue'
 
 /**
  * Defines route hooks that can be applied before entering, updating, or leaving a route, as well as after these events.
@@ -18,6 +19,7 @@ export type WithHooks = {
 export type BeforeHookContext = {
   to: ResolvedRoute,
   from: ResolvedRoute | null,
+  app: App | null,
 }
 
 export type RouteHookBeforeRunner = (context: BeforeHookContext) => Promise<BeforeRouteHookResponse>
@@ -25,6 +27,7 @@ export type RouteHookBeforeRunner = (context: BeforeHookContext) => Promise<Befo
 export type AfterHookContext = {
   to: ResolvedRoute,
   from: ResolvedRoute | null,
+  app: App | null,
 }
 
 export type RouteHookAfterRunner = (context: AfterHookContext) => Promise<AfterRouteHookResponse>

--- a/src/utilities/props.ts
+++ b/src/utilities/props.ts
@@ -1,13 +1,15 @@
+import { App } from 'vue'
 import { isPromise } from './promises'
+import { runWithContext } from './runWithContext'
 
 /**
  * Takes a props callback and returns a value
  * For sync props, this will return the props value or an error.
  * For async props, this will return a promise that resolves to the props value or an error.
  */
-export function getPropsValue(callback: () => unknown): unknown {
+export function getPropsValue(callback: () => unknown, app: App | null): unknown {
   try {
-    const value = callback()
+    const value = runWithContext(callback, app)
 
     if (isPromise(value)) {
       return value.catch((error: unknown) => error)

--- a/src/utilities/runWithContext.ts
+++ b/src/utilities/runWithContext.ts
@@ -1,0 +1,9 @@
+import { App } from "vue"
+
+export function runWithContext<T>(callback: () => T, app: App | null): T {
+  if (!app) {
+    return callback()
+  }
+
+  return app.runWithContext(callback)
+}


### PR DESCRIPTION
# Description
Since 3.3 vue has had a utility called [runWithContext](https://vuejs.org/api/application.html#app-runwithcontext) which allows for global injection to work within any callback. Using this when running hooks and props means that global injection also works within those callback. 

```ts
import { inject } from 'vue'

router.onAfterRouteEnter((to, context) => {
  const value = inject('global')

  ...
})
```

```ts
import { inject } from 'vue'

const route = createRoute({
  ...
}, async (route) => {
  const value = inject('global')

  return { value }
})
```