### PR TITLE
Fix insertBaseRoute stringifying `path` and not `path.value`

### DIFF
--- a/src/services/insertBaseRoute.ts
+++ b/src/services/insertBaseRoute.ts
@@ -8,7 +8,7 @@ export function insertBaseRoute(routes: Routes, base?: string): Routes {
   }
 
   return routes.map((route) => {
-    const value = `${base}${route.path}`
+    const value = `${base}${route.path.value}`
 
     return {
       ...route,


### PR DESCRIPTION
# Description
Fixes an issue with base paths where the path was not properly stringified