### PR TITLE
Type bug assigning params with default

### DIFF
--- a/src/services/combinePath.ts
+++ b/src/services/combinePath.ts
@@ -1,6 +1,7 @@
 import { RemoveLeadingQuestionMarkFromKeys } from '@/types/params'
 import { checkDuplicateParams } from '@/utilities/checkDuplicateKeys'
-import { ParamsWithParamNameExtracted, ToWithParams, withParams, WithParams } from '@/services/withParams'
+import { ToWithParams, withParams, WithParams } from '@/services/withParams'
+import { Param } from '@/types/paramTypes'
 
 type CombinePathString<TParent extends string, TChild extends string> = `${TParent}${TChild}`
 
@@ -9,9 +10,9 @@ export type CombinePath<
   TChild extends WithParams
 > = ToWithParams<TParent> extends { value: infer TParentPath extends string, params: infer TParentParams extends Record<string, unknown> }
   ? ToWithParams<TChild> extends { value: infer TChildPath extends string, params: infer TChildParams extends Record<string, unknown> }
-    ? RemoveLeadingQuestionMarkFromKeys<TParentParams> & RemoveLeadingQuestionMarkFromKeys<TChildParams> extends ParamsWithParamNameExtracted<CombinePathString<TParentPath, TChildPath>>
+    ? RemoveLeadingQuestionMarkFromKeys<TParentParams> & RemoveLeadingQuestionMarkFromKeys<TChildParams> extends Record<string, Param | undefined>
       ? WithParams<CombinePathString<TParentPath, TChildPath>, RemoveLeadingQuestionMarkFromKeys<TParentParams> & RemoveLeadingQuestionMarkFromKeys<TChildParams>>
-      : WithParams<'', {}>
+      : WithParams<CombinePathString<TParentPath, TChildPath>, {}>
     : WithParams<'', {}>
   : WithParams<'', {}>
 

--- a/src/services/combineQuery.ts
+++ b/src/services/combineQuery.ts
@@ -1,7 +1,8 @@
 import { RemoveLeadingQuestionMarkFromKeys } from '@/types/params'
 import { checkDuplicateParams } from '@/utilities/checkDuplicateKeys'
 import { StringHasValue, stringHasValue } from '@/utilities/guards'
-import { ParamsWithParamNameExtracted, ToWithParams, withParams, WithParams } from '@/services/withParams'
+import { ToWithParams, withParams, WithParams } from '@/services/withParams'
+import { Param } from '@/types/paramTypes'
 
 type CombineQueryString<TParent extends string | undefined, TChild extends string | undefined> =
   StringHasValue<TParent> extends true
@@ -15,9 +16,9 @@ export type CombineQuery<
   TChild extends WithParams
 > = ToWithParams<TParent> extends { value: infer TParentQuery extends string, params: infer TParentParams extends Record<string, unknown> }
   ? ToWithParams<TChild> extends { value: infer TChildQuery extends string, params: infer TChildParams extends Record<string, unknown> }
-    ? RemoveLeadingQuestionMarkFromKeys<TParentParams> & RemoveLeadingQuestionMarkFromKeys<TChildParams> extends ParamsWithParamNameExtracted<CombineQueryString<TParentQuery, TChildQuery>>
+    ? RemoveLeadingQuestionMarkFromKeys<TParentParams> & RemoveLeadingQuestionMarkFromKeys<TChildParams> extends Record<string, Param | undefined>
       ? WithParams<CombineQueryString<TParentQuery, TChildQuery>, RemoveLeadingQuestionMarkFromKeys<TParentParams> & RemoveLeadingQuestionMarkFromKeys<TChildParams>>
-      : WithParams<'', {}>
+      : WithParams<CombineQueryString<TParentQuery, TChildQuery>, {}>
     : WithParams<'', {}>
   : WithParams<'', {}>
 

--- a/src/services/withParams.ts
+++ b/src/services/withParams.ts
@@ -4,20 +4,22 @@ import { Param } from '@/types/paramTypes'
 import { Identity } from '@/types/utilities'
 import { isRecord } from '@/utilities/guards'
 
+type AssignableParamsFromString<
+  TValue extends string
+> = TValue extends `${string}${ParamStart}${infer TParam}${ParamEnd}${infer Rest}`
+  ? Record<ExtractParamName<TParam>, Param | undefined> & AssignableParamsFromString<Rest>
+  : {}
+
 type ExtractParamsFromString<
   TValue extends string,
   TParams extends Record<string, Param | undefined> = Record<never, never>
-> = TValue extends `${string}${ParamStart}${infer Param}${ParamEnd}${infer Rest}`
-  ? Record<Param, ExtractWithParamsParamType<Param, TParams>> & ExtractParamsFromString<Rest, TParams>
-  : Record<never, never>
-
-export type ParamsWithParamNameExtracted<TValue extends string> = {
-  [K in keyof ExtractParamsFromString<TValue> as ExtractParamName<K>]?: Param
-}
+> = TValue extends `${string}${ParamStart}${infer TParam}${ParamEnd}${infer Rest}`
+  ? Record<ExtractParamName<TParam>, ExtractWithParamsParamType<TParam, TParams>> & ExtractParamsFromString<Rest, TParams>
+  : {}
 
 export type WithParams<
   TValue extends string = string,
-  TParams extends ParamsWithParamNameExtracted<TValue> = Record<string, Param | undefined>
+  TParams extends Record<string, Param | undefined> = Record<string, Param | undefined>
 > = {
   value: TValue,
   params: string extends TValue ? Record<string, Param> : Identity<ExtractParamsFromString<TValue, TParams>>,
@@ -50,7 +52,7 @@ export function toWithParams<T extends string | WithParams | undefined>(value: T
 
 export function withParams<
   const TValue extends string,
-  const TParams extends ParamsWithParamNameExtracted<TValue>
+  const TParams extends AssignableParamsFromString<TValue>
 >(value: TValue, params: TParams): WithParams<TValue, TParams>
 export function withParams(): WithParams<'', {}>
 export function withParams(value?: string, params?: Record<string, Param | undefined>): WithParams {

--- a/src/services/withParams.ts
+++ b/src/services/withParams.ts
@@ -3,6 +3,7 @@ import { ExtractParamName, ExtractWithParamsParamType, ParamEnd, ParamStart } fr
 import { Param } from '@/types/paramTypes'
 import { Identity } from '@/types/utilities'
 import { isRecord } from '@/utilities/guards'
+import { MakeOptional } from '@/utilities/makeOptional'
 
 type AssignableParamsFromString<
   TValue extends string
@@ -14,7 +15,7 @@ type ExtractParamsFromString<
   TValue extends string,
   TParams extends Record<string, Param | undefined> = Record<never, never>
 > = TValue extends `${string}${ParamStart}${infer TParam}${ParamEnd}${infer Rest}`
-  ? Record<ExtractParamName<TParam>, ExtractWithParamsParamType<TParam, TParams>> & ExtractParamsFromString<Rest, TParams>
+  ? Record<TParam, ExtractWithParamsParamType<TParam, TParams>> & ExtractParamsFromString<Rest, TParams>
   : {}
 
 export type WithParams<
@@ -52,7 +53,7 @@ export function toWithParams<T extends string | WithParams | undefined>(value: T
 
 export function withParams<
   const TValue extends string,
-  const TParams extends AssignableParamsFromString<TValue>
+  const TParams extends MakeOptional<AssignableParamsFromString<TValue>>
 >(value: TValue, params: TParams): WithParams<TValue, TParams>
 export function withParams(): WithParams<'', {}>
 export function withParams(value?: string, params?: Record<string, Param | undefined>): WithParams {

--- a/src/services/withParams.ts
+++ b/src/services/withParams.ts
@@ -5,17 +5,17 @@ import { Identity } from '@/types/utilities'
 import { isRecord } from '@/utilities/guards'
 import { MakeOptional } from '@/utilities/makeOptional'
 
-type AssignableParamsFromString<
+type WithParamsParamsInput<
   TValue extends string
 > = TValue extends `${string}${ParamStart}${infer TParam}${ParamEnd}${infer Rest}`
-  ? Record<ExtractParamName<TParam>, Param | undefined> & AssignableParamsFromString<Rest>
+  ? Record<ExtractParamName<TParam>, Param | undefined> & WithParamsParamsInput<Rest>
   : {}
 
-type ExtractParamsFromString<
+type WithParamsParamsOutput<
   TValue extends string,
   TParams extends Record<string, Param | undefined> = Record<never, never>
 > = TValue extends `${string}${ParamStart}${infer TParam}${ParamEnd}${infer Rest}`
-  ? Record<TParam, ExtractWithParamsParamType<TParam, TParams>> & ExtractParamsFromString<Rest, TParams>
+  ? Record<TParam, ExtractWithParamsParamType<TParam, TParams>> & WithParamsParamsOutput<Rest, TParams>
   : {}
 
 export type WithParams<
@@ -23,7 +23,7 @@ export type WithParams<
   TParams extends Record<string, Param | undefined> = Record<string, Param | undefined>
 > = {
   value: TValue,
-  params: string extends TValue ? Record<string, Param> : Identity<ExtractParamsFromString<TValue, TParams>>,
+  params: string extends TValue ? Record<string, Param> : Identity<WithParamsParamsOutput<TValue, TParams>>,
 }
 
 export type ToWithParams<T extends string | WithParams | undefined> = T extends string
@@ -53,7 +53,7 @@ export function toWithParams<T extends string | WithParams | undefined>(value: T
 
 export function withParams<
   const TValue extends string,
-  const TParams extends MakeOptional<AssignableParamsFromString<TValue>>
+  const TParams extends MakeOptional<WithParamsParamsInput<TValue>>
 >(value: TValue, params: TParams): WithParams<TValue, TParams>
 export function withParams(): WithParams<'', {}>
 export function withParams(value?: string, params?: Record<string, Param | undefined>): WithParams {

--- a/src/types/RouterResolve.ts
+++ b/src/types/RouterResolve.ts
@@ -1,5 +1,6 @@
 import { Routes } from '@/types/route'
 import { RoutesName } from '@/types/routesMap'
+import { withParams } from '@/services/withParams'
 import { RouteParamsByKey } from '@/types/routeWithParams'
 import { AllPropertiesAreOptional } from '@/types/utilities'
 import { QuerySource } from '@/types/querySource'
@@ -24,3 +25,52 @@ type RouterResolveArgs<
 export type RouterResolve<
   TRoutes extends Routes
 > = <TSource extends RoutesName<TRoutes>>(name: TSource, ...args: RouterResolveArgs<TRoutes, TSource>) => ResolvedRoute
+
+import { component } from '@/utilities/testHelpers'
+import { ExtractParamName, ExtractRouteParamTypesOptionalReading, ExtractRouteParamTypesOptionalWriting, ExtractWithParamsParamType } from './params'
+import { createRoute } from '@/services/createRoute'
+import { withDefault } from '@/services/withDefault'
+import { unionOf } from '@/services/unionOf'
+
+const home = createRoute({
+  name: 'home',
+  path: '/',
+  component,
+})
+
+const settings = createRoute({
+  name: 'settings',
+  path: '/settings',
+  query: 'search=[?search]',
+  component,
+})
+
+const profile = createRoute({
+  parent: settings,
+  name: 'settings.profile',
+  path: '/profile',
+  component,
+})
+
+const keys = createRoute({
+  parent: settings,
+  name: 'settings.keys',
+  path: '/keys',
+  query: withParams('sort=[?sort]', {
+    sort: withDefault(unionOf('asc', 'desc'), 'asc'),
+  }),
+  component,
+})
+
+type TK = typeof profile['query']
+//    ^?
+type T0 = typeof keys['query']
+//    ^?
+
+const routes = [home, settings, profile, keys] as const
+
+type T1 = RouteParamsByKey<typeof routes, 'settings.keys'>
+//    ^?
+
+type T2 = ExtractRouteParamTypesOptionalReading<typeof keys>
+type T3 = ExtractRouteParamTypesOptionalWriting<typeof keys>

--- a/src/types/RouterResolve.ts
+++ b/src/types/RouterResolve.ts
@@ -1,6 +1,5 @@
 import { Routes } from '@/types/route'
 import { RoutesName } from '@/types/routesMap'
-import { withParams } from '@/services/withParams'
 import { RouteParamsByKey } from '@/types/routeWithParams'
 import { AllPropertiesAreOptional } from '@/types/utilities'
 import { QuerySource } from '@/types/querySource'
@@ -25,52 +24,3 @@ type RouterResolveArgs<
 export type RouterResolve<
   TRoutes extends Routes
 > = <TSource extends RoutesName<TRoutes>>(name: TSource, ...args: RouterResolveArgs<TRoutes, TSource>) => ResolvedRoute
-
-import { component } from '@/utilities/testHelpers'
-import { ExtractParamName, ExtractRouteParamTypesOptionalReading, ExtractRouteParamTypesOptionalWriting, ExtractWithParamsParamType } from './params'
-import { createRoute } from '@/services/createRoute'
-import { withDefault } from '@/services/withDefault'
-import { unionOf } from '@/services/unionOf'
-
-const home = createRoute({
-  name: 'home',
-  path: '/',
-  component,
-})
-
-const settings = createRoute({
-  name: 'settings',
-  path: '/settings',
-  query: 'search=[?search]',
-  component,
-})
-
-const profile = createRoute({
-  parent: settings,
-  name: 'settings.profile',
-  path: '/profile',
-  component,
-})
-
-const keys = createRoute({
-  parent: settings,
-  name: 'settings.keys',
-  path: '/keys',
-  query: withParams('sort=[?sort]', {
-    sort: withDefault(unionOf('asc', 'desc'), 'asc'),
-  }),
-  component,
-})
-
-type TK = typeof profile['query']
-//    ^?
-type T0 = typeof keys['query']
-//    ^?
-
-const routes = [home, settings, profile, keys] as const
-
-type T1 = RouteParamsByKey<typeof routes, 'settings.keys'>
-//    ^?
-
-type T2 = ExtractRouteParamTypesOptionalReading<typeof keys>
-type T3 = ExtractRouteParamTypesOptionalWriting<typeof keys>

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -177,6 +177,6 @@ export type ExtractParamType<TParam extends Param> =
           : string
 
 type RemoveLeadingQuestionMark<T extends PropertyKey> = T extends `?${infer TRest extends string}` ? TRest : T
-export type RemoveLeadingQuestionMarkFromKeys<T extends Record<string, unknown>> = {
+export type RemoveLeadingQuestionMarkFromKeys<T> = {
   [K in keyof T as RemoveLeadingQuestionMark<K>]: T[K]
 }

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -2,6 +2,7 @@ import { ZodSchemaLike } from '@/services/zod'
 import { LiteralParam, Param, ParamGetSet, ParamGetter } from '@/types/paramTypes'
 import { Identity } from '@/types/utilities'
 import { MakeOptional } from '@/utilities/makeOptional'
+import { Route } from './route'
 
 export const paramStart = '['
 export type ParamStart = typeof paramStart
@@ -86,14 +87,8 @@ export type ExtractWithParamsParamType<
  * @template TRoute - The route type from which to extract and merge parameter types.
  * @returns A record of parameter names to their respective types, extracted and merged from both path and query parameters.
  */
-export type ExtractRouteParamTypes<TRoute> = TRoute extends {
-  host: { params: infer HostParams extends Record<string, Param> },
-  path: { params: infer PathParams extends Record<string, Param> },
-  query: { params: infer QueryParams extends Record<string, Param> },
-  hash: { params: infer HashParams extends Record<string, Param> },
-}
-  ? ExtractParamTypes<HostParams & PathParams & QueryParams & HashParams>
-  : Record<string, unknown>
+export type ExtractRouteParamTypes<TRoute extends Route> =
+  ExtractParamTypes<TRoute['host']['params'] & TRoute['path']['params'] & TRoute['query']['params'] & TRoute['hash']['params']>
 
 /**
  * Does everything that ExtractRouteParamTypes does, but takes into consideration optional properties.
@@ -101,14 +96,8 @@ export type ExtractRouteParamTypes<TRoute> = TRoute extends {
  * @template TRoute - The route type from which to extract and merge parameter types.
  * @returns A record of parameter names to their respective types, extracted and merged from both path and query parameters.
  */
-export type ExtractRouteParamTypesOptionalReading<TRoute> = TRoute extends {
-  host: { params: infer HostParams extends Record<string, Param> },
-  path: { params: infer PathParams extends Record<string, Param> },
-  query: { params: infer QueryParams extends Record<string, Param> },
-  hash: { params: infer HashParams extends Record<string, Param> },
-}
-  ? Identity<MakeOptional<ExtractParamTypesOptionalReading<HostParams> & ExtractParamTypesOptionalReading<PathParams> & ExtractParamTypesOptionalReading<QueryParams> & ExtractParamTypesOptionalReading<HashParams>>>
-  : Record<string, unknown>
+export type ExtractRouteParamTypesOptionalReading<TRoute extends Route> =
+  Identity<MakeOptional<ExtractParamTypesOptionalReading<TRoute['host']['params']> & ExtractParamTypesOptionalReading<TRoute['path']['params']> & ExtractParamTypesOptionalReading<TRoute['query']['params']> & ExtractParamTypesOptionalReading<TRoute['hash']['params']>>>
 
 /**
  * Does everything that ExtractRouteParamTypes does, but takes into consideration optional properties.
@@ -116,14 +105,8 @@ export type ExtractRouteParamTypesOptionalReading<TRoute> = TRoute extends {
  * @template TRoute - The route type from which to extract and merge parameter types.
  * @returns A record of parameter names to their respective types, extracted and merged from both path and query parameters.
  */
-export type ExtractRouteParamTypesOptionalWriting<TRoute> = TRoute extends {
-  host: { params: infer HostParams extends Record<string, Param> },
-  path: { params: infer PathParams extends Record<string, Param> },
-  query: { params: infer QueryParams extends Record<string, Param> },
-  hash: { params: infer HashParams extends Record<string, Param> },
-}
-  ? Identity<MakeOptional<ExtractParamTypesOptionalWriting<HostParams> & ExtractParamTypesOptionalWriting<PathParams> & ExtractParamTypesOptionalWriting<QueryParams> & ExtractParamTypesOptionalWriting<HashParams>>>
-  : Record<string, unknown>
+export type ExtractRouteParamTypesOptionalWriting<TRoute extends Route> =
+  Identity<MakeOptional<ExtractParamTypesOptionalWriting<TRoute['host']['params']> & ExtractParamTypesOptionalWriting<TRoute['path']['params']> & ExtractParamTypesOptionalWriting<TRoute['query']['params']> & ExtractParamTypesOptionalWriting<TRoute['hash']['params']>>>
 
 /**
  * Transforms a record of parameter types into a type with optional properties where the original type allows undefined.
@@ -177,6 +160,6 @@ export type ExtractParamType<TParam extends Param> =
           : string
 
 type RemoveLeadingQuestionMark<T extends PropertyKey> = T extends `?${infer TRest extends string}` ? TRest : T
-export type RemoveLeadingQuestionMarkFromKeys<T> = {
+export type RemoveLeadingQuestionMarkFromKeys<T extends Record<string, unknown>> = {
   [K in keyof T as RemoveLeadingQuestionMark<K>]: T[K]
 }

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -102,12 +102,12 @@ export type ExtractRouteParamTypes<TRoute> = TRoute extends {
  * @returns A record of parameter names to their respective types, extracted and merged from both path and query parameters.
  */
 export type ExtractRouteParamTypesOptionalReading<TRoute> = TRoute extends {
-  host: { value: infer Host extends string, params: infer HostParams extends Record<string, Param> },
-  path: { value: infer Path extends string, params: infer PathParams extends Record<string, Param> },
-  query: { value: infer Query extends string, params: infer QueryParams extends Record<string, Param> },
-  hash: { value: infer Hash extends string, params: infer HashParams extends Record<string, Param> },
+  host: { params: infer HostParams extends Record<string, Param> },
+  path: { params: infer PathParams extends Record<string, Param> },
+  query: { params: infer QueryParams extends Record<string, Param> },
+  hash: { params: infer HashParams extends Record<string, Param> },
 }
-  ? Identity<MakeOptional<ExtractParamTypesOptionalReading<Host, HostParams> & ExtractParamTypesOptionalReading<Path, PathParams> & ExtractParamTypesOptionalReading<Query, QueryParams> & ExtractParamTypesOptionalReading<Hash, HashParams>>>
+  ? Identity<MakeOptional<ExtractParamTypesOptionalReading<HostParams> & ExtractParamTypesOptionalReading<PathParams> & ExtractParamTypesOptionalReading<QueryParams> & ExtractParamTypesOptionalReading<HashParams>>>
   : Record<string, unknown>
 
 /**
@@ -117,12 +117,12 @@ export type ExtractRouteParamTypesOptionalReading<TRoute> = TRoute extends {
  * @returns A record of parameter names to their respective types, extracted and merged from both path and query parameters.
  */
 export type ExtractRouteParamTypesOptionalWriting<TRoute> = TRoute extends {
-  host: { value: infer Host extends string, params: infer HostParams extends Record<string, Param> },
-  path: { value: infer Path extends string, params: infer PathParams extends Record<string, Param> },
-  query: { value: infer Query extends string, params: infer QueryParams extends Record<string, Param> },
-  hash: { value: infer Hash extends string, params: infer HashParams extends Record<string, Param> },
+  host: { params: infer HostParams extends Record<string, Param> },
+  path: { params: infer PathParams extends Record<string, Param> },
+  query: { params: infer QueryParams extends Record<string, Param> },
+  hash: { params: infer HashParams extends Record<string, Param> },
 }
-  ? Identity<MakeOptional<ExtractParamTypesOptionalWriting<Host, HostParams> & ExtractParamTypesOptionalWriting<Path, PathParams> & ExtractParamTypesOptionalWriting<Query, QueryParams> & ExtractParamTypesOptionalWriting<Hash, HashParams>>>
+  ? Identity<MakeOptional<ExtractParamTypesOptionalWriting<HostParams> & ExtractParamTypesOptionalWriting<PathParams> & ExtractParamTypesOptionalWriting<QueryParams> & ExtractParamTypesOptionalWriting<HashParams>>>
   : Record<string, unknown>
 
 /**
@@ -140,8 +140,8 @@ export type ExtractParamTypes<TParams extends Record<string, Param>> = Identity<
  * @template TParams - The record of parameter types, possibly including undefined.
  * @returns A new type with the appropriate properties marked as optional.
  */
-export type ExtractParamTypesOptionalReading<TValue extends string, TParams extends Record<string, Param>> = {
-  [K in keyof TParams as ExtractParamName<K>]: TValue extends `${string}${ParamStart}?${K & string}${ParamEnd}${string}`
+export type ExtractParamTypesOptionalReading<TParams extends Record<string, Param>> = {
+  [K in keyof TParams as ExtractParamName<K>]: K extends `?${string}`
     ? TParams[K] extends Required<ParamGetSet>
       ? ExtractParamType<TParams[K]>
       : ExtractParamType<TParams[K]> | undefined
@@ -154,8 +154,8 @@ export type ExtractParamTypesOptionalReading<TValue extends string, TParams exte
  * @template TParams - The record of parameter types, possibly including undefined.
  * @returns A new type with the appropriate properties marked as optional.
  */
-export type ExtractParamTypesOptionalWriting<TValue extends string, TParams extends Record<string, Param>> = {
-  [K in keyof TParams as ExtractParamName<K>]: TValue extends `${string}${ParamStart}?${K & string}${ParamEnd}${string}`
+export type ExtractParamTypesOptionalWriting<TParams extends Record<string, Param>> = {
+  [K in keyof TParams as ExtractParamName<K>]: K extends `?${string}`
     ? ExtractParamType<TParams[K]> | undefined
     : ExtractParamType<TParams[K]>
 }

--- a/src/types/resolved.spec-d.ts
+++ b/src/types/resolved.spec-d.ts
@@ -1,11 +1,18 @@
 import { expectTypeOf, test } from 'vitest'
 import { RouterRoute } from '@/services/createRouterRoute'
 import { ResolvedRoute } from '@/types/resolved'
-import { Route } from '@/types/route'
-import { WithParams } from '@/services/withParams'
+import { withParams } from '@/services/withParams'
+import { createRoute } from '@/services/createRoute'
 
 test('given a specific Route, params are narrow', () => {
-    type TestRoute = Route<'parentA', WithParams<'', {}>, WithParams<'/[paramA]', {}>, WithParams<'foo=[paramB]&bar=[?paramC]', { paramB: BooleanConstructor }>>
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const testRoute = createRoute({
+    name: 'parentA',
+    path: '/parentA/[paramA]',
+    query: withParams('foo=[paramB]&bar=[?paramC]', { paramB: Boolean }),
+  })
+
+    type TestRoute = typeof testRoute
 
     type Source = RouterRoute<ResolvedRoute<TestRoute>>['params']
     type Expect = { paramA: string, paramB: boolean, paramC?: string | undefined }

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -1,4 +1,4 @@
-import { ExtractRouteParamTypesWithOptional } from '@/types/params'
+import { ExtractRouteParamTypesOptionalReading } from '@/types/params'
 import { Route } from '@/types/route'
 import { ExtractRouteStateParamsAsOptional } from '@/types/state'
 import { Url } from '@/types/url'
@@ -36,7 +36,7 @@ export type ResolvedRoute<TRoute extends Route = Route> = Readonly<{
   /**
    * Key value pair for route params, values will be the user provided value from current browser location.
   */
-  params: ExtractRouteParamTypesWithOptional<TRoute>,
+  params: ExtractRouteParamTypesOptionalReading<TRoute>,
   /**
    * Type for additional data intended to be stored in history state.
    */

--- a/src/types/route.spec-d.ts
+++ b/src/types/route.spec-d.ts
@@ -1,15 +1,28 @@
 import { describe, expectTypeOf, test } from 'vitest'
-import { ExtractRouteParamTypesWithOptional } from '@/types/params'
+import { ExtractRouteParamTypesOptionalWriting, ExtractRouteParamTypesOptionalReading } from '@/types/params'
 import { Route } from '@/types/route'
 import { WithParams } from '@/services/withParams'
+import { ParamGetSet } from './paramTypes'
 
 describe('ExtractRouteParamTypes', () => {
-  test('given routes with different params, some optional, combines into expected args for developer', () => {
+  test('when reading/writing params, given routes with different params, some optional, no defaults, combines into expected args', () => {
     type TestRoute = Route<'parentA', WithParams<'https://[inHost].dev', {}>, WithParams<'/[inPath]', {}>, WithParams<'foo=[inQuery]&bar=[?paramC]', { inQuery: BooleanConstructor }>, WithParams<'[inHash]', {}>>
 
-    type Source = ExtractRouteParamTypesWithOptional<TestRoute>
+    type SourceWriting = ExtractRouteParamTypesOptionalWriting<TestRoute>
+    type SourceReading = ExtractRouteParamTypesOptionalReading<TestRoute>
     type Expect = { inHost: string, inPath: string, paramC?: string, inQuery: boolean, inHash: string }
 
-    expectTypeOf<Source>().toEqualTypeOf<Expect>()
+    expectTypeOf<SourceWriting>().toEqualTypeOf<Expect>()
+    expectTypeOf<SourceReading>().toEqualTypeOf<Expect>()
+  })
+
+  test('when optional params have defaults, Reading and Writing change', () => {
+    type TestRoute = Route<'parentA', WithParams<'https://kitbag.dev', {}>, WithParams<'/', {}>, WithParams<'foo=[required]&bar=[?optional]', { required: BooleanConstructor, optional: Required<ParamGetSet<string>> }>, WithParams<'', {}>>
+
+    type SourceWriting = ExtractRouteParamTypesOptionalWriting<TestRoute>
+    type SourceReading = ExtractRouteParamTypesOptionalReading<TestRoute>
+
+    expectTypeOf<SourceWriting>().toEqualTypeOf<{ required: boolean, optional?: string | undefined }>()
+    expectTypeOf<SourceReading>().toEqualTypeOf<{ required: boolean, optional: string }>()
   })
 })

--- a/src/types/routeWithParams.ts
+++ b/src/types/routeWithParams.ts
@@ -1,4 +1,4 @@
-import { ExtractRouteParamTypesWithOptional } from '@/types/params'
+import { ExtractRouteParamTypesOptionalWriting } from '@/types/params'
 import { Routes } from '@/types/route'
 import { RoutesName, RoutesMap } from '@/types/routesMap'
 
@@ -7,4 +7,4 @@ export type RouteGetByKey<TRoutes extends Routes, TKey extends RoutesName<TRoute
 export type RouteParamsByKey<
   TRoutes extends Routes,
   TKey extends string
-> = ExtractRouteParamTypesWithOptional<RouteGetByKey<TRoutes, TKey>>
+> = ExtractRouteParamTypesOptionalWriting<RouteGetByKey<TRoutes, TKey>>

--- a/src/types/routeWithParams.ts
+++ b/src/types/routeWithParams.ts
@@ -1,5 +1,5 @@
 import { ExtractRouteParamTypesOptionalWriting } from '@/types/params'
-import { Routes } from '@/types/route'
+import { Route, Routes } from '@/types/route'
 import { RoutesName, RoutesMap } from '@/types/routesMap'
 
 export type RouteGetByKey<TRoutes extends Routes, TKey extends RoutesName<TRoutes>> = RoutesMap<TRoutes>[TKey]
@@ -7,4 +7,6 @@ export type RouteGetByKey<TRoutes extends Routes, TKey extends RoutesName<TRoute
 export type RouteParamsByKey<
   TRoutes extends Routes,
   TKey extends string
-> = ExtractRouteParamTypesOptionalWriting<RouteGetByKey<TRoutes, TKey>>
+> = RouteGetByKey<TRoutes, TKey> extends Route
+  ? ExtractRouteParamTypesOptionalWriting<RouteGetByKey<TRoutes, TKey>>
+  : Record<string, unknown>

--- a/src/types/state.ts
+++ b/src/types/state.ts
@@ -1,13 +1,13 @@
-import { ExtractParamTypes, ExtractParamTypesWithOptional } from '@/types/params'
+import { ExtractParamTypes, ExtractParamType } from '@/types/params'
 import { Param } from '@/types/paramTypes'
 import { Routes } from '@/types/route'
 import { RouteGetByKey } from '@/types/routeWithParams'
 
 export type ToState<TState extends Record<string, Param> | undefined> = TState extends undefined ? Record<string, Param> : unknown extends TState ? {} : TState
 
-export type ExtractRouteStateParamsAsOptional<T extends Record<string, Param>> = ExtractParamTypesWithOptional<{
-  [K in keyof T as K extends string ? `?${K}` : never]: T[K]
-}>
+export type ExtractRouteStateParamsAsOptional<TParams extends Record<string, Param>> = {
+  [K in keyof TParams]: ExtractParamType<TParams[K]> | undefined
+}
 
 export type RouteStateByName<
   TRoutes extends Routes,


### PR DESCRIPTION
when we [simplified the extract type logic](https://github.com/kitbagjs/router/pull/455), we de-duped the ExtractType logic from src/types/routeWithParams.ts so now there are 2 types in src/types/params.ts. The types are `ExtractParamTypes` and `ExtractParamTypesWithOptional`. When testing some params I had the following test case

```ts
const keys = createRoute({
  parent: settings,
  name: 'settings.keys',
  path: '/keys',
  query: withParams('sort=[?sort]', { 
    sort: withDefault(unionOf('asc', 'desc'), 'asc') 
  }),
  component: defineAsyncComponent(() => import('../views/SettingsKeysView.vue'))
})
```

and I found that when I tried pushing to `settings.keys` it was expecting `sort` to be passed because our logic in `ExtractParamTypesWithOptional` says if an optional param has a default, it should REMOVE the `| undefined`. This is true when **reading** params but opposite when **writing**. 

While verbose, this PR further bifurcates the `ExtractParamTypesWithOptional` into 
- ExtractParamTypesOptionalReading
- ExtractParamTypesOptionalWriting

So now there are 3 "extract params" types (with comments in code to explain)
- **ExtractParamTypes**: Doesn't consider optionality
- **ExtractParamTypesOptionalReading**: Differs from ExtractParamTypes in that it also reads the string `value` from WithParams to determine what should be optional.
- **ExtractParamTypesOptionalWriting**: Differs from ExtractParamTypesOptionalReading in that optional params with defaults will remain optional.
