### PR TITLE
alt approach to knowing what params are optional

### DIFF
--- a/src/services/combineHash.spec.ts
+++ b/src/services/combineHash.spec.ts
@@ -19,7 +19,10 @@ test('given 2 hash with params, returns new Hash joined together with params', (
   const response = combineHash(aHash, bHash)
 
   expect(response.value).toBe('/[foz]/[baz]')
-  expect(Object.entries(response.params)).toMatchObject([['foz', Boolean], ['baz', Number]])
+  expect(response.params).toMatchObject({
+    foz: Boolean,
+    baz: Number,
+  })
 })
 
 test('given 2 hash with optional params, returns new Hash joined together with params', () => {
@@ -29,7 +32,10 @@ test('given 2 hash with optional params, returns new Hash joined together with p
   const response = combineHash(aHash, bHash)
 
   expect(response.value).toBe('/[?foz]/[?baz]')
-  expect(Object.entries(response.params)).toMatchObject([['?foz', Boolean], ['?baz', Number]])
+  expect(response.params).toMatchObject({
+    foz: Boolean,
+    baz: Number,
+  })
 })
 
 test('given 2 hash with params that include duplicates, throws DuplicateParamsError', () => {

--- a/src/services/combinePath.spec-d.ts
+++ b/src/services/combinePath.spec-d.ts
@@ -1,0 +1,87 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { expectTypeOf, test } from 'vitest'
+import { withParams, WithParams } from '@/services/withParams'
+import { combinePath } from './combinePath'
+
+test('given withParams without params, combines value, leaves params empty', () => {
+  const parent = withParams('/parent-without-params', {})
+  const child = withParams('/child-without-params', {})
+
+  const response = combinePath(parent, child)
+
+  type Source = typeof response
+  type Expect = WithParams<'/parent-without-params/child-without-params', {}>
+
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
+})
+
+test('given withParams with unassigned params on parent, combines value, has single param from parent', () => {
+  const parent = withParams('/parent-with-[param]', {})
+  const child = withParams('/child-without-params', {})
+
+  const response = combinePath(parent, child)
+
+  type Source = typeof response
+  type Expect = WithParams<'/parent-with-[param]/child-without-params', {
+    param: StringConstructor,
+  }>
+
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
+})
+
+test('given withParams with optional unassigned params on parent, combines value, has single param from parent', () => {
+  const parent = withParams('/parent-with-[?param]', {})
+  const child = withParams('/child-without-params', {})
+
+  const response = combinePath(parent, child)
+
+  type Source = typeof response
+  type Expect = WithParams<'/parent-with-[?param]/child-without-params', {
+    param: StringConstructor,
+  }>
+
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
+})
+
+test('given withParams with params on parent, combines value, has single param from parent', () => {
+  const parent = withParams('/parent-with-[param]', { param: Boolean })
+  const child = withParams('/child-without-params', {})
+
+  const response = combinePath(parent, child)
+
+  type Source = typeof response
+  type Expect = WithParams<'/parent-with-[param]/child-without-params', {
+    param: BooleanConstructor,
+  }>
+
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
+})
+
+test('given withParams with optional params on parent, combines value, has single param from parent', () => {
+  const parent = withParams('/parent-with-[?param]', { param: Boolean })
+  const child = withParams('/child-without-params', {})
+
+  const response = combinePath(parent, child)
+
+  type Source = typeof response
+  type Expect = WithParams<'/parent-with-[?param]/child-without-params', {
+    param: BooleanConstructor,
+  }>
+
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
+})
+
+test('given withParams with params on both, combines value, has single param from parent', () => {
+  const parent = withParams('/parent-with-[param]', { param: Boolean })
+  const child = withParams('/child-with-[something]', { something: Number })
+
+  const response = combinePath(parent, child)
+
+  type Source = typeof response
+  type Expect = WithParams<'/parent-with-[param]/child-with-[something]', {
+    param: BooleanConstructor,
+    something: NumberConstructor,
+  }>
+
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
+})

--- a/src/services/combinePath.spec.ts
+++ b/src/services/combinePath.spec.ts
@@ -19,7 +19,10 @@ test('given 2 paths with params, returns new Path joined together with params', 
   const response = combinePath(aPath, bPath)
 
   expect(response.value).toBe('/[foz]/[baz]')
-  expect(Object.entries(response.params)).toMatchObject([['foz', Boolean], ['baz', Number]])
+  expect(response.params).toMatchObject({
+    foz: Boolean,
+    baz: Number,
+  })
 })
 
 test('given 2 paths with optional params, returns new Path joined together with params', () => {
@@ -29,7 +32,10 @@ test('given 2 paths with optional params, returns new Path joined together with 
   const response = combinePath(aPath, bPath)
 
   expect(response.value).toBe('/[?foz]/[?baz]')
-  expect(Object.entries(response.params)).toMatchObject([['?foz', Boolean], ['?baz', Number]])
+  expect(response.params).toMatchObject({
+    foz: Boolean,
+    baz: Number,
+  })
 })
 
 test('given 2 paths with params that include duplicates, throws DuplicateParamsError', () => {

--- a/src/services/combinePath.ts
+++ b/src/services/combinePath.ts
@@ -1,4 +1,3 @@
-import { RemoveLeadingQuestionMarkFromKeys } from '@/types/params'
 import { checkDuplicateParams } from '@/utilities/checkDuplicateKeys'
 import { ToWithParams, withParams, WithParams } from '@/services/withParams'
 import { Param } from '@/types/paramTypes'
@@ -10,8 +9,8 @@ export type CombinePath<
   TChild extends WithParams
 > = ToWithParams<TParent> extends { value: infer TParentPath extends string, params: infer TParentParams extends Record<string, unknown> }
   ? ToWithParams<TChild> extends { value: infer TChildPath extends string, params: infer TChildParams extends Record<string, unknown> }
-    ? RemoveLeadingQuestionMarkFromKeys<TParentParams> & RemoveLeadingQuestionMarkFromKeys<TChildParams> extends Record<string, Param | undefined>
-      ? WithParams<CombinePathString<TParentPath, TChildPath>, RemoveLeadingQuestionMarkFromKeys<TParentParams> & RemoveLeadingQuestionMarkFromKeys<TChildParams>>
+    ? TParentParams & TChildParams extends Record<string, Param | undefined>
+      ? WithParams<CombinePathString<TParentPath, TChildPath>, TParentParams & TChildParams>
       : WithParams<CombinePathString<TParentPath, TChildPath>, {}>
     : WithParams<'', {}>
   : WithParams<'', {}>

--- a/src/services/combineQuery.spec.ts
+++ b/src/services/combineQuery.spec.ts
@@ -19,7 +19,10 @@ test('given 2 queries with params, returns new Query joined together with params
   const response = combineQuery(aQuery, bQuery)
 
   expect(response.value).toBe('foo=[foz]&bar=[baz]')
-  expect(Object.entries(response.params)).toMatchObject([['foz', Boolean], ['baz', Number]])
+  expect(response.params).toMatchObject({
+    foz: Boolean,
+    baz: Number,
+  })
 })
 
 test('given 2 queries with optional params, returns new Query joined together with params', () => {
@@ -29,7 +32,10 @@ test('given 2 queries with optional params, returns new Query joined together wi
   const response = combineQuery(aQuery, bQuery)
 
   expect(response.value).toBe('foo=[?foz]&bar=[?baz]')
-  expect(Object.entries(response.params)).toMatchObject([['?foz', Boolean], ['?baz', Number]])
+  expect(response.params).toMatchObject({
+    foz: Boolean,
+    baz: Number,
+  })
 })
 
 test('given 2 queries with params that include duplicates, throws DuplicateParamsError', () => {

--- a/src/services/combineQuery.ts
+++ b/src/services/combineQuery.ts
@@ -1,4 +1,3 @@
-import { RemoveLeadingQuestionMarkFromKeys } from '@/types/params'
 import { checkDuplicateParams } from '@/utilities/checkDuplicateKeys'
 import { StringHasValue, stringHasValue } from '@/utilities/guards'
 import { ToWithParams, withParams, WithParams } from '@/services/withParams'
@@ -16,8 +15,8 @@ export type CombineQuery<
   TChild extends WithParams
 > = ToWithParams<TParent> extends { value: infer TParentQuery extends string, params: infer TParentParams extends Record<string, unknown> }
   ? ToWithParams<TChild> extends { value: infer TChildQuery extends string, params: infer TChildParams extends Record<string, unknown> }
-    ? RemoveLeadingQuestionMarkFromKeys<TParentParams> & RemoveLeadingQuestionMarkFromKeys<TChildParams> extends Record<string, Param | undefined>
-      ? WithParams<CombineQueryString<TParentQuery, TChildQuery>, RemoveLeadingQuestionMarkFromKeys<TParentParams> & RemoveLeadingQuestionMarkFromKeys<TChildParams>>
+    ? TParentParams & TChildParams extends Record<string, Param | undefined>
+      ? WithParams<CombineQueryString<TParentQuery, TChildQuery>, TParentParams & TChildParams>
       : WithParams<CombineQueryString<TParentQuery, TChildQuery>, {}>
     : WithParams<'', {}>
   : WithParams<'', {}>

--- a/src/services/createExternalRoute.ts
+++ b/src/services/createExternalRoute.ts
@@ -18,7 +18,7 @@ export function createExternalRoute<
   const TQuery extends string | WithParams | undefined = undefined,
   const THash extends string | WithParams | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta
->(options: CreateRouteOptions<TName, TPath, TQuery> & WithHost<THost> & WithoutParent):
+>(options: CreateRouteOptions<TName, TPath, TQuery, THash, TMeta> & WithHost<THost> & WithoutParent):
 Route<ToName<TName>, ToWithParams<THost>, ToWithParams<TPath>, ToWithParams<TQuery>, ToWithParams<THash>, TMeta>
 
 export function createExternalRoute<
@@ -28,7 +28,7 @@ export function createExternalRoute<
   const TQuery extends string | WithParams | undefined = undefined,
   const THash extends string | WithParams | undefined = undefined,
   const TMeta extends RouteMeta = RouteMeta
->(options: CreateRouteOptions<TName, TPath, TQuery> & WithoutHost & WithParent<TParent>):
+>(options: CreateRouteOptions<TName, TPath, TQuery, THash, TMeta> & WithoutHost & WithParent<TParent>):
 Route<ToName<TName>, WithParams<'', {}>, CombinePath<TParent['path'], ToWithParams<TPath>>, CombineQuery<TParent['query'], ToWithParams<TQuery>>, CombineHash<TParent['hash'], ToWithParams<THash>>, CombineMeta<TMeta, TParent['meta']>>
 
 export function createExternalRoute(options: CreateRouteOptions & (WithoutHost | WithHost)): Route {

--- a/src/services/getParamsForString.ts
+++ b/src/services/getParamsForString.ts
@@ -1,6 +1,5 @@
 import { getParam } from '@/services/params'
-import { getParamName } from '@/services/routeRegex'
-import { paramEnd, paramStart } from '@/types/params'
+import { getParamName, paramRegex } from '@/services/routeRegex'
 import { Param } from '@/types/paramTypes'
 import { stringHasValue } from '@/utilities/guards'
 import { checkDuplicateParams } from '@/utilities/checkDuplicateKeys'
@@ -10,8 +9,7 @@ export function getParamsForString(string: string = '', params: Record<string, P
     return {}
   }
 
-  const paramPattern = new RegExp(`\\${paramStart}(\\??[\\w-_]+)\\${paramEnd}`, 'g')
-  const matches = Array.from(string.matchAll(paramPattern))
+  const matches = Array.from(string.matchAll(new RegExp(paramRegex, 'g')))
 
   return matches.reduce<Record<string, Param>>((value, [match, key]) => {
     const paramName = getParamName(match)

--- a/src/services/paramValidation.ts
+++ b/src/services/paramValidation.ts
@@ -4,7 +4,7 @@ import { getParamValueFromUrl } from '@/services/paramsFinder'
 import { Route } from '@/types/route'
 import { RouteMatchRule } from '@/types/routeMatchRule'
 import { WithParams } from '@/services/withParams'
-import { getParamName, isOptionalParamSyntax } from '@/services/routeRegex'
+import { getParamName, isOptionalParamSyntax, paramIsOptional } from '@/services/routeRegex'
 
 export const routeParamsAreValid: RouteMatchRule = (route, url) => {
   try {
@@ -31,13 +31,12 @@ function getParams(path: WithParams, url: string): Record<string, unknown> {
   const values: Record<string, unknown> = {}
   const decodedValueFromUrl = decodeURIComponent(url)
 
-  for (const [key, param] of Object.entries(path.params)) {
-    const isOptional = key.startsWith('?')
-    const paramName = isOptional ? key.slice(1) : key
-    const stringValue = getParamValueFromUrl(decodedValueFromUrl, path.value, key)
+  for (const [name, param] of Object.entries(path.params)) {
+    const stringValue = getParamValueFromUrl(decodedValueFromUrl, path, name)
+    const isOptional = paramIsOptional(path, name)
     const paramValue = getParamValue(stringValue, param, isOptional)
 
-    values[paramName] = paramValue
+    values[name] = paramValue
   }
 
   return values
@@ -61,9 +60,8 @@ function getQueryParams(query: WithParams, url: string): Record<string, unknown>
       continue
     }
     const isOptional = isOptionalParamSyntax(value)
-    const paramKey = isOptional ? `?${paramName}` : paramName
     const valueOnUrl = actualSearch.get(key) ?? undefined
-    const paramValue = getParamValue(valueOnUrl, query.params[paramKey], isOptional)
+    const paramValue = getParamValue(valueOnUrl, query.params[paramName], isOptional)
     values[paramName] = paramValue
   }
   return values

--- a/src/services/params.ts
+++ b/src/services/params.ts
@@ -7,7 +7,7 @@ import { stringHasValue } from '@/utilities/guards'
 import { createZodParam, isZodParam } from './zod'
 
 export function getParam(params: Record<string, Param | undefined>, paramName: string): Param {
-  return params[paramName] ?? params[`?${paramName}`] ?? String
+  return params[paramName] ?? String
 }
 
 const extras: ParamExtras = {

--- a/src/services/paramsFinder.spec.ts
+++ b/src/services/paramsFinder.spec.ts
@@ -1,34 +1,40 @@
 import { describe, expect, test } from 'vitest'
 import { InvalidRouteParamValueError } from '@/errors/invalidRouteParamValueError'
 import { getParamValueFromUrl, setParamValueOnUrl } from '@/services/paramsFinder'
+import { withParams } from '@/services/withParams'
 
 describe('getParamValueFromUrl', () => {
   test('given path WITHOUT params, always returns undefined', () => {
-    const response = getParamValueFromUrl('/no-params', '/no-params', 'key')
+    const path = withParams('/no-params', {})
+    const response = getParamValueFromUrl('/no-params', path, 'key')
 
     expect(response).toBe(undefined)
   })
 
   test('given paramName that does NOT match param on route, always returns undefined', () => {
-    const response = getParamValueFromUrl('/key/ABC/not-in/123', '/key/[key]/not-in/[route]', 'fail')
+    const path = withParams('/key/[key]/not-in/[route]', {})
+    const response = getParamValueFromUrl('/key/ABC/not-in/123', path, 'fail')
 
     expect(response).toBe(undefined)
   })
 
   test('given paramName that matches param on route but value is not present, always returns undefined', () => {
-    const response = getParamValueFromUrl('/simple', '/simple/[simple]', 'simple')
+    const path = withParams('/simple/[simple]', {})
+    const response = getParamValueFromUrl('/simple', path, 'simple')
 
     expect(response).toBe(undefined)
   })
 
   test('given paramName that matches param on route, returns value', () => {
-    const response = getParamValueFromUrl('/simple/ABC', '/simple/[simple]', 'simple')
+    const path = withParams('/simple/[simple]', {})
+    const response = getParamValueFromUrl('/simple/ABC', path, 'simple')
 
     expect(response).toBe('ABC')
   })
 
   test('given multiple params, uses wildcards for non-selected param name', () => {
-    const response = getParamValueFromUrl('/ABC/123/true', '/[str]/[num]/[bool]', 'num')
+    const path = withParams('/[str]/[num]/[bool]', {})
+    const response = getParamValueFromUrl('/ABC/123/true', path, 'num')
 
     expect(response).toBe('123')
   })
@@ -36,25 +42,29 @@ describe('getParamValueFromUrl', () => {
 
 describe('setParamValueOnUrl', () => {
   test('given path WITHOUT params, always returns url as it was passed', () => {
-    const response = setParamValueOnUrl('/no-params')
+    const path = withParams('/no-params', {})
+    const response = setParamValueOnUrl('/no-params', path, 'key', 'ABC')
 
     expect(response).toBe('/no-params')
   })
 
   test('given paramName that does NOT match param on route, returns url unmodified', () => {
-    const response = setParamValueOnUrl('/key/[key]/not-in/[route]', { name: 'fail', param: String, value: 'ABC' })
+    const path = withParams('/key/[key]/not-in/[route]', {})
+    const response = setParamValueOnUrl('/key/[key]/not-in/[route]', path, 'fail', 'ABC')
 
     expect(response).toBe('/key/[key]/not-in/[route]')
   })
 
   test('given paramName that matches param on route, returns url with param replaced', () => {
-    const response = setParamValueOnUrl('/simple/[simple]', { name: 'simple', param: String, value: 'ABC' })
+    const path = withParams('/simple/[simple]', {})
+    const response = setParamValueOnUrl('/simple/[simple]', path, 'simple', 'ABC')
 
     expect(response).toBe('/simple/ABC')
   })
 
   test('given paramName that matches param on route and value is not present, throws InvalidRouteParamValueError', () => {
-    const action: () => void = () => setParamValueOnUrl('/simple/[simple]', { name: 'simple', param: String, value: undefined })
+    const path = withParams('/simple/[simple]', {})
+    const action: () => void = () => setParamValueOnUrl('/simple/[simple]', path, 'simple', undefined)
 
     expect(action).toThrowError(InvalidRouteParamValueError)
   })

--- a/src/services/paramsFinder.ts
+++ b/src/services/paramsFinder.ts
@@ -1,69 +1,19 @@
 import { setParamValue } from '@/services/params'
-import { getCaptureGroups, replaceParamSyntaxWithCatchAlls } from '@/services/routeRegex'
-import { paramEnd, paramStart } from '@/types/params'
-import { Param } from '@/types/paramTypes'
+import { getCaptureGroups, getParamRegexPattern, paramIsOptional, replaceIndividualParamWithCaptureGroup, replaceParamSyntaxWithCatchAlls } from '@/services/routeRegex'
+import { WithParams } from './withParams'
 
-export function getParamValueFromUrl(url: string, path: string, paramName: string): string | undefined {
-  const regexPattern = getParamRegexPattern(path, paramName)
-  const [paramValue] = getCaptureGroups(url, regexPattern)
+export function getParamValueFromUrl(url: string, path: WithParams, paramName: string): string | undefined {
+  const paramNameCaptureGroup = replaceIndividualParamWithCaptureGroup(path.value, paramName)
+  const otherParamsCatchAll = replaceParamSyntaxWithCatchAlls(paramNameCaptureGroup)
+
+  const [paramValue] = getCaptureGroups(url, new RegExp(otherParamsCatchAll, 'g'))
 
   return paramValue
 }
 
-export type ParamReplace = {
-  name: string,
-  param: Param,
-  value?: unknown,
-}
+export function setParamValueOnUrl(url: string, path: WithParams, paramName: string, value: unknown): string {
+  const isOptional = paramIsOptional(path, paramName)
+  const paramValue = setParamValue(value, path.params[paramName], isOptional)
 
-export function setParamValueOnUrl(path: string, paramReplace?: ParamReplace): string {
-  if (!paramReplace) {
-    return path
-  }
-
-  const { name, param, value } = paramReplace
-  const regexPattern = getParamRegexPattern(path, name)
-  const captureGroups = getCaptureGroups(path, regexPattern)
-
-  return captureGroups.reduce<string>((url, captureGroup) => {
-    if (captureGroup === undefined) {
-      return url
-    }
-
-    return url.replace(captureGroup, () => {
-      return setParamValue(value, param, name.startsWith('?'))
-    })
-  }, path)
-}
-
-function getParamRegexPattern(path: string, paramName: string): RegExp {
-  const regexPattern = [
-    replaceOptionalParamSyntaxWithCaptureGroup,
-    replaceRequiredParamSyntaxWithCaptureGroup,
-    replaceParamSyntaxWithCatchAlls,
-  ].reduce((pattern, regexBuild) => {
-    return regexBuild(pattern, paramName)
-  }, path)
-
-  return new RegExp(regexPattern, 'g')
-}
-
-function replaceOptionalParamSyntaxWithCaptureGroup(path: string, paramName: string): string {
-  if (!paramName.startsWith('?')) {
-    return path
-  }
-
-  const optionalParamRegex = new RegExp(`\\${paramStart}\\${paramName}\\${paramEnd}`, 'g')
-
-  return path.replace(optionalParamRegex, '(.*)')
-}
-
-function replaceRequiredParamSyntaxWithCaptureGroup(path: string, paramName: string): string {
-  if (paramName.startsWith('?')) {
-    return path
-  }
-
-  const requiredParamRegex = new RegExp(`\\${paramStart}${paramName}\\${paramEnd}`, 'g')
-
-  return path.replace(requiredParamRegex, '(.+)')
+  return url.replace(getParamRegexPattern(paramName), paramValue)
 }

--- a/src/services/routeMatchScore.spec.ts
+++ b/src/services/routeMatchScore.spec.ts
@@ -102,8 +102,9 @@ describe('getRouteScoreSortMethod', () => {
 
     const sortByRouteScore = getRouteScoreSortMethod('/red')
     const response = routes.sort(sortByRouteScore)
+    const matchNames = response.map((route) => route.matched.name)
 
-    expect(response.map((route) => route.matched.name)).toMatchObject(['higher-depth-child', 'lower-depth', 'higher-depth'])
+    expect(matchNames).toMatchObject(['higher-depth-child', 'lower-depth', 'higher-depth'])
   })
 
   test('given routes with different query scores, returns them sorted by query score descending', () => {

--- a/src/services/routeMatchScore.ts
+++ b/src/services/routeMatchScore.ts
@@ -3,6 +3,7 @@ import { getParamValueFromUrl } from '@/services/paramsFinder'
 import { Route } from '@/types/route'
 import { routeHashMatches } from '@/services/routeMatchRules'
 import { QuerySource } from '@/types/querySource'
+import { paramIsOptional } from '@/services/routeRegex'
 
 type RouteSortMethod = (aRoute: Route, bRoute: Route) => number
 
@@ -44,10 +45,10 @@ export function getRouteScoreSortMethod(url: string): RouteSortMethod {
 
 export function countExpectedPathParams(route: Route, actualPath: string): number {
   const optionalParams = Object.keys(route.path.params)
-    .filter((key) => key.startsWith('?'))
+    .filter((key) => paramIsOptional(route.path, key))
     .map((key) => key)
 
-  const missing = optionalParams.filter((expected) => getParamValueFromUrl(actualPath, route.path.value, expected) === undefined)
+  const missing = optionalParams.filter((expected) => getParamValueFromUrl(actualPath, route.path, expected) === undefined)
 
   return optionalParams.length - missing.length
 }

--- a/src/services/routeRegex.spec.ts
+++ b/src/services/routeRegex.spec.ts
@@ -40,7 +40,7 @@ describe('generateRoutePathRegexPattern', () => {
 
     const result = generateRoutePathRegexPattern(route)
 
-    const catchAll = '.*'
+    const catchAll = '.+'
     const expected = new RegExp(`^parent/child/${catchAll}/grand-child/${catchAll}$`, 'i')
     expect(result.toString()).toBe(expected.toString())
   })

--- a/src/services/routeRegex.ts
+++ b/src/services/routeRegex.ts
@@ -1,6 +1,7 @@
 import { paramEnd, paramStart } from '@/types/params'
 import { Route } from '@/types/route'
 import { stringHasValue } from '@/utilities/guards'
+import { WithParams } from '@/services/withParams'
 
 export function escapeRegExp(string: string): string {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -58,45 +59,57 @@ export function generateRouteQueryRegexPatterns(route: Route): RegExp[] {
 export function replaceParamSyntaxWithCatchAllsAndEscapeRest(value: string): string {
   return splitByMatches(value, new RegExp(paramRegex, 'g'))
     .map((slice) => {
-      return slice.startsWith(paramStart) ? replaceParamSyntaxWithCatchAlls(slice) : escapeRegExp(slice)
+      const isParam = slice.startsWith(paramStart)
+
+      return isParam ? replaceParamSyntaxWithCatchAlls(slice) : escapeRegExp(slice)
     })
     .join('')
 }
 
 export function replaceParamSyntaxWithCatchAlls(value: string): string {
-  return [
-    replaceOptionalParamSyntaxWithCatchAll,
-    replaceRequiredParamSyntaxWithCatchAll,
-  ].reduce((pattern, regexBuild) => {
-    return regexBuild(pattern)
-  }, value)
+  return value.replace(new RegExp(paramRegex, 'g'), '.+')
 }
 
-const paramRegex = `\\${paramStart}\\??([\\w-_]+)\\${paramEnd}`
-const optionalParamRegex = `\\${paramStart}\\?([\\w-_]+)\\${paramEnd}`
-const requiredParamRegex = `\\${paramStart}([\\w-_]+)\\${paramEnd}`
+export function replaceParamSyntaxWithCaptureGroups(value: string): string {
+  return value.replace(new RegExp(paramRegex, 'g'), '(.*)')
+}
 
-function replaceOptionalParamSyntaxWithCatchAll(value: string): string {
-  return value.replace(new RegExp(optionalParamRegex, 'g'), '.*')
+export function replaceIndividualParamWithCaptureGroup(path: string, paramName: string): string {
+  const paramRegex = getParamRegexPattern(paramName)
+
+  return path.replace(paramRegex, '(.*)')
+}
+
+export function paramIsOptional(path: WithParams, paramName: string): boolean {
+  const paramRegex = getOptionalParamRegexPattern(paramName)
+
+  return paramRegex.test(path.value)
 }
 
 export function isOptionalParamSyntax(value: string): boolean {
   return new RegExp(optionalParamRegex, 'g').test(value)
 }
 
-function replaceRequiredParamSyntaxWithCatchAll(value: string): string {
-  return value.replace(new RegExp(requiredParamRegex, 'g'), '.+')
-}
-
 export function isRequiredParamSyntax(value: string): boolean {
   return new RegExp(requiredParamRegex, 'g').test(value)
 }
 
-export function getParamName(value: string): string | undefined {
-  const [optionalName] = getCaptureGroups(value, new RegExp(optionalParamRegex, 'g'))
-  const [requiredName] = getCaptureGroups(value, new RegExp(requiredParamRegex, 'g'))
+export const paramRegex = `\\${paramStart}\\??([\\w-_]+)\\${paramEnd}`
+export const optionalParamRegex = `\\${paramStart}\\?([\\w-_]+)\\${paramEnd}`
+export const requiredParamRegex = `\\${paramStart}([\\w-_]+)\\${paramEnd}`
 
-  return optionalName ?? requiredName
+export function getParamName(value: string): string | undefined {
+  const [paramName] = getCaptureGroups(value, new RegExp(paramRegex, 'g'))
+
+  return paramName
+}
+
+export function getParamRegexPattern(paramName: string): RegExp {
+  return new RegExp(`\\${paramStart}\\??${paramName}\\${paramEnd}`, 'g')
+}
+
+export function getOptionalParamRegexPattern(paramName: string): RegExp {
+  return new RegExp(`\\${paramStart}\\?${paramName}\\${paramEnd}`, 'g')
 }
 
 export function getCaptureGroups(value: string, pattern: RegExp): (string | undefined)[] {

--- a/src/services/urlAssembly.ts
+++ b/src/services/urlAssembly.ts
@@ -1,7 +1,6 @@
 import { setParamValue } from '@/services/params'
 import { setParamValueOnUrl } from '@/services/paramsFinder'
 import { getParamName, isOptionalParamSyntax } from '@/services/routeRegex'
-import { paramEnd, paramStart } from '@/types/params'
 import { Route } from '@/types/route'
 import { Url } from '@/types/url'
 import { createUrl } from '@/services/urlCreator'
@@ -32,26 +31,14 @@ export function assembleUrl(route: Route, options: AssembleUrlOptions = {}): Url
 function assembleHostParamValues(host: WithParams, paramValues: Record<string, unknown>): string {
   const hostWithProtocol = !!host.value && !host.value.startsWith('http') ? `https://${host.value}` : host.value
 
-  return Object.entries(host.params).reduce((url, [name, param]) => {
-    const paramName = getParamName(`${paramStart}${name}${paramEnd}`)
-
-    if (!paramName) {
-      return url
-    }
-
-    return setParamValueOnUrl(url, { name, param, value: paramValues[paramName] })
+  return Object.keys(host.params).reduce((url, name) => {
+    return setParamValueOnUrl(url, host, name, paramValues[name])
   }, hostWithProtocol)
 }
 
 function assemblePathParamValues(path: WithParams, paramValues: Record<string, unknown>): string {
-  return Object.entries(path.params).reduce((url, [name, param]) => {
-    const paramName = getParamName(`${paramStart}${name}${paramEnd}`)
-
-    if (!paramName) {
-      return url
-    }
-
-    return setParamValueOnUrl(url, { name, param, value: paramValues[paramName] })
+  return Object.keys(path.params).reduce((url, name) => {
+    return setParamValueOnUrl(url, path, name, paramValues[name])
   }, path.value)
 }
 
@@ -71,8 +58,7 @@ function assembleQueryParamValues(query: WithParams, paramValues: Record<string,
     }
 
     const isOptional = isOptionalParamSyntax(value)
-    const paramKey = isOptional ? `?${paramName}` : paramName
-    const paramValue = setParamValue(paramValues[paramName], query.params[paramKey], isOptional)
+    const paramValue = setParamValue(paramValues[paramName], query.params[paramName], isOptional)
     const valueNotProvidedAndNoDefaultUsed = paramValues[paramName] === undefined && paramValue === ''
     const shouldLeaveEmptyValueOut = isOptional && valueNotProvidedAndNoDefaultUsed
 

--- a/src/services/withParams.spec-d.ts
+++ b/src/services/withParams.spec-d.ts
@@ -1,0 +1,48 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import { expectTypeOf, test } from 'vitest'
+import { withParams, WithParams } from '@/services/withParams'
+
+test('given a string without params, expects no params', () => {
+  const source = withParams('/something-without-params', {})
+
+  type Source = typeof source
+  type Expect = WithParams<'/something-without-params', {}>
+
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
+})
+
+test('given a string with required params NOT assigned, uses string constructor', () => {
+  const source = withParams('/something-with-[param]', {})
+
+  type Source = typeof source
+  type Expect = WithParams<'/something-with-[param]', { param: StringConstructor }>
+
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
+})
+
+test('given a string with optional params NOT assigned, uses string constructor', () => {
+  const source = withParams('/something-with-[?param]', {})
+
+  type Source = typeof source
+  type Expect = WithParams<'/something-with-[?param]', { param: StringConstructor }>
+
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
+})
+
+test('given a string with required params assigned, uses passed in Type', () => {
+  const source = withParams('/something-with-[param]', { param: Boolean })
+
+  type Source = typeof source
+  type Expect = WithParams<'/something-with-[param]', { param: BooleanConstructor }>
+
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
+})
+
+test('given a string with optional params assigned, uses passed in Type', () => {
+  const source = withParams('/something-with-[?param]', { param: Boolean })
+
+  type Source = typeof source
+  type Expect = WithParams<'/something-with-[?param]', { param: BooleanConstructor }>
+
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
+})

--- a/src/services/withParams.ts
+++ b/src/services/withParams.ts
@@ -1,5 +1,5 @@
 import { getParamsForString } from '@/services/getParamsForString'
-import { ExtractParamName, ExtractWithParamsParamType, ParamEnd, ParamStart } from '@/types/params'
+import { ExtractParamName, ParamEnd, ParamStart } from '@/types/params'
 import { Param } from '@/types/paramTypes'
 import { Identity } from '@/types/utilities'
 import { isRecord } from '@/utilities/guards'
@@ -15,8 +15,15 @@ type WithParamsParamsOutput<
   TValue extends string,
   TParams extends Record<string, Param | undefined> = Record<never, never>
 > = TValue extends `${string}${ParamStart}${infer TParam}${ParamEnd}${infer Rest}`
-  ? Record<TParam, ExtractWithParamsParamType<TParam, TParams>> & WithParamsParamsOutput<Rest, TParams>
+  ? Record<ExtractParamName<TParam>, ParamTypeOrDefault<ExtractParamName<TParam>, TParams>> & WithParamsParamsOutput<Rest, TParams>
   : {}
+
+type ParamTypeOrDefault<
+  TKey extends string,
+  TParams extends Record<string, Param | undefined>
+> = TKey extends keyof TParams
+  ? TParams[TKey]
+  : StringConstructor
 
 export type WithParams<
   TValue extends string = string,

--- a/src/services/withParams.ts
+++ b/src/services/withParams.ts
@@ -15,15 +15,10 @@ type WithParamsParamsOutput<
   TValue extends string,
   TParams extends Record<string, Param | undefined> = Record<never, never>
 > = TValue extends `${string}${ParamStart}${infer TParam}${ParamEnd}${infer Rest}`
-  ? Record<ExtractParamName<TParam>, ParamTypeOrDefault<ExtractParamName<TParam>, TParams>> & WithParamsParamsOutput<Rest, TParams>
+  ? ExtractParamName<TParam> extends keyof TParams
+    ? Record<ExtractParamName<TParam>, TParams[ExtractParamName<TParam>]> & WithParamsParamsOutput<Rest, TParams>
+    : Record<ExtractParamName<TParam>, StringConstructor> & WithParamsParamsOutput<Rest, TParams>
   : {}
-
-type ParamTypeOrDefault<
-  TKey extends string,
-  TParams extends Record<string, Param | undefined>
-> = TKey extends keyof TParams
-  ? TParams[TKey]
-  : StringConstructor
 
 export type WithParams<
   TValue extends string = string,

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -3,6 +3,7 @@ import { LiteralParam, Param, ParamGetSet, ParamGetter } from '@/types/paramType
 import { Identity } from '@/types/utilities'
 import { MakeOptional } from '@/utilities/makeOptional'
 import { Route } from './route'
+import { WithParams } from '@/services/withParams'
 
 export const paramStart = '['
 export type ParamStart = typeof paramStart
@@ -65,82 +66,45 @@ export type ExtractParamName<
     : TParam
 
 /**
- * Determines the type of a path parameter from a record of parameter types, considering optional parameters.
- * @template TParam - The parameter name string.
- * @template TParams - The record object mapping parameter names to their types.
- * @returns The type associated with the parameter, or StringConstructor if unspecified; may be undefined for optional parameters.
+ * Extracts combined types of path and query parameters for a given route, creating a unified parameter object.
+ * @template TRoute - The route type from which to extract and merge parameter types.
+ * @returns A record of parameter names to their respective types, extracted and merged from both path and query parameters.
  */
-export type ExtractWithParamsParamType<
-  TParam extends string,
-  TParams extends Record<string, Param | undefined>
-> = TParam extends `?${infer OptionalParam}`
-  ? OptionalParam extends keyof TParams
-    ? TParams[OptionalParam]
-    : StringConstructor
-  : TParam extends keyof TParams
-    ? TParams[TParam]
-    : StringConstructor
+export type ExtractRouteParamTypesReading<TRoute extends Route> =
+  Identity<MakeOptional<ExtractParamTypesReading<TRoute['host']> & ExtractParamTypesReading<TRoute['path']> & ExtractParamTypesReading<TRoute['query']> & ExtractParamTypesReading<TRoute['hash']>>>
 
 /**
  * Extracts combined types of path and query parameters for a given route, creating a unified parameter object.
- * This parameter object type represents the expected type when accessing params from router.route or useRoute.
+ * Differs from ExtractRouteParamTypesReading in that optional params with defaults will remain optional.
  * @template TRoute - The route type from which to extract and merge parameter types.
  * @returns A record of parameter names to their respective types, extracted and merged from both path and query parameters.
  */
-export type ExtractRouteParamTypes<TRoute extends Route> =
-  ExtractParamTypes<TRoute['host']['params'] & TRoute['path']['params'] & TRoute['query']['params'] & TRoute['hash']['params']>
+export type ExtractRouteParamTypesWriting<TRoute extends Route> =
+  Identity<MakeOptional<ExtractParamTypesWriting<TRoute['host']> & ExtractParamTypesWriting<TRoute['path']> & ExtractParamTypesWriting<TRoute['query']> & ExtractParamTypesWriting<TRoute['hash']>>>
 
 /**
- * Does everything that ExtractRouteParamTypes does, but takes into consideration optional properties.
- * Differs from ExtractRouteParamTypes in that it also reads the string `value` from WithParams to determine what should be optional.
- * @template TRoute - The route type from which to extract and merge parameter types.
- * @returns A record of parameter names to their respective types, extracted and merged from both path and query parameters.
- */
-export type ExtractRouteParamTypesOptionalReading<TRoute extends Route> =
-  Identity<MakeOptional<ExtractParamTypesOptionalReading<TRoute['host']['params']> & ExtractParamTypesOptionalReading<TRoute['path']['params']> & ExtractParamTypesOptionalReading<TRoute['query']['params']> & ExtractParamTypesOptionalReading<TRoute['hash']['params']>>>
-
-/**
- * Does everything that ExtractRouteParamTypes does, but takes into consideration optional properties.
- * Differs from ExtractRouteParamTypesOptionalReading in that optional params with defaults will remain optional.
- * @template TRoute - The route type from which to extract and merge parameter types.
- * @returns A record of parameter names to their respective types, extracted and merged from both path and query parameters.
- */
-export type ExtractRouteParamTypesOptionalWriting<TRoute extends Route> =
-  Identity<MakeOptional<ExtractParamTypesOptionalWriting<TRoute['host']['params']> & ExtractParamTypesOptionalWriting<TRoute['path']['params']> & ExtractParamTypesOptionalWriting<TRoute['query']['params']> & ExtractParamTypesOptionalWriting<TRoute['hash']['params']>>>
-
-/**
- * Transforms a record of parameter types into a type with optional properties where the original type allows undefined.
+ * Extracts combined types of path and query parameters for a given route, creating a unified parameter object.
  * @template TParams - The record of parameter types, possibly including undefined.
  * @returns A new type with the appropriate properties marked as optional.
  */
-export type ExtractParamTypes<TParams extends Record<string, Param>> = Identity<MakeOptional<{
-  [K in keyof TParams as ExtractParamName<K>]: ExtractParamType<TParams[K]>
-}>>
-
-/**
- * Does everything that ExtractParamTypes does, but takes into consideration optional properties.
- * Differs from ExtractParamTypes in that it also reads the string `value` from WithParams to determine what should be optional.
- * @template TParams - The record of parameter types, possibly including undefined.
- * @returns A new type with the appropriate properties marked as optional.
- */
-export type ExtractParamTypesOptionalReading<TParams extends Record<string, Param>> = {
-  [K in keyof TParams as ExtractParamName<K>]: K extends `?${string}`
-    ? TParams[K] extends Required<ParamGetSet>
-      ? ExtractParamType<TParams[K]>
-      : ExtractParamType<TParams[K]> | undefined
-    : ExtractParamType<TParams[K]>
+export type ExtractParamTypesReading<TWithParams extends WithParams> = {
+  [K in keyof TWithParams['params'] as ExtractParamName<K>]: TWithParams['value'] extends `${string}${ParamStart}?${K & string}${ParamEnd}${string}`
+    ? TWithParams['params'][K] extends Required<ParamGetSet>
+      ? ExtractParamType<TWithParams['params'][K]>
+      : ExtractParamType<TWithParams['params'][K]> | undefined
+    : ExtractParamType<TWithParams['params'][K]>
 }
 
 /**
- * Does everything that ExtractParamTypes does, but takes into consideration optional properties.
- * Differs from ExtractParamTypesOptionalReading in that optional params with defaults will remain optional.
+ * Extracts combined types of path and query parameters for a given route, creating a unified parameter object.
+ * Differs from ExtractParamTypesReading in that optional params with defaults will remain optional.
  * @template TParams - The record of parameter types, possibly including undefined.
  * @returns A new type with the appropriate properties marked as optional.
  */
-export type ExtractParamTypesOptionalWriting<TParams extends Record<string, Param>> = {
-  [K in keyof TParams as ExtractParamName<K>]: K extends `?${string}`
-    ? ExtractParamType<TParams[K]> | undefined
-    : ExtractParamType<TParams[K]>
+export type ExtractParamTypesWriting<TWithParams extends WithParams> = {
+  [K in keyof TWithParams['params'] as ExtractParamName<K>]: TWithParams['value'] extends `${string}${ParamStart}?${K & string}${ParamEnd}${string}`
+    ? ExtractParamType<TWithParams['params'][K]> | undefined
+    : ExtractParamType<TWithParams['params'][K]>
 }
 
 /**
@@ -158,8 +122,3 @@ export type ExtractParamType<TParam extends Param> =
         : TParam extends LiteralParam
           ? TParam
           : string
-
-type RemoveLeadingQuestionMark<T extends PropertyKey> = T extends `?${infer TRest extends string}` ? TRest : T
-export type RemoveLeadingQuestionMarkFromKeys<T extends Record<string, unknown>> = {
-  [K in keyof T as RemoveLeadingQuestionMark<K>]: T[K]
-}

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -57,13 +57,15 @@ export function isLiteralParam(value: Param): value is LiteralParam {
  */
 export type ExtractParamName<
   TParam extends PropertyKey
-> = TParam extends `?${infer Param}`
-  ? Param extends ''
-    ? never
-    : Param
-  : TParam extends ''
-    ? never
-    : TParam
+> = TParam extends string
+  ? TParam extends `?${infer Param}`
+    ? Param extends ''
+      ? never
+      : Param
+    : TParam extends ''
+      ? never
+      : TParam
+  : never
 
 /**
  * Extracts combined types of path and query parameters for a given route, creating a unified parameter object.
@@ -88,7 +90,7 @@ export type ExtractRouteParamTypesWriting<TRoute extends Route> =
  * @returns A new type with the appropriate properties marked as optional.
  */
 export type ExtractParamTypesReading<TWithParams extends WithParams> = {
-  [K in keyof TWithParams['params'] as ExtractParamName<K>]: TWithParams['value'] extends `${string}${ParamStart}?${K & string}${ParamEnd}${string}`
+  [K in keyof TWithParams['params']]: TWithParams['value'] extends `${string}${ParamStart}?${K & string}${ParamEnd}${string}`
     ? TWithParams['params'][K] extends Required<ParamGetSet>
       ? ExtractParamType<TWithParams['params'][K]>
       : ExtractParamType<TWithParams['params'][K]> | undefined
@@ -102,7 +104,7 @@ export type ExtractParamTypesReading<TWithParams extends WithParams> = {
  * @returns A new type with the appropriate properties marked as optional.
  */
 export type ExtractParamTypesWriting<TWithParams extends WithParams> = {
-  [K in keyof TWithParams['params'] as ExtractParamName<K>]: TWithParams['value'] extends `${string}${ParamStart}?${K & string}${ParamEnd}${string}`
+  [K in keyof TWithParams['params']]: TWithParams['value'] extends `${string}${ParamStart}?${K & string}${ParamEnd}${string}`
     ? ExtractParamType<TWithParams['params'][K]> | undefined
     : ExtractParamType<TWithParams['params'][K]>
 }

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -1,4 +1,4 @@
-import { ExtractRouteParamTypesOptionalReading } from '@/types/params'
+import { ExtractRouteParamTypesReading } from '@/types/params'
 import { Route } from '@/types/route'
 import { ExtractRouteStateParamsAsOptional } from '@/types/state'
 import { Url } from '@/types/url'
@@ -36,7 +36,7 @@ export type ResolvedRoute<TRoute extends Route = Route> = Readonly<{
   /**
    * Key value pair for route params, values will be the user provided value from current browser location.
   */
-  params: ExtractRouteParamTypesOptionalReading<TRoute>,
+  params: ExtractRouteParamTypesReading<TRoute>,
   /**
    * Type for additional data intended to be stored in history state.
    */

--- a/src/types/route.spec-d.ts
+++ b/src/types/route.spec-d.ts
@@ -1,5 +1,5 @@
 import { describe, expectTypeOf, test } from 'vitest'
-import { ExtractRouteParamTypesOptionalWriting, ExtractRouteParamTypesOptionalReading } from '@/types/params'
+import { ExtractRouteParamTypesWriting, ExtractRouteParamTypesReading } from '@/types/params'
 import { Route } from '@/types/route'
 import { WithParams } from '@/services/withParams'
 import { ParamGetSet } from './paramTypes'
@@ -8,8 +8,8 @@ describe('ExtractRouteParamTypes', () => {
   test('when reading/writing params, given routes with different params, some optional, no defaults, combines into expected args', () => {
     type TestRoute = Route<'parentA', WithParams<'https://[inHost].dev', {}>, WithParams<'/[inPath]', {}>, WithParams<'foo=[inQuery]&bar=[?paramC]', { inQuery: BooleanConstructor }>, WithParams<'[inHash]', {}>>
 
-    type SourceWriting = ExtractRouteParamTypesOptionalWriting<TestRoute>
-    type SourceReading = ExtractRouteParamTypesOptionalReading<TestRoute>
+    type SourceWriting = ExtractRouteParamTypesWriting<TestRoute>
+    type SourceReading = ExtractRouteParamTypesReading<TestRoute>
     type Expect = { inHost: string, inPath: string, paramC?: string, inQuery: boolean, inHash: string }
 
     expectTypeOf<SourceWriting>().toEqualTypeOf<Expect>()
@@ -19,8 +19,8 @@ describe('ExtractRouteParamTypes', () => {
   test('when optional params have defaults, Reading and Writing change', () => {
     type TestRoute = Route<'parentA', WithParams<'https://kitbag.dev', {}>, WithParams<'/', {}>, WithParams<'foo=[required]&bar=[?optional]', { required: BooleanConstructor, optional: Required<ParamGetSet<string>> }>, WithParams<'', {}>>
 
-    type SourceWriting = ExtractRouteParamTypesOptionalWriting<TestRoute>
-    type SourceReading = ExtractRouteParamTypesOptionalReading<TestRoute>
+    type SourceWriting = ExtractRouteParamTypesWriting<TestRoute>
+    type SourceReading = ExtractRouteParamTypesReading<TestRoute>
 
     expectTypeOf<SourceWriting>().toEqualTypeOf<{ required: boolean, optional?: string | undefined }>()
     expectTypeOf<SourceReading>().toEqualTypeOf<{ required: boolean, optional: string }>()

--- a/src/types/route.spec-d.ts
+++ b/src/types/route.spec-d.ts
@@ -1,12 +1,23 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { describe, expectTypeOf, test } from 'vitest'
 import { ExtractRouteParamTypesWriting, ExtractRouteParamTypesReading } from '@/types/params'
-import { Route } from '@/types/route'
-import { WithParams } from '@/services/withParams'
-import { ParamGetSet } from './paramTypes'
+import { withParams } from '@/services/withParams'
+import { withDefault } from '@/services/withDefault'
+import { createRoute } from '@/services/createRoute'
+import { createExternalRoute } from '@/services/createExternalRoute'
 
 describe('ExtractRouteParamTypes', () => {
   test('when reading/writing params, given routes with different params, some optional, no defaults, combines into expected args', () => {
-    type TestRoute = Route<'parentA', WithParams<'https://[inHost].dev', {}>, WithParams<'/[inPath]', {}>, WithParams<'foo=[inQuery]&bar=[?paramC]', { inQuery: BooleanConstructor }>, WithParams<'[inHash]', {}>>
+    const testRoute = createExternalRoute({
+      name: 'parentA',
+      host: 'https://[inHost].dev',
+      path: '/[inPath]',
+      query: withParams('foo=[inQuery]&bar=[?paramC]', {
+        inQuery: Boolean,
+      }),
+      hash: '[inHash]',
+    })
+    type TestRoute = typeof testRoute
 
     type SourceWriting = ExtractRouteParamTypesWriting<TestRoute>
     type SourceReading = ExtractRouteParamTypesReading<TestRoute>
@@ -17,7 +28,16 @@ describe('ExtractRouteParamTypes', () => {
   })
 
   test('when optional params have defaults, Reading and Writing change', () => {
-    type TestRoute = Route<'parentA', WithParams<'https://kitbag.dev', {}>, WithParams<'/', {}>, WithParams<'foo=[required]&bar=[?optional]', { required: BooleanConstructor, optional: Required<ParamGetSet<string>> }>, WithParams<'', {}>>
+    const testRoute = createRoute({
+      name: 'parentA',
+      host: 'https://kitbag.dev',
+      path: '/',
+      query: withParams('foo=[required]&bar=[?optional]', {
+        required: Boolean,
+        optional: withDefault(String, 'ABC'),
+      }),
+    })
+    type TestRoute = typeof testRoute
 
     type SourceWriting = ExtractRouteParamTypesWriting<TestRoute>
     type SourceReading = ExtractRouteParamTypesReading<TestRoute>

--- a/src/types/routeWithParams.ts
+++ b/src/types/routeWithParams.ts
@@ -1,4 +1,4 @@
-import { ExtractRouteParamTypesOptionalWriting } from '@/types/params'
+import { ExtractRouteParamTypesWriting } from '@/types/params'
 import { Route, Routes } from '@/types/route'
 import { RoutesName, RoutesMap } from '@/types/routesMap'
 
@@ -8,5 +8,5 @@ export type RouteParamsByKey<
   TRoutes extends Routes,
   TKey extends string
 > = RouteGetByKey<TRoutes, TKey> extends Route
-  ? ExtractRouteParamTypesOptionalWriting<RouteGetByKey<TRoutes, TKey>>
+  ? ExtractRouteParamTypesWriting<RouteGetByKey<TRoutes, TKey>>
   : Record<string, unknown>

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -1,7 +1,9 @@
-import { ExtractParamTypes, ExtractParamType } from '@/types/params'
+import { ExtractParamName, ExtractParamType } from '@/types/params'
 import { Param } from '@/types/paramTypes'
 import { Routes } from '@/types/route'
 import { RouteGetByKey } from '@/types/routeWithParams'
+import { MakeOptional } from '@/utilities/makeOptional'
+import { Identity } from '@/types/utilities'
 
 export type ToState<TState extends Record<string, Param> | undefined> = TState extends undefined ? Record<string, Param> : unknown extends TState ? {} : TState
 
@@ -19,3 +21,7 @@ type ExtractStateParams<TRoute> = TRoute extends {
 }
   ? ExtractParamTypes<TState>
   : Record<string, unknown>
+
+type ExtractParamTypes<TParams extends Record<string, Param>> = Identity<MakeOptional<{
+  [K in keyof TParams as ExtractParamName<K>]: ExtractParamType<TParams[K]>
+}>>

--- a/src/utilities/checkDuplicateKeys.ts
+++ b/src/utilities/checkDuplicateKeys.ts
@@ -3,7 +3,7 @@ import { getCount } from '@/utilities/array'
 
 export function checkDuplicateParams(...withParams: (Record<string, unknown> | string[])[]): void {
   const paramNames = withParams.flatMap((params) => {
-    return Array.isArray(params) ? params : Object.keys(params).map(removeLeadingQuestionMark)
+    return Array.isArray(params) ? params : Object.keys(params)
   })
 
   for (const paramName of paramNames) {
@@ -11,12 +11,4 @@ export function checkDuplicateParams(...withParams: (Record<string, unknown> | s
       throw new DuplicateParamsError(paramName)
     }
   }
-}
-
-function removeLeadingQuestionMark(value: string): string {
-  if (value.startsWith('?')) {
-    return value.slice(1)
-  }
-
-  return value
 }


### PR DESCRIPTION
## The Background

Currently, anything that can have params is normalized to `WithParams` type. This type has a `params` property that stores `Record<string, Param>`. The key for each param is where we store if we expect the param to be optional or not.

For example: 

```ts
{ value: '/[foo], params: { "foo": Boolean } }
```

This `WithParams` has a single param "foo", which we can see is **NOT** optional.


```ts
{ value: '/[?foo], params: { "?foo": Boolean } }
```

Versus this `WithParams`, where "foo" is now optional.

## The Motivation

We've never loved sticking the leading "?" in the params object for several reasons

- it's ugly
- it's changing the keys as defined by the user
- when we check for duplicate param names we need to look for the same name in twice where one has the question mark
- we combine two `withParams` objects we have to de-normalize param names back to exclude the question mark
- it creates a situation where there are 2 possibly conflicting sources of truth, the user already provides the optional declaration in the `value` property

That last reason is one that I found the most compelling and why I chose to try this syntax. This is also something that I didn't love about the suggestion to introduce a new `optional` property that only tracks what params are optional.

## The Solution

Now `WithParams` leaves params alone and looks at the `value` to determine what's optional.

```ts
{ value: '/[foo], params: { "foo": Boolean } } // required
{ value: '/[?foo], params: { "foo": Boolean } } // optional
```