### PR TITLE
make types for createExternalRoute more like createRoute

### DIFF
--- a/src/services/createExternalRoute.ts
+++ b/src/services/createExternalRoute.ts
@@ -1,35 +1,18 @@
 import { markRaw } from 'vue'
-import { CombineHash } from '@/services/combineHash'
-import { CombineMeta } from '@/services/combineMeta'
-import { CombinePath } from '@/services/combinePath'
-import { CombineQuery } from '@/services/combineQuery'
 import { createRouteId } from '@/services/createRouteId'
-import { combineRoutes, CreateRouteOptions, isWithParent, WithHost, WithoutHost, WithoutParent, WithParent } from '@/types/createRouteOptions'
-import { toName, ToName } from '@/types/name'
-import { RouteMeta } from '@/types/register'
+import { combineRoutes, CreateRouteOptions, isWithParent, ToRoute, WithHost, WithoutHost, WithoutParent, WithParent } from '@/types/createRouteOptions'
+import { toName } from '@/types/name'
 import { Route } from '@/types/route'
 import { checkDuplicateParams } from '@/utilities/checkDuplicateKeys'
-import { toWithParams, ToWithParams, WithParams } from '@/services/withParams'
+import { toWithParams } from '@/services/withParams'
 
 export function createExternalRoute<
-  const THost extends string | WithParams,
-  const TName extends string | undefined = undefined,
-  const TPath extends string | WithParams | undefined = undefined,
-  const TQuery extends string | WithParams | undefined = undefined,
-  const THash extends string | WithParams | undefined = undefined,
-  const TMeta extends RouteMeta = RouteMeta
->(options: CreateRouteOptions<TName, TPath, TQuery, THash, TMeta> & WithHost<THost> & WithoutParent):
-Route<ToName<TName>, ToWithParams<THost>, ToWithParams<TPath>, ToWithParams<TQuery>, ToWithParams<THash>, TMeta>
+  const TOptions extends CreateRouteOptions & WithHost & WithoutParent
+>(options: TOptions): ToRoute<TOptions, undefined>
 
 export function createExternalRoute<
-  const TParent extends Route,
-  const TName extends string | undefined = undefined,
-  const TPath extends string | WithParams | undefined = undefined,
-  const TQuery extends string | WithParams | undefined = undefined,
-  const THash extends string | WithParams | undefined = undefined,
-  const TMeta extends RouteMeta = RouteMeta
->(options: CreateRouteOptions<TName, TPath, TQuery, THash, TMeta> & WithoutHost & WithParent<TParent>):
-Route<ToName<TName>, WithParams<'', {}>, CombinePath<TParent['path'], ToWithParams<TPath>>, CombineQuery<TParent['query'], ToWithParams<TQuery>>, CombineHash<TParent['hash'], ToWithParams<THash>>, CombineMeta<TMeta, TParent['meta']>>
+  const TOptions extends CreateRouteOptions & WithoutHost & WithParent
+>(options: TOptions): ToRoute<TOptions, undefined>
 
 export function createExternalRoute(options: CreateRouteOptions & (WithoutHost | WithHost)): Route {
   const id = createRouteId()

--- a/src/services/withParams.ts
+++ b/src/services/withParams.ts
@@ -28,7 +28,7 @@ export type WithParams<
   params: string extends TValue ? Record<string, Param> : Identity<WithParamsParamsOutput<TValue, TParams>>,
 }
 
-export type ToWithParams<T extends string | WithParams | undefined> = T extends string
+export type ToWithParams<T> = T extends string
   ? WithParams<T, {}>
   : T extends undefined
     ? WithParams<'', {}>

--- a/src/services/withParams.ts
+++ b/src/services/withParams.ts
@@ -28,7 +28,7 @@ export type WithParams<
   params: string extends TValue ? Record<string, Param> : Identity<WithParamsParamsOutput<TValue, TParams>>,
 }
 
-export type ToWithParams<T> = T extends string
+export type ToWithParams<T extends string | WithParams | undefined> = T extends string
   ? WithParams<T, {}>
   : T extends undefined
     ? WithParams<'', {}>

--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -160,7 +160,7 @@ export type ToRoute<
   : TOptions extends { parent: infer TParent extends Route }
     ? Route<
       ToName<TOptions['name']>,
-      WithParams<'', {}>,
+      ToWithParams<TParent['host']>,
       CombinePath<ToWithParams<TParent['path']>, ToWithParams<TOptions['path']>>,
       CombineQuery<ToWithParams<TParent['query']>, ToWithParams<TOptions['query']>>,
       CombineHash<ToWithParams<TParent['hash']>, ToWithParams<TOptions['hash']>>,
@@ -170,7 +170,7 @@ export type ToRoute<
     >
     : Route<
       ToName<TOptions['name']>,
-      WithParams<'', {}>,
+      TOptions extends { host: string | WithParams } ? ToWithParams<TOptions['host']> : WithParams<'', {}>,
       ToWithParams<TOptions['path']>,
       ToWithParams<TOptions['query']>,
       ToWithParams<TOptions['hash']>,


### PR DESCRIPTION
quite awhile ago, we greatly [simplified the types for overloads in createRoute](https://github.com/kitbagjs/router/pull/421). I noticed that our types for overloads in `createExternalRoute` never got the same treatment. This PR addresses that and keeps the 2 utilities working more or less the same.