### PR TITLE
fixed bug with accessing rejection types from register interface

### DIFF
--- a/src/types/register.ts
+++ b/src/types/register.ts
@@ -38,7 +38,7 @@ export type RegisteredRoutes<T = Register> = T extends { router: Router<infer TR
 /**
  * Represents the possible Rejections registered within {@link Register}
  */
-export type RegisteredRejectionType<T = Register> = T extends { router: Router<Routes, infer TOptions extends RouterOptions> }
+export type RegisteredRejectionType<T = Register> = T extends { router: Router<any, infer TOptions extends RouterOptions> }
   ? keyof TOptions['rejections'] | BuiltInRejectionType
   : BuiltInRejectionType
 


### PR DESCRIPTION
here's the test case I used to find the bug (in router-preview)

```ts
import { defineAsyncComponent } from "vue";
import { createRouter, createRoute, withParams, unionOf, withDefault } from "@kitbag/router";
import HomeView from "../views/HomeView.vue";
import LoginView from "../views/LoginView.vue";

const home = createRoute({
  name: 'home',
  path: '/',
  component: HomeView
})

const settings = createRoute({
  name: 'settings',
  path: '/settings',
  query: 'search=[?search]',
  component: defineAsyncComponent(() => import('../views/SettingsView.vue'))
})

const profile = createRoute({
  parent: settings,
  name: 'settings.profile',
  path: '/profile',
  component: defineAsyncComponent(() => import('../views/SettingsProfileView.vue'))
})

const keys = createRoute({
  parent: settings,
  name: 'settings.keys',
  path: '/keys',
  query: withParams('sort=[?sort]', {
    sort: withDefault(unionOf('asc', 'desc'), 'asc')
  }),
  component: defineAsyncComponent(() => import('../views/SettingsKeysView.vue'))
})

const requiresAuth = createRoute({
  name: 'auth',
  path: '/requires-auth',
  onBeforeRouteEnter: (_to, { reject }) => {
    // here is the error
    reject('NotAuthorized')
  },
})

export const routes = [home, settings, profile, keys, requiresAuth] as const
export const router = createRouter(routes, {
  rejections: { NotAuthorized: LoginView },
})
```

I tried copying in the exact type from router

```ts
export type RegisteredRejectionType<T = Register> = T extends { router: Router<Routes, infer TOptions extends RouterOptions> }
  ? keyof TOptions['rejections'] | BuiltInRejectionType
  : BuiltInRejectionType
```

and found the same result, only shows `"NotFound"`. However, if I replace `Routes` with `any`, it correctly becomes `"NotFound" | "NotAuthorized"`