### PR TITLE
Fix "NotFound" flashing when using transitions

### DIFF
--- a/src/components/routerView.browser.spec.ts
+++ b/src/components/routerView.browser.spec.ts
@@ -69,6 +69,34 @@ test('renders components for initial route', async () => {
   expect(wrapper.html()).toBe('Child')
 })
 
+test('does not render component when router is not started', async () => {
+  const route = createRoute({
+    name: 'foo',
+    path: '/',
+    component: { template: 'hello world' },
+  })
+
+  const router = createRouter([route], {
+    initialUrl: '/',
+  })
+
+  const root = {
+    template: '<RouterView/>',
+  }
+
+  const wrapper = mount(root, {
+    global: {
+      plugins: [router],
+    },
+  })
+
+  expect(wrapper.text()).toBe('')
+
+  await router.start()
+
+  expect(wrapper.text()).toBe('hello world')
+})
+
 test('updates components when route changes', async () => {
   const routes = [
     createRoute({

--- a/src/components/routerView.vue
+++ b/src/components/routerView.vue
@@ -15,12 +15,14 @@
   import { RouterRoute } from '@/services/createRouterRoute'
   import { depthInjectionKey } from '@/types/injectionDepth'
   import { useComponentsStore } from '@/compositions/useComponentsStore'
+  import { useRouter } from '@/compositions/useRouter'
 
   const { name = 'default' } = defineProps<{
     name?: string,
   }>()
 
   const route = useRoute()
+  const { started } = useRouter()
   const rejection = useRejection()
   const depth = useRouterDepth()
 
@@ -37,6 +39,10 @@
   provide(depthInjectionKey, depth + 1)
 
   const component = computed(() => {
+    if (!started.value) {
+      return null
+    }
+
     if (rejection.value) {
       return rejection.value.component
     }

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -1,4 +1,4 @@
-import { App, Component } from 'vue'
+import { App, Component, Ref } from 'vue'
 import { RouterHistoryMode } from '@/services/createRouterHistory'
 import { RouterRoute } from '@/services/createRouterRoute'
 import { AddAfterRouteHook, AddBeforeRouteHook, WithHooks } from '@/types/hooks'
@@ -129,6 +129,10 @@ export type Router<
    * Initializes the router based on the initial route. Automatically called when the router is installed. Calling this more than once has no effect.
    */
   start: () => Promise<void>,
+  /**
+   * Returns true if the router has been started.
+   */
+  started: Ref<boolean>,
   /**
    * Stops the router and teardown any listeners.
    */


### PR DESCRIPTION
# Description
Taeling reported in discord that when they added transitions to their router view the "NotFound" text was being shown first before the matched route was shown. 

This was happening because
A) The default route is the not found route
B) The router view renders immediately
C) The router itself is started asynchronously 