### PR TITLE
simplify extract param type, move check for optional

### DIFF
--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -1,4 +1,4 @@
-import { ExtractRouteParamTypes } from '@/types/params'
+import { ExtractRouteParamTypesWithOptional } from '@/types/params'
 import { Route } from '@/types/route'
 import { ExtractRouteStateParamsAsOptional } from '@/types/state'
 import { Url } from '@/types/url'
@@ -36,7 +36,7 @@ export type ResolvedRoute<TRoute extends Route = Route> = Readonly<{
   /**
    * Key value pair for route params, values will be the user provided value from current browser location.
   */
-  params: ExtractRouteParamTypes<TRoute>,
+  params: ExtractRouteParamTypesWithOptional<TRoute>,
   /**
    * Type for additional data intended to be stored in history state.
    */

--- a/src/types/route.spec-d.ts
+++ b/src/types/route.spec-d.ts
@@ -1,5 +1,5 @@
 import { describe, expectTypeOf, test } from 'vitest'
-import { ExtractRouteParamTypes } from '@/types/params'
+import { ExtractRouteParamTypesWithOptional } from '@/types/params'
 import { Route } from '@/types/route'
 import { WithParams } from '@/services/withParams'
 
@@ -7,7 +7,7 @@ describe('ExtractRouteParamTypes', () => {
   test('given routes with different params, some optional, combines into expected args for developer', () => {
     type TestRoute = Route<'parentA', WithParams<'https://[inHost].dev', {}>, WithParams<'/[inPath]', {}>, WithParams<'foo=[inQuery]&bar=[?paramC]', { inQuery: BooleanConstructor }>, WithParams<'[inHash]', {}>>
 
-    type Source = ExtractRouteParamTypes<TestRoute>
+    type Source = ExtractRouteParamTypesWithOptional<TestRoute>
     type Expect = { inHost: string, inPath: string, paramC?: string, inQuery: boolean, inHash: string }
 
     expectTypeOf<Source>().toEqualTypeOf<Expect>()

--- a/src/types/routeWithParams.ts
+++ b/src/types/routeWithParams.ts
@@ -1,48 +1,10 @@
-import { ExtractParamName } from '@/types/params'
-import { LiteralParam, Param, ParamGetSet, ParamGetter } from '@/types/paramTypes'
+import { ExtractRouteParamTypesWithOptional } from '@/types/params'
 import { Routes } from '@/types/route'
 import { RoutesName, RoutesMap } from '@/types/routesMap'
-import { Identity } from '@/types/utilities'
-import { MakeOptional } from '@/utilities/makeOptional'
-import type { ZodSchema } from 'zod'
 
 export type RouteGetByKey<TRoutes extends Routes, TKey extends RoutesName<TRoutes>> = RoutesMap<TRoutes>[TKey]
 
 export type RouteParamsByKey<
   TRoutes extends Routes,
   TKey extends string
-> = ExtractRouteParamTypesWithoutLosingOptional<RouteGetByKey<TRoutes, TKey>>
-
-type ExtractRouteParamTypesWithoutLosingOptional<TRoute> = TRoute extends {
-  host: { params: infer HostParams extends Record<string, Param> },
-  path: { params: infer PathParams extends Record<string, Param> },
-  query: { params: infer QueryParams extends Record<string, Param> },
-  hash: { params: infer HashParams extends Record<string, Param> },
-}
-  ? ExtractParamTypesWithoutLosingOptional<HostParams & PathParams & QueryParams & HashParams>
-  : Record<string, unknown>
-
-type ExtractParamTypesWithoutLosingOptional<TParams extends Record<string, Param>> = Identity<MakeOptional<{
-  [K in keyof TParams as ExtractParamName<K>]: ExtractParamTypeWithoutLosingOptional<TParams[K], K>
-}>>
-
-export type ExtractParamTypeWithoutLosingOptional<TParam extends Param, TParamKey extends PropertyKey> =
-  TParam extends ParamGetSet<infer Type>
-    ? TParamKey extends `?${string}`
-      ? Type | undefined
-      : Type
-    : TParam extends ParamGetter
-      ? TParamKey extends `?${string}`
-        ? ReturnType<TParam> | undefined
-        : ReturnType<TParam>
-      : TParam extends ZodSchema<infer Type>
-        ? TParamKey extends `?${string}`
-          ? Type | undefined
-          : Type
-        : TParam extends LiteralParam
-          ? TParamKey extends `?${string}`
-            ? TParam | undefined
-            : TParam
-          : TParamKey extends `?${string}`
-            ? string | undefined
-            : string
+> = ExtractRouteParamTypesWithOptional<RouteGetByKey<TRoutes, TKey>>

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -1,11 +1,11 @@
-import { ExtractParamTypes } from '@/types/params'
+import { ExtractParamTypes, ExtractParamTypesWithOptional } from '@/types/params'
 import { Param } from '@/types/paramTypes'
 import { Routes } from '@/types/route'
 import { RouteGetByKey } from '@/types/routeWithParams'
 
 export type ToState<TState extends Record<string, Param> | undefined> = TState extends undefined ? Record<string, Param> : unknown extends TState ? {} : TState
 
-export type ExtractRouteStateParamsAsOptional<T extends Record<string, Param>> = ExtractParamTypes<{
+export type ExtractRouteStateParamsAsOptional<T extends Record<string, Param>> = ExtractParamTypesWithOptional<{
   [K in keyof T as K extends string ? `?${K}` : never]: T[K]
 }>
 


### PR DESCRIPTION
Currently there are some "extract param types" types were responsible for both finding out what type a param should be and also based on the key determining if the type should include `| undefined`. This PR moves that 2nd responsibility out into a separate type and also just aims to clean up the two similar but different extract types.

This needs to manual testing. I did a little testing and obviously the minimal type tests we have are passing but it would be easy to miss something that should have `| undefined` and doesn't or vice-versa.