### PR TITLE
Adds documentation for props with named views

### DIFF
--- a/docs/core-concepts/component-props.md
+++ b/docs/core-concepts/component-props.md
@@ -16,6 +16,23 @@ This is obviously useful for assigning static values or route params down to you
 - Correct type for return type.
 - Support for async prop fetching.
 
+## Named Views
+When using the [`components`](/core-concepts/routes.html#components) property the `props` argument must be an object. Each component can have its own props callback.
+
+```ts {5-6,9-10}
+const user = createRoute({
+  name: 'user',
+  path: '/user/[id]',
+  components: {
+    defailt: UserComponent,
+    sidebar: UserSidebarComponent,
+  }
+}, {
+  default: (route) => ({ userId: route.params.id }),
+  sidebar: (route) => ({ userId: route.params.id })
+})
+```
+
 ## Params Type
 
 The params passed to your callback has all of the type context including params from parents and any defaults applied.


### PR DESCRIPTION
# Description
Adds documentation explaining how to use the `props` option with named views.

This enhancement clarifies how to configure props when using the `components` option in routes, where props need to be defined as an object with a callback for each named component.