### PR TITLE
narrow the types of Param that can be sent to createParam

### DIFF
--- a/src/services/createParam.ts
+++ b/src/services/createParam.ts
@@ -5,7 +5,7 @@ import { Param, ParamGetSet } from '@/types/paramTypes'
 
 export function createParam<TParam extends ParamWithDefault>(param: TParam): TParam
 export function createParam<TParam extends Param>(param: TParam): ParamGetSet<ExtractParamType<TParam>>
-export function createParam<TParam extends Param>(param: TParam, defaultValue: ExtractParamType<TParam>): ParamWithDefault<TParam>
+export function createParam<TParam extends Param>(param: TParam, defaultValue: NoInfer<ExtractParamType<TParam>>): ParamWithDefault<TParam>
 export function createParam<TParam extends Param>(param: TParam, defaultValue?: ExtractParamType<TParam>): ParamGetSet<ExtractParamType<TParam>> {
   if (isParamGetSet(param)) {
     return { ...param, defaultValue: defaultValue ?? param.defaultValue }


### PR DESCRIPTION
in the router-preview project we have the following custom param

```ts
import { createParam } from "@kitbag/router"

type SortDirection = 'asc' | 'desc'

function isSortDirection(value: unknown): value is SortDirection {
  return !!value && typeof value === 'string' && ['asc', 'desc'].includes(value)
}

export const sortParam = createParam((value, {invalid}) => {
    if(isSortDirection(value)){
      return value
    }
    
    throw invalid(`value provided does not satisfy `)
  }, 'asc')
```

with any version of Kitbag router after we added [LiteralParams](https://github.com/kitbagjs/router/pull/434), we get the following error

<img width="995" alt="image" src="https://github.com/user-attachments/assets/88001d8e-d619-48ac-be9c-9fad1339db5e" />

Simply adding `NoInfer` around the default value seemed to do the trick 🎉 