### PR TITLE
Make sure router view waits for the router to be started when doing SSR

### DIFF
--- a/src/components/routerView.spec.ts
+++ b/src/components/routerView.spec.ts
@@ -1,0 +1,29 @@
+import { createSSRApp } from 'vue'
+import { describe, it, expect } from 'vitest'
+import { createRoute } from '@/services/createRoute'
+import { createRouter } from '@/services/createRouter'
+import { renderToString } from 'vue/server-renderer'
+
+describe('SSR', () => {
+  it('should render the route', async () => {
+    const route = createRoute({
+      name: 'foo',
+      path: '/',
+      component: { template: 'hello world' },
+    })
+
+    const router = createRouter([route], {
+      initialUrl: '/',
+    })
+
+    const app = createSSRApp({
+      template: '<RouterView/>',
+    })
+
+    app.use(router)
+
+    const html = await renderToString(app)
+
+    expect(html).toMatchInlineSnapshot('"<!--[-->hello world<!--]-->"')
+  })
+})

--- a/src/components/routerView.vue
+++ b/src/components/routerView.vue
@@ -16,7 +16,7 @@
 </script>
 
 <script lang="ts" setup>
-  import { Component, UnwrapRef, VNode, computed, provide } from 'vue'
+  import { Component, UnwrapRef, VNode, computed, provide, onServerPrefetch } from 'vue'
   import { useRejection } from '@/compositions/useRejection'
   import { useRoute } from '@/compositions/useRoute'
   import { useRouterDepth } from '@/compositions/useRouterDepth'
@@ -31,9 +31,13 @@
   }>()
 
   const route = useRoute()
-  const { started } = useRouter()
+  const router = useRouter()
   const rejection = useRejection()
   const depth = useRouterDepth()
+
+  onServerPrefetch(async () => {
+    await router.start()
+  })
 
   const { getRouteComponents } = useComponentsStore()
 
@@ -48,7 +52,7 @@
   provide(depthInjectionKey, depth + 1)
 
   const component = computed(() => {
-    if (!started.value) {
+    if (!router.started.value) {
       return null
     }
 


### PR DESCRIPTION
# Description
Because the router's initialization is async the router view won't render anything when the vue app first starts. In we rely on reactivity to automatically render the route component when the router is finished initializing. But when doing SSR we need to make sure the router is initialized BEFORE we attempt to render anything. Leveraging `onServerPrefetch` let's vue know to wait to render the router view component until the router is finished initializing. 