### PR TITLE
Add classes and slot scope for "active" links

### DIFF
--- a/src/components/routerLink.browser.spec.ts
+++ b/src/components/routerLink.browser.spec.ts
@@ -258,7 +258,7 @@ test('to prop as Url renders and routes correctly', async () => {
 test.each<{ to: Url, match: boolean, exactMatch: boolean }>([
   { to: '/parent-route', match: true, exactMatch: false },
   { to: '/parent-route/child-route', match: true, exactMatch: true },
-  { to: '/other-route', match: false, exactMatch: false },
+  { to: '/other', match: false, exactMatch: false },
 ])('isMatch and isExactMatch classes and slot props works as expected', async ({ to, match, exactMatch }) => {
   const parentRoute = createRoute({
     name: 'parent-route',
@@ -352,6 +352,65 @@ test('isMatch correctly matches parent when sibling has the same url', async () 
 
   expect(link.classes()).toContain('router-link--match')
   expect(link.classes()).not.toContain('router-link--exact-match')
+})
+
+test.each<{ to: Url, active: boolean, exactActive: boolean }>([
+  { to: '/parent-route', active: true, exactActive: false },
+  { to: '/parent-route/child-route/pass', active: true, exactActive: true },
+  { to: '/parent-route/child-route/fail', active: false, exactActive: false },
+  { to: '/other', active: false, exactActive: false },
+])('isActive and isExactActive classes and slot props work as expected', async ({ to, active, exactActive }) => {
+  const parentRoute = createRoute({
+    name: 'parent-route',
+    path: '/parent-route',
+  })
+
+  const childRoute = createRoute({
+    parent: parentRoute,
+    name: 'child-route',
+    path: '/child-route/[param]',
+    component,
+  })
+
+  const otherRoute = createRoute({
+    name: 'other',
+    path: '/other',
+    component,
+  })
+
+  const router = createRouter([parentRoute, childRoute, otherRoute], {
+    initialUrl: '/parent-route/child-route/pass',
+  })
+
+  const wrapper = mount(routerLink, {
+    props: {
+      to,
+    },
+    slots: {
+      default: '{{ params.isActive }} {{ params.isExactActive }}',
+    },
+    global: {
+      plugins: [router],
+    },
+  })
+
+  await router.start()
+
+  const anchor = wrapper.find('a')
+
+  expect(anchor.text()).toBe(`${active} ${exactActive}`)
+
+  if (active) {
+    expect(anchor.classes()).toContain('router-link--active')
+  } else {
+    expect(anchor.classes()).not.toContain('router-link--active')
+  }
+
+  if (exactActive) {
+    expect(anchor.classes()).toContain('router-link--exact-active')
+  } else {
+    expect(anchor.classes()).not.toContain('router-link--exact-active')
+  }
 })
 
 test.each([

--- a/src/components/routerLink.vue
+++ b/src/components/routerLink.vue
@@ -1,6 +1,6 @@
 <template>
   <a ref="element" :href="href" class="router-link" :class="classes" @click="onClick">
-    <slot v-bind="{ route, isMatch, isExactMatch, isExternal }" />
+    <slot v-bind="{ route, isMatch, isExactMatch, isActive, isExactActive, isExternal }" />
   </a>
 </template>
 
@@ -44,6 +44,8 @@
       route: ResolvedRoute | undefined,
       isMatch: boolean,
       isExactMatch: boolean,
+      isActive: boolean,
+      isExactActive: boolean,
       isExternal: boolean,
     }) => unknown,
   }>()
@@ -60,7 +62,7 @@
     return options
   })
 
-  const { element, isMatch, isExactMatch, isExternal, push } = useLink(() => {
+  const { element, isMatch, isExactMatch, isActive, isExactActive, isExternal, push } = useLink(() => {
     if (typeof props.to === 'function') {
       return props.to(router.resolve)
     }
@@ -71,6 +73,8 @@
   const classes = computed(() => ({
     'router-link--match': isMatch.value,
     'router-link--exact-match': isExactMatch.value,
+    'router-link--active': isActive.value,
+    'router-link--exact-active': isExactActive.value,
   }))
 
   function getResolvedRoute(to: Url | ResolvedRoute | ToCallback | undefined): ResolvedRoute | undefined {

--- a/src/compositions/useLink.ts
+++ b/src/compositions/useLink.ts
@@ -11,6 +11,7 @@ import { Url, isUrl } from '@/types/url'
 import { AllPropertiesAreOptional } from '@/types/utilities'
 import { isRoute } from '@/guards/routes'
 import { combineUrlSearchParams } from '@/utilities/urlSearchParams'
+import { isDefined } from '@/utilities/guards'
 
 export type UseLink = {
   /**
@@ -33,6 +34,14 @@ export type UseLink = {
    * True if route matches current URL. Route is the same as what's currently stored at `router.route`.
    */
   isExactMatch: ComputedRef<boolean>,
+  /**
+   * True if route matches current URL, or is a parent route that matches the parent of the current URL.
+   */
+  isActive: ComputedRef<boolean>,
+  /**
+   * True if route matches current URL exactly.
+   */
+  isExactActive: ComputedRef<boolean>,
   /**
    *
    */
@@ -110,6 +119,8 @@ export function useLink(
 
   const isMatch = computed(() => isRoute(router.route) && router.route.matches.some((match) => match.id === route.value?.id))
   const isExactMatch = computed(() => router.route.id === route.value?.id)
+  const isActive = computed(() => isRoute(router.route) && isDefined(route.value) && router.route.href.startsWith(route.value.href))
+  const isExactActive = computed(() => router.route.href === route.value?.href)
   const isExternal = computed(() => !!href.value && router.isExternal(href.value))
 
   const linkOptions = computed<UseLinkOptions>(() => {
@@ -152,6 +163,8 @@ export function useLink(
     href,
     isMatch,
     isExactMatch,
+    isActive,
+    isExactActive,
     isExternal,
     push,
     replace,

--- a/src/utilities/guards.ts
+++ b/src/utilities/guards.ts
@@ -1,3 +1,7 @@
+export function isDefined<T>(value: T | undefined): value is T {
+  return value !== undefined
+}
+
 export function isRecord(value: unknown): value is Record<PropertyKey, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value)
 }


### PR DESCRIPTION
# Description
The `isMatch` and `isExactMatch` properties of `useLink` and `router-link` give users insight into whether or not the link's route matches the current route based on the actual route definitions. This means for the route `/posts/[postId]` both `/posts/foo` and `/posts/bar` are exact matches if the current route is `/posts/baz`. and `/posts` is a match for all three. 

These aren't very useful when trying to determine if a link is the same as the current routes href (the url the user sees). 

Introducing `isActive` and `isExactActive` to address this. These properties focus on the hrefs/urls themselves. So in the posts example, if the current url is `/posts/baz`
| Link | Active | Exact Active |
|----------|----------|----------|
| `/posts/foo`   | false    | false     |
| `/posts/bar`   | false    | false     |
| `/posts/baz`  | true      | true      |
| `/posts`         | true      | false     |

Closes https://github.com/kitbagjs/router/issues/516