### PR TITLE
Add some dependabot groups for dev dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,54 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
-    directory: "/" # Location of package manifests
+
+  # Build tools
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      build-tools:
+        patterns:
+          - "vite"
+          - "vite-plugin-dts"
+          - "@vitejs/plugin-vue"
+          - "typescript"
+          - "vue-tsc"
+
+  # Testing tools
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      test-tools:
+        patterns:
+          - "vitest"
+          - "@vue/test-utils"
+          - "happy-dom"
+
+  # Documentation tools
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      docs-tools:
+        patterns:
+          - "vitepress"
+          - "typedoc"
+          - "typedoc-plugin-markdown"
+          - "typedoc-vitepress-theme"
+
+  # Linting and code quality
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      linting:
+        patterns:
+          - "eslint"
+          - "@kitbag/eslint-config"
+          - "globals"


### PR DESCRIPTION
# Description
I believe this will make dependabot open a single PR with multiple dependencies. That way the tests can run once and they can all be merged. This will be a lot easier to maintain vs the many individual prs. 