### PR TITLE
Fix valibot params causing `Param` to be type `any`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "@kitbag/router",
       "version": "0.20.0",
       "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
         "history": "^5.3.0"
       },
       "devDependencies": {
@@ -1987,6 +1988,12 @@
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-9.3.1.tgz",
       "integrity": "sha512-79QfK1393x9Ho60QFyLti+QfdJzRQCVLFb97kOIV7Eo9vQU/roINgk7m24uv0a7AUvN//RDH36FLjjK48v0s9g==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
       "license": "MIT"
     },
     "node_modules/@stylistic/eslint-plugin": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     }
   },
   "dependencies": {
+    "@standard-schema/spec": "^1.0.0",
     "history": "^5.3.0"
   }
 }

--- a/src/services/valibot.spec-d.ts
+++ b/src/services/valibot.spec-d.ts
@@ -1,10 +1,18 @@
 import { expectTypeOf, test } from 'vitest'
 import { withParams } from './withParams'
-import { string } from 'valibot'
+import { string, boolean } from 'valibot'
+import { ExtractParamType } from '@/types/params'
 
 test('withParams accepts valibot schemas', () => {
   const schema = string()
   const { params } = withParams('/[foo]', { foo: schema })
 
   expectTypeOf(params.foo).toEqualTypeOf(schema)
+})
+
+test('ExtractParamType returns the correct type for valibot params', () => {
+  const param = boolean()
+  type Input = ExtractParamType<typeof param>
+
+  expectTypeOf<Input>().toEqualTypeOf<boolean>()
 })

--- a/src/services/valibot.ts
+++ b/src/services/valibot.ts
@@ -2,9 +2,11 @@
 import { Param, ParamGetSet } from '@/types/paramTypes'
 import { isRecord } from '@/utilities/guards'
 import { isPromise } from '@/utilities/promises'
-import type { BaseIssue, BaseSchema, UnionOptions, UnionSchema, VariantSchema } from 'valibot'
+import { StandardSchemaV1 } from '@standard-schema/spec'
 
-export type ValibotSchemaLike = BaseSchema<unknown, unknown, BaseIssue<unknown>> | UnionSchema<UnionOptions, any> | VariantSchema<any, any, any>
+export interface ValibotSchemaLike extends StandardSchemaV1<any> {
+  type: string;
+}
 
 // inferring the return type is preferred for this function
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type

--- a/src/services/zod.spec-d.ts
+++ b/src/services/zod.spec-d.ts
@@ -1,10 +1,18 @@
 import { expectTypeOf, test } from 'vitest'
 import { withParams } from './withParams'
 import { z } from 'zod'
+import { ExtractParamType } from '@/types/params'
 
 test('withParams accepts zod schemas', () => {
   const schema = z.string()
   const { params } = withParams('/[foo]', { foo: schema })
 
   expectTypeOf(params.foo).toEqualTypeOf(schema)
+})
+
+test('ExtractParamType returns the correct type for zod params', () => {
+  const param = z.boolean()
+  type Input = ExtractParamType<typeof param>
+
+  expectTypeOf<Input>().toEqualTypeOf<boolean>()
 })

--- a/src/services/zod.ts
+++ b/src/services/zod.ts
@@ -1,10 +1,12 @@
 /* eslint-disable @typescript-eslint/only-throw-error */
 import { Param, ParamGetSet } from '@/types/paramTypes'
 import { Routes } from '@/types/route'
+import { isRecord } from '@/utilities/guards'
+import { StandardSchemaV1 } from '@standard-schema/spec'
 import type { ZodSchema } from 'zod'
 
-export type ZodSchemaLike<TOutput = any> = {
-  parse: (input: any) => TOutput,
+export interface ZodSchemaLike extends StandardSchemaV1<any> {
+  parse: (input: any) => any  
 }
 
 let zod: ZodSchemas | null = null
@@ -68,7 +70,13 @@ export function zotParamsDetected(routes: Routes): boolean {
 }
 
 function isZodSchemaLike(param: Param): param is ZodSchemaLike {
-  return typeof param === 'object' && 'parse' in param && typeof param.parse === 'function'
+  return isRecord(param)
+    && 'parse' in param
+    && typeof param.parse === 'function'
+    && '~standard' in param
+    && isRecord(param['~standard'])
+    && 'vendor' in param['~standard']
+    && param['~standard'].vendor === 'zod'
 }
 
 export async function initZod(): Promise<void> {

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -1,4 +1,3 @@
-import { ZodSchemaLike } from '@/services/zod'
 import { LiteralParam, Param, ParamGetSet, ParamGetter } from '@/types/paramTypes'
 import { Identity } from '@/types/utilities'
 import { MakeOptional } from '@/utilities/makeOptional'

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -4,6 +4,7 @@ import { Identity } from '@/types/utilities'
 import { MakeOptional } from '@/utilities/makeOptional'
 import { Route } from './route'
 import { WithParams } from '@/services/withParams'
+import { StandardSchemaV1 } from '@standard-schema/spec'
 
 export const paramStart = '['
 export type ParamStart = typeof paramStart
@@ -121,6 +122,8 @@ export type ExtractParamType<TParam extends Param> =
       ? ReturnType<TParam>
       : TParam extends ZodSchemaLike<infer Type>
         ? Type
-        : TParam extends LiteralParam
-          ? TParam
-          : string
+        : TParam extends StandardSchemaV1
+          ? StandardSchemaV1.InferOutput<TParam>
+          : TParam extends LiteralParam
+            ? TParam
+            : string

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -120,10 +120,8 @@ export type ExtractParamType<TParam extends Param> =
     ? Type
     : TParam extends ParamGetter
       ? ReturnType<TParam>
-      : TParam extends ZodSchemaLike<infer Type>
-        ? Type
-        : TParam extends StandardSchemaV1
-          ? StandardSchemaV1.InferOutput<TParam>
-          : TParam extends LiteralParam
-            ? TParam
-            : string
+      : TParam extends StandardSchemaV1
+        ? StandardSchemaV1.InferOutput<TParam>
+        : TParam extends LiteralParam
+          ? TParam
+          : string


### PR DESCRIPTION
# Description
Should fix type issues around valibot params