### PR TITLE
Export useQueryValue composition

### DIFF
--- a/src/compositions/index.ts
+++ b/src/compositions/index.ts
@@ -1,6 +1,7 @@
 export * from './useLink'
 export { useRoute } from './useRoute'
 export { useRouter } from './useRouter'
+export { useQueryValue } from './useQueryValue'
 export {
   onBeforeRouteLeave,
   onBeforeRouteUpdate,


### PR DESCRIPTION
# Description
This composition was not in the compositions barrel so it was not exported as part of the public api. 

Closes #540 