### PR TITLE
Make sure zod isn't required if zod params are not being used

### DIFF
--- a/src/services/ zod.spec.ts
+++ b/src/services/ zod.spec.ts
@@ -1,6 +1,7 @@
 import { safeGetParamValue, safeSetParamValue } from './params'
 import { z } from 'zod'
 import { test, expect } from 'vitest'
+import { initZod } from './zod'
 
 enum Fruits {
   Apple = 0,
@@ -40,7 +41,9 @@ test.each([
   { schema: z.record(z.string(), z.object({ foo: z.string() })), string: '{"one":{"foo":"bar"}}', parsed: { one: { foo: 'bar' } } },
   { schema: z.map(z.string(), z.number()), string: '[["one",1]]', parsed: new Map([['one', 1]]) },
   { schema: z.set(z.number()), string: '[1,2,3]', parsed: new Set([1, 2, 3]) },
-])('given $schema, returns $parsed for $string', ({ schema, string, parsed }) => {
+])('given $schema, returns $parsed for $string', async ({ schema, string, parsed }) => {
+  await initZod()
+
   if (typeof parsed === 'string' || typeof parsed === 'number' || typeof parsed === 'boolean') {
     expect(safeGetParamValue(string, schema)).toBe(parsed)
     expect(safeSetParamValue(parsed, schema)).toBe(string)

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -32,6 +32,7 @@ import { EmptyRouterPlugin, RouterPlugin } from '@/types/routerPlugin'
 import { getRoutesForRouter } from './getRoutesForRouter'
 import { getGlobalHooksForRouter } from './getGlobalHooksForRouter'
 import { componentsStoreKey, createComponentsStore } from './createComponentsStore'
+import { initZod, zotParamsDetected } from './zod'
 
 type RouterUpdateOptions = {
   replace?: boolean,
@@ -289,6 +290,12 @@ export function createRouter<
   async function start(): Promise<void> {
     if (initializing) {
       return initialize
+    }
+
+    const shouldInitZod = zotParamsDetected(routes)
+
+    if (shouldInitZod) {
+      await initZod()
     }
 
     initializing = true

--- a/src/services/params.ts
+++ b/src/services/params.ts
@@ -4,8 +4,7 @@ import { isParamWithDefault } from '@/services/withDefault'
 import { ExtractParamType, isLiteralParam, isParamGetSet, isParamGetter } from '@/types/params'
 import { LiteralParam, Param, ParamExtras, ParamGetSet } from '@/types/paramTypes'
 import { stringHasValue } from '@/utilities/guards'
-import { ZodSchema } from 'zod'
-import { createZodParam } from './zod'
+import { createZodParam, isZodParam } from './zod'
 
 export function getParam(params: Record<string, Param | undefined>, paramName: string): Param {
   return params[paramName] ?? String
@@ -184,7 +183,7 @@ export function getParamValue<T extends Param>(value: string | undefined, param:
     throw new InvalidRouteParamValueError()
   }
 
-  if (param instanceof ZodSchema) {
+  if (isZodParam(param)) {
     return createZodParam(param).get(value, extras)
   }
 
@@ -250,7 +249,7 @@ export function setParamValue(value: unknown, param: Param, isOptional = false):
     return (value as LiteralParam).toString()
   }
 
-  if (param instanceof ZodSchema) {
+  if (isZodParam(param)) {
     return createZodParam(param).set(value, extras)
   }
 

--- a/src/types/paramTypes.ts
+++ b/src/types/paramTypes.ts
@@ -1,4 +1,4 @@
-import { ZodSchema } from 'zod'
+import type { ZodSchema } from 'zod'
 
 export type ParamExtras = {
   invalid: (message?: string) => never,

--- a/src/types/routeWithParams.ts
+++ b/src/types/routeWithParams.ts
@@ -4,7 +4,7 @@ import { Routes } from '@/types/route'
 import { RoutesName, RoutesMap } from '@/types/routesMap'
 import { Identity } from '@/types/utilities'
 import { MakeOptional } from '@/utilities/makeOptional'
-import { ZodSchema } from 'zod'
+import type { ZodSchema } from 'zod'
 
 export type RouteGetByKey<TRoutes extends Routes, TKey extends RoutesName<TRoutes>> = RoutesMap<TRoutes>[TKey]
 


### PR DESCRIPTION
# Description
https://github.com/kitbagjs/router/pull/446 introduced experimental support for zod params. However it didn't account for zod not being installed even though its clearly marked as an optional param. 

In order to account for this we can use an asyn import and only import actual zod code if we detect that a zod param is being used