### PR TITLE
update param utilities to accept options, separator for arrays

### DIFF
--- a/src/services/arrayOf.spec.ts
+++ b/src/services/arrayOf.spec.ts
@@ -8,7 +8,7 @@ test.each([
   ['true,23,foo', [true, 23, 'foo']],
   ['1,2,3,4,5', [1, 2, 3, 4, 5]],
 ])('given an array of params with valid values, returns an array of values', (input, expected) => {
-  const array = arrayOf(Number, Boolean, String)
+  const array = arrayOf([Number, Boolean, String])
 
   const result = getParamValue(input, array)
 
@@ -16,7 +16,7 @@ test.each([
 })
 
 test('given an array of params with an invalid value, throws InvalidRouteParamValueError', () => {
-  const array = arrayOf(Number, Boolean)
+  const array = arrayOf([Number, Boolean])
 
   const action: () => void = () => getParamValue('true, 23, foo', array)
 
@@ -24,9 +24,17 @@ test('given an array of params with an invalid value, throws InvalidRouteParamVa
 })
 
 test('given value is not an array, throws InvalidRouteParamValueError', () => {
-  const array = arrayOf(Number, Boolean)
+  const array = arrayOf([Number, Boolean])
 
   const action: () => void = () => setParamValue({}, array)
 
   expect(action).toThrow('Expected an array')
+})
+
+test('given a separator, uses it to split the value', () => {
+  const array = arrayOf([Number, Boolean, String], { separator: '|' })
+
+  const result = getParamValue('1|2|3', array)
+
+  expect(result).toEqual([1, 2, 3])
 })

--- a/src/services/arrayOf.ts
+++ b/src/services/arrayOf.ts
@@ -3,19 +3,28 @@ import { Param, ParamGetSet } from '@/types/paramTypes'
 import { ExtractParamType } from '@/types/params'
 import { unionOf } from './unionOf'
 
-export function arrayOf<const T extends Param[]>(...params: T): ParamGetSet<ExtractParamType<T[number]>[]> {
-  const union = unionOf(...params)
+type ArrayOfOptions = {
+  separator?: string,
+}
+
+const defaultOptions = {
+  separator: ',',
+} satisfies ArrayOfOptions
+
+export function arrayOf<const T extends Param[]>(params: T, options: ArrayOfOptions = {}): ParamGetSet<ExtractParamType<T[number]>[]> {
+  const { separator } = { ...defaultOptions, ...options }
+  const union = unionOf(params)
 
   return {
     get: (value, extras) => {
-      return value.split(',').map((value) => union.get(value, extras))
+      return value.split(separator).map((value) => union.get(value, extras))
     },
     set: (value, extras) => {
       if (!Array.isArray(value)) {
         throw extras.invalid('Expected an array')
       }
 
-      return value.map((value) => union.set(value, extras)).join(',')
+      return value.map((value) => union.set(value, extras)).join(separator)
     },
   }
 }

--- a/src/services/tupleOf.spec.ts
+++ b/src/services/tupleOf.spec.ts
@@ -7,7 +7,7 @@ test.each([
   ['23,true,foo', [23, true, 'foo']],
   ['-2,false,bar', [-2, false, 'bar']],
 ])('given an array of params with valid values, returns an array of values', (input, expected) => {
-  const array = tupleOf(Number, Boolean, String)
+  const array = tupleOf([Number, Boolean, String])
 
   const result = getParamValue(input, array)
 
@@ -17,7 +17,7 @@ test.each([
 test.each([
   {}, true, '', Infinity,
 ])('given value is %s not an array, throws InvalidRouteParamValueError', (value) => {
-  const array = tupleOf(Number, Boolean)
+  const array = tupleOf([Number, Boolean])
 
   const action: () => void = () => setParamValue(value, array)
 
@@ -25,7 +25,7 @@ test.each([
 })
 
 test('given value with too few values, throws InvalidRouteParamValueError', () => {
-  const array = tupleOf(Number, Number)
+  const array = tupleOf([Number, Number])
 
   const action: () => void = () => setParamValue([1], array)
 
@@ -33,7 +33,7 @@ test('given value with too few values, throws InvalidRouteParamValueError', () =
 })
 
 test('given value with too many values, throws InvalidRouteParamValueError', () => {
-  const array = tupleOf(Number, Number)
+  const array = tupleOf([Number, Number])
 
   const action: () => void = () => setParamValue([1, 2, 3], array)
 
@@ -44,7 +44,7 @@ test.each([
   ['23'],
   ['true,23'],
 ])('given an array of params with invalid value %s, throws InvalidRouteParamValueError', (value) => {
-  const array = tupleOf(Number, Boolean)
+  const array = tupleOf([Number, Boolean])
 
   const action: () => void = () => getParamValue(value, array)
 

--- a/src/services/tupleOf.ts
+++ b/src/services/tupleOf.ts
@@ -3,12 +3,22 @@ import { Param, ParamGetSet } from '@/types/paramTypes'
 import { ExtractParamType } from '@/types/params'
 import { getParamValue, setParamValue } from '@/services/params'
 
+type TupleOfOptions = {
+  separator?: string,
+}
+
+const defaultOptions = {
+  separator: ',',
+} satisfies TupleOfOptions
+
 type TupleOf<T extends Param[]> = { [K in keyof T]: ExtractParamType<T[K]> }
 
-export function tupleOf<const T extends Param[]>(...params: T): ParamGetSet<TupleOf<T>> {
+export function tupleOf<const T extends Param[]>(params: T, options: TupleOfOptions = {}): ParamGetSet<TupleOf<T>> {
+  const { separator } = { ...defaultOptions, ...options }
+
   return {
     get: (value) => {
-      const values = value.split(',')
+      const values = value.split(separator)
 
       return params.map((param, index) => getParamValue(values.at(index), param)) as TupleOf<T>
     },
@@ -21,7 +31,7 @@ export function tupleOf<const T extends Param[]>(...params: T): ParamGetSet<Tupl
         throw invalid(`Expected tuple with ${params.length} values but received ${value.length} values`)
       }
 
-      return params.map((param, index) => setParamValue(value.at(index), param)).join(',')
+      return params.map((param, index) => setParamValue(value.at(index), param)).join(separator)
     },
   }
 }

--- a/src/services/unionOf.spec.ts
+++ b/src/services/unionOf.spec.ts
@@ -15,7 +15,7 @@ test('given several params, calls each until one returns a value', () => {
   const cParam = vi.fn().mockImplementationOnce(() => 'works!')
   const dParam = vi.fn().mockImplementationOnce(() => 'also works!')
 
-  const union = unionOf(aParam, bParam, cParam, dParam)
+  const union = unionOf([aParam, bParam, cParam, dParam])
 
   const result = getParamValue('foo', union)
 
@@ -33,7 +33,7 @@ test('given no param returns value, throws InvalidRouteParamValueError', () => {
   const cParam = vi.fn().mockImplementationOnce(throwsInvalidRouteParamValueError())
   const dParam = vi.fn().mockImplementationOnce(throwsInvalidRouteParamValueError())
 
-  const union = unionOf(aParam, bParam, cParam, dParam)
+  const union = unionOf([aParam, bParam, cParam, dParam])
 
   const action: () => void = () => getParamValue('foo', union)
 
@@ -49,7 +49,7 @@ test('given a param that throws something other than InvalidRouteParamValueError
     throw new Error('Something went wrong')
   })
 
-  const union = unionOf(param)
+  const union = unionOf([param])
 
   const action: () => void = () => getParamValue('foo', union)
 
@@ -64,7 +64,7 @@ test.each([
   [/foo/, 'foo', 'foo'],
   [String, 'foo', 'foo'],
 ])('works with param of built-in type %s', (param, input, output) => {
-  const union = unionOf(param)
+  const union = unionOf([param])
 
   const result = getParamValue(input, union)
 
@@ -78,7 +78,7 @@ test.each([
 test.each([
   23, 'foo', true,
 ])('works with literal param of type %s', (value) => {
-  const union = unionOf(value)
+  const union = unionOf([value])
 
   const result = getParamValue(value.toString(), union)
 

--- a/src/services/unionOf.ts
+++ b/src/services/unionOf.ts
@@ -3,7 +3,7 @@ import { Param, ParamGetSet } from '@/types/paramTypes'
 import { safeGetParamValue, safeSetParamValue } from '@/services/params'
 import { ExtractParamType } from '@/types/params'
 
-export function unionOf<const T extends Param[]>(...params: T): ParamGetSet<ExtractParamType<T[number]>> {
+export function unionOf<const T extends Param[]>(params: T): ParamGetSet<ExtractParamType<T[number]>> {
   return {
     get: (value, { invalid }) => {
       for (const param of params) {


### PR DESCRIPTION
in a [recent PR](https://github.com/kitbagjs/router/pull/436) we introduced 3 new param utilities

`arrayOf`, `tupleOf`, and `unionOf`

This PR modifies the call signature of these utilities to accept an array of param types as the 1st argument instead of spreading the argument. This allows for a 2nd argument to be specified for "options".

As of right now, array and tuple are the only ones that accept options, and their options are identical.

```ts
type options = {
  separator?: string,
}
```

This allows users to override the default behavior of the utilities to choose their own separator instead of the default comma `","`.  For example, users might choose a pipe `"|"` which changes the url from

> https://ticketing.service.dev?category=music,sports,art

to be

> https://ticketing.service.dev?category=music|sports|art

Thanks to @nclemeur for making the [suggestion](https://discord.com/channels/1240867447033172138/1240868059196030977/1341662846626435073) in our Discord