### PR TITLE
Fix combine bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "homepage": "https://github.com/kitbagjs/router#readme",
   "scripts": {
     "build": "vite build",
-    "build:watch": "vite build --watch",
+    "build:watch": "vite build --watch --minify=false",
     "test": "vitest --typecheck",
     "lint": "eslint ./src",
     "lint:fix": "eslint ./src --fix",

--- a/src/services/combineHash.spec.ts
+++ b/src/services/combineHash.spec.ts
@@ -13,13 +13,23 @@ test('given 2 hash, returns new Hash joined together', () => {
 })
 
 test('given 2 hash with params, returns new Hash joined together with params', () => {
-  const aHash = withParams('/[foz]', { foz: String })
+  const aHash = withParams('/[foz]', { foz: Boolean })
+  const bHash = withParams('/[baz]', { baz: Number })
+
+  const response = combineHash(aHash, bHash)
+
+  expect(response.value).toBe('/[foz]/[baz]')
+  expect(Object.entries(response.params)).toMatchObject([['foz', Boolean], ['baz', Number]])
+})
+
+test('given 2 hash with optional params, returns new Hash joined together with params', () => {
+  const aHash = withParams('/[?foz]', { foz: Boolean })
   const bHash = withParams('/[?baz]', { baz: Number })
 
   const response = combineHash(aHash, bHash)
 
-  expect(response.value).toBe('/[foz]/[?baz]')
-  expect(Object.keys(response.params)).toMatchObject(['foz', '?baz'])
+  expect(response.value).toBe('/[?foz]/[?baz]')
+  expect(Object.entries(response.params)).toMatchObject([['?foz', Boolean], ['?baz', Number]])
 })
 
 test('given 2 hash with params that include duplicates, throws DuplicateParamsError', () => {

--- a/src/services/combinePath.spec.ts
+++ b/src/services/combinePath.spec.ts
@@ -13,13 +13,23 @@ test('given 2 paths, returns new Path joined together', () => {
 })
 
 test('given 2 paths with params, returns new Path joined together with params', () => {
-  const aPath = withParams('/[foz]', { foz: String })
+  const aPath = withParams('/[foz]', { foz: Boolean })
+  const bPath = withParams('/[baz]', { baz: Number })
+
+  const response = combinePath(aPath, bPath)
+
+  expect(response.value).toBe('/[foz]/[baz]')
+  expect(Object.entries(response.params)).toMatchObject([['foz', Boolean], ['baz', Number]])
+})
+
+test('given 2 paths with optional params, returns new Path joined together with params', () => {
+  const aPath = withParams('/[?foz]', { foz: Boolean })
   const bPath = withParams('/[?baz]', { baz: Number })
 
   const response = combinePath(aPath, bPath)
 
-  expect(response.value).toBe('/[foz]/[?baz]')
-  expect(Object.keys(response.params)).toMatchObject(['foz', '?baz'])
+  expect(response.value).toBe('/[?foz]/[?baz]')
+  expect(Object.entries(response.params)).toMatchObject([['?foz', Boolean], ['?baz', Number]])
 })
 
 test('given 2 paths with params that include duplicates, throws DuplicateParamsError', () => {

--- a/src/services/combineQuery.spec.ts
+++ b/src/services/combineQuery.spec.ts
@@ -13,13 +13,23 @@ test('given 2 queries, returns new Query joined together', () => {
 })
 
 test('given 2 queries with params, returns new Query joined together with params', () => {
-  const aQuery = withParams('foo=[foz]', { foz: String })
+  const aQuery = withParams('foo=[foz]', { foz: Boolean })
+  const bQuery = withParams('bar=[baz]', { baz: Number })
+
+  const response = combineQuery(aQuery, bQuery)
+
+  expect(response.value).toBe('foo=[foz]&bar=[baz]')
+  expect(Object.entries(response.params)).toMatchObject([['foz', Boolean], ['baz', Number]])
+})
+
+test('given 2 queries with optional params, returns new Query joined together with params', () => {
+  const aQuery = withParams('foo=[?foz]', { foz: Boolean })
   const bQuery = withParams('bar=[?baz]', { baz: Number })
 
   const response = combineQuery(aQuery, bQuery)
 
-  expect(response.value).toBe('foo=[foz]&bar=[?baz]')
-  expect(Object.keys(response.params)).toMatchObject(['foz', '?baz'])
+  expect(response.value).toBe('foo=[?foz]&bar=[?baz]')
+  expect(Object.entries(response.params)).toMatchObject([['?foz', Boolean], ['?baz', Number]])
 })
 
 test('given 2 queries with params that include duplicates, throws DuplicateParamsError', () => {

--- a/src/services/params.ts
+++ b/src/services/params.ts
@@ -7,7 +7,7 @@ import { stringHasValue } from '@/utilities/guards'
 import { createZodParam, isZodParam } from './zod'
 
 export function getParam(params: Record<string, Param | undefined>, paramName: string): Param {
-  return params[paramName] ?? String
+  return params[paramName] ?? params[`?${paramName}`] ?? String
 }
 
 const extras: ParamExtras = {


### PR DESCRIPTION
when we [unified our param utilities into withParams](https://github.com/kitbagjs/router/pull/447), we also changed the logic for the combine utilities like `combinePath`, `combineQuery`, etc. Those utilities used to just spread the params together

```ts
return {
    value: newPathString,
    params: { ...parentPath.params, ...childPath.params },
}
```

But with the half thought of a `toString()` method I updated this to re-call `withParams`

```ts
return withParams(newPathString, { ...parentPath.params, ...childPath.params })
```

Even without the `toString()` property this felt right but caused a bug. Because `withParams` renames param keys to possibly start with a leading "?" it ends up being lost when we re-call `withParams` when combining. Therefore if you assign a custom param (anything other than String) to a route with a parent, it will just become a string param.

For this PR I decided to update the `getParam` utility to check for a param without "?", then check for the param with a leading "?", then use the default "String".

Alternatively I'd be happy to go back to the version we had previously where we do not re-call `withParams`.