### PR TITLE
return unique method for finding param values in the query

### DIFF
--- a/src/services/paramValidation.ts
+++ b/src/services/paramValidation.ts
@@ -4,6 +4,7 @@ import { getParamValueFromUrl } from '@/services/paramsFinder'
 import { Route } from '@/types/route'
 import { RouteMatchRule } from '@/types/routeMatchRule'
 import { WithParams } from '@/services/withParams'
+import { getParamName, isOptionalParamSyntax } from '@/services/routeRegex'
 
 export const routeParamsAreValid: RouteMatchRule = (route, url) => {
   try {
@@ -21,7 +22,7 @@ export const getRouteParamValues = (route: Route, url: string): Record<string, u
   return {
     ...getParams(route.host, `${protocol}//${host}`),
     ...getParams(route.path, pathname),
-    ...getParams(route.query, search),
+    ...getQueryParams(route.query, search),
     ...getParams(route.hash, hash),
   }
 }
@@ -39,5 +40,31 @@ function getParams(path: WithParams, url: string): Record<string, unknown> {
     values[paramName] = paramValue
   }
 
+  return values
+}
+
+/**
+ * This function has unique responsibilities not accounted for by getParams thanks to URLSearchParams
+ *
+ * 1. Find query values when other query params are omitted or in a different order
+ * 2. Find query values based on the url search key, which might not match the param name
+ */
+function getQueryParams(query: WithParams, url: string): Record<string, unknown> {
+  const values: Record<string, unknown> = {}
+  const routeSearch = new URLSearchParams(query.value)
+  const actualSearch = new URLSearchParams(url)
+
+  for (const [key, value] of Array.from(routeSearch.entries())) {
+    const paramName = getParamName(value)
+    const isNotParam = !paramName
+    if (isNotParam) {
+      continue
+    }
+    const isOptional = isOptionalParamSyntax(value)
+    const paramKey = isOptional ? `?${paramName}` : paramName
+    const valueOnUrl = actualSearch.get(key) ?? undefined
+    const paramValue = getParamValue(valueOnUrl, query.params[paramKey], isOptional)
+    values[paramName] = paramValue
+  }
   return values
 }


### PR DESCRIPTION
in a [previous PR](https://github.com/kitbagjs/router/commit/caecf3e76a43287fc4d26558a1a5fc7ec3a6781a#diff-56f61b45256cb6dd3fc0a966c28a11f79b10821217a99a2cb8931d9224a9844d) we over-simplified the process of getting param values out of different parts of the URL. There are unique responsibilities of the function that gets values from the query.

1. Find query values when other query params are omitted or in a different order
2. Find query values based on the url search key, which might not match the param name