### PR TITLE
Update type tests and fixes `ExtractParamType` returning `any`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,7 @@
   "cSpell.words": [
     "composables",
     "tseslint",
+    "Valibot",
     "vitepress"
   ],
 }

--- a/src/guards/routes.spec-d.ts
+++ b/src/guards/routes.spec-d.ts
@@ -31,49 +31,49 @@ test('router route can be narrowed', () => {
 
   const { route } = createRouter(routes)
 
-  expectTypeOf<typeof route.name>().toMatchTypeOf<'parentA' | 'parentB' | 'childA'>()
+  expectTypeOf<typeof route.name>().toEqualTypeOf<'parentA' | 'parentB' | 'childA'>()
 
   if (route.name === 'parentA') {
-    expectTypeOf<typeof route.name>().toMatchTypeOf<'parentA'>()
+    expectTypeOf<typeof route.name>().toEqualTypeOf<'parentA'>()
   }
 
   if (isRoute(route, 'parentA', { exact: true })) {
-    expectTypeOf<typeof route.name>().toMatchTypeOf<'parentA'>()
+    expectTypeOf<typeof route.name>().toEqualTypeOf<'parentA'>()
   }
 
   if (isRoute(route, 'parentB', { exact: true })) {
-    expectTypeOf<typeof route.name>().toMatchTypeOf<'parentB'>()
+    expectTypeOf<typeof route.name>().toEqualTypeOf<'parentB'>()
   }
 
   if (isRoute(route, 'parentA', { exact: false })) {
-    expectTypeOf<typeof route.name>().toMatchTypeOf<'parentA' | 'childA'>()
+    expectTypeOf<typeof route.name>().toEqualTypeOf<'parentA' | 'childA'>()
   }
 
   if (isRoute(route, 'parentB', { exact: false })) {
-    expectTypeOf<typeof route.name>().toMatchTypeOf<'parentB'>()
+    expectTypeOf<typeof route.name>().toEqualTypeOf<'parentB'>()
   }
 
   if (isRoute(route, 'parentA')) {
-    expectTypeOf<typeof route.name>().toMatchTypeOf<'parentA' | 'childA'>()
+    expectTypeOf<typeof route.name>().toEqualTypeOf<'parentA' | 'childA'>()
   }
 
   if (route.name === 'parentA') {
-    expectTypeOf<typeof route.params>().toMatchTypeOf<{}>()
+    expectTypeOf<typeof route.params>().toEqualTypeOf<{}>()
   }
 
   if (isRoute(route, 'parentA', { exact: true })) {
-    expectTypeOf<typeof route.params>().toMatchTypeOf<{}>()
+    expectTypeOf<typeof route.params>().toEqualTypeOf<{}>()
   }
 
   if (isRoute(route, 'parentA', { exact: false })) {
-    expectTypeOf<typeof route.params>().toMatchTypeOf<{
+    expectTypeOf<typeof route.params>().toEqualTypeOf<{} | {
       foo?: string | undefined,
       bar?: boolean | undefined,
     }>()
   }
 
   if (isRoute(route, 'parentA')) {
-    expectTypeOf<typeof route.params>().toMatchTypeOf<{
+    expectTypeOf<typeof route.params>().toEqualTypeOf<{} | {
       foo?: string | undefined,
       bar?: boolean | undefined,
     }>()

--- a/src/services/createRoute.spec-d.ts
+++ b/src/services/createRoute.spec-d.ts
@@ -40,7 +40,7 @@ test('options with path', () => {
   type Source = typeof route['path']
   type Expect = { value: '/foo', params: {} }
 
-  expectTypeOf<Source>().toMatchTypeOf<Expect>()
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
 })
 
 test('options with path and parent', () => {
@@ -53,7 +53,7 @@ test('options with path and parent', () => {
   type Source = typeof route['path']
   type Expect = { value: '/foo/bar', params: {} }
 
-  expectTypeOf<Source>().toMatchTypeOf<Expect>()
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
 })
 
 test('options with path with params', () => {
@@ -61,7 +61,7 @@ test('options with path with params', () => {
   type Source = typeof route['path']
   type Expect = { value: '/foo/[bar]', params: { bar: StringConstructor } }
 
-  expectTypeOf<Source>().toMatchTypeOf<Expect>()
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
 })
 
 test('options with path with params and parent', () => {
@@ -83,7 +83,7 @@ test('options with path with params and parent', () => {
     },
   }
 
-  expectTypeOf<Source>().toMatchTypeOf<Expect>()
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
 })
 
 test('options with path with params with custom param types', () => {
@@ -97,7 +97,7 @@ test('options with path with params with custom param types', () => {
     params: { bar: NumberConstructor },
   }
 
-  expectTypeOf<Source>().toMatchTypeOf<Expect>()
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
 })
 
 test('options with path with params with custom param types and parent', () => {
@@ -119,7 +119,7 @@ test('options with path with params with custom param types and parent', () => {
     },
   }
 
-  expectTypeOf<Source>().toMatchTypeOf<Expect>()
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
 })
 
 test('options with query', () => {
@@ -130,7 +130,7 @@ test('options with query', () => {
   type Source = typeof route['query']
   type Expect = { value: 'foo=bar', params: {} }
 
-  expectTypeOf<Source>().toMatchTypeOf<Expect>()
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
 })
 
 test('options with query and parent', () => {
@@ -146,7 +146,7 @@ test('options with query and parent', () => {
   type Source = typeof route['query']
   type Expect = { value: 'parent=parent&child=child', params: {} }
 
-  expectTypeOf<Source>().toMatchTypeOf<Expect>()
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
 })
 
 test('options with query with params', () => {
@@ -154,7 +154,7 @@ test('options with query with params', () => {
   type Source = typeof route['query']
   type Expect = { value: 'foo=[bar]', params: { bar: StringConstructor } }
 
-  expectTypeOf<Source>().toMatchTypeOf<Expect>()
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
 })
 
 test('options with query with params and parent', () => {
@@ -176,7 +176,7 @@ test('options with query with params and parent', () => {
     },
   }
 
-  expectTypeOf<Source>().toMatchTypeOf<Expect>()
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
 })
 
 test('options with query with params with custom param types', () => {
@@ -184,7 +184,7 @@ test('options with query with params with custom param types', () => {
   type Source = typeof route['query']
   type Expect = { value: 'foo=[bar]', params: { bar: NumberConstructor } }
 
-  expectTypeOf<Source>().toMatchTypeOf<Expect>()
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
 })
 
 test('options with query with params with custom param types and parent', () => {
@@ -206,7 +206,7 @@ test('options with query with params with custom param types and parent', () => 
     },
   }
 
-  expectTypeOf<Source>().toMatchTypeOf<Expect>()
+  expectTypeOf<Source>().toEqualTypeOf<Expect>()
 })
 
 test('options with hash', () => {
@@ -215,7 +215,7 @@ test('options with hash', () => {
   type Source = typeof route['hash']
   type Expect = { value: 'foo' }
 
-  expectTypeOf<Source>().toMatchTypeOf<Expect>()
+  expectTypeOf<Source>().toExtend<Expect>()
 })
 
 test('options with hash and parent', () => {
@@ -225,7 +225,7 @@ test('options with hash and parent', () => {
   type Source = typeof route['hash']
   type Expect = { value: 'parentchild' }
 
-  expectTypeOf<Source>().toMatchTypeOf<Expect>()
+  expectTypeOf<Source>().toExtend<Expect>()
 })
 
 test('options with meta', () => {

--- a/src/services/unionOf.ts
+++ b/src/services/unionOf.ts
@@ -3,7 +3,8 @@ import { Param, ParamGetSet } from '@/types/paramTypes'
 import { safeGetParamValue, safeSetParamValue } from '@/services/params'
 import { ExtractParamType } from '@/types/params'
 
-export function unionOf<const T extends Param[]>(params: T): ParamGetSet<ExtractParamType<T[number]>> {
+export function unionOf<const T extends Param[]>(params: T): ParamGetSet<ExtractParamType<T[number]>>
+export function unionOf(params: Param[]): ParamGetSet {
   return {
     get: (value, { invalid }) => {
       for (const param of params) {

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -73,7 +73,14 @@ export type ExtractParamName<
  * @returns A record of parameter names to their respective types, extracted and merged from both path and query parameters.
  */
 export type ExtractRouteParamTypesReading<TRoute extends Route> =
-  Identity<MakeOptional<ExtractParamTypesReading<TRoute['host']> & ExtractParamTypesReading<TRoute['path']> & ExtractParamTypesReading<TRoute['query']> & ExtractParamTypesReading<TRoute['hash']>>>
+  Identity<
+    MakeOptional<
+      ExtractParamTypesReading<TRoute['host']> &
+      ExtractParamTypesReading<TRoute['path']> &
+      ExtractParamTypesReading<TRoute['query']> &
+      ExtractParamTypesReading<TRoute['hash']>
+    >
+  >
 
 /**
  * Extracts combined types of path and query parameters for a given route, creating a unified parameter object.
@@ -115,12 +122,14 @@ export type ExtractParamTypesWriting<TWithParams extends WithParams> = {
  * @returns The extracted type, or 'string' as a fallback.
  */
 export type ExtractParamType<TParam extends Param> =
-  TParam extends ParamGetSet<infer Type>
-    ? Type
-    : TParam extends ParamGetter
-      ? ReturnType<TParam>
-      : TParam extends StandardSchemaV1
-        ? StandardSchemaV1.InferOutput<TParam>
-        : TParam extends LiteralParam
-          ? TParam
-          : string
+  Param extends TParam
+    ? unknown
+    : TParam extends ParamGetSet<infer Type>
+      ? Type
+      : TParam extends ParamGetter
+        ? ReturnType<TParam>
+        : TParam extends StandardSchemaV1
+          ? StandardSchemaV1.InferOutput<TParam>
+          : TParam extends LiteralParam
+            ? TParam
+            : string

--- a/src/types/register.spec.ts
+++ b/src/types/register.spec.ts
@@ -9,7 +9,7 @@ test('given routes, RegisteredRoutes is correct', () => {
 
   type Routes = RegisteredRoutes<{ router: typeof router }>
 
-  expectTypeOf<Routes>().toMatchTypeOf<typeof routes>()
+  expectTypeOf<Routes>().toEqualTypeOf<typeof routes>()
 })
 
 test('given rejections in router options, RegisteredRejectionType is correct', () => {
@@ -23,11 +23,11 @@ test('given rejections in router options, RegisteredRejectionType is correct', (
 
   type Rejections = RegisteredRejectionType<{ router: typeof router }>
 
-  expectTypeOf<Rejections>().toMatchTypeOf<'AuthNeeded' | 'NotFound'>()
+  expectTypeOf<Rejections>().toEqualTypeOf<'AuthNeeded' | 'NotFound'>()
 })
 
 test('given route meta in router options, RouteMeta is correct', () => {
   type Meta = RouteMeta<{ routeMeta: { zoo: number } }>
 
-  expectTypeOf<Meta>().toMatchTypeOf<{ zoo: number }>()
+  expectTypeOf<Meta>().toEqualTypeOf<{ zoo: number }>()
 })

--- a/src/types/resolved.spec-d.ts
+++ b/src/types/resolved.spec-d.ts
@@ -17,12 +17,12 @@ test('given a specific Route, params are narrow', () => {
     type Source = RouterRoute<ResolvedRoute<TestRoute>>['params']
     type Expect = { paramA: string, paramB: boolean, paramC?: string | undefined }
 
-    expectTypeOf<Expect>().toMatchTypeOf<Source>()
+    expectTypeOf<Expect>().toEqualTypeOf<Source>()
 })
 
 test('without a specific Route, params are Record<string, unknown>', () => {
   type Source = RouterRoute['params']
-  type Expect = Record<string, Readonly<unknown>>
+  type Expect = Record<string, unknown>
 
-  expectTypeOf<Expect>().toMatchTypeOf<Source>()
+  expectTypeOf<Expect>().toEqualTypeOf<Source>()
 })


### PR DESCRIPTION
# Description
Noticed that `toMatchTypeOf` was deprecated. Updated to using `toEqualTypeOf` which is more accurate and also found a bug in `ExtractParamType` where it would return `any` when it should return `undefined` in cases where the generic `Param` was passed. 