### PR TITLE
move types to TS file, export with bundle

### DIFF
--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -1,6 +1,6 @@
 import RouterLink from '@/components/routerLink.vue'
 import RouterView from '@/components/routerView.vue'
-export type { ToCallback } from '@/components/routerLink.vue'
+export type { RouterLinkProps, ToCallback } from '@/components/routerLink'
 
 export { RouterView, RouterLink }
 

--- a/src/components/routerLink.ts
+++ b/src/components/routerLink.ts
@@ -1,0 +1,17 @@
+import { PrefetchConfig } from '@/types/prefetch'
+import { Url } from '@/types/url'
+import { ResolvedRoute } from '@/types/resolved'
+import { RegisteredRouter } from '@/types/register'
+
+export type ToCallback = (resolve: RegisteredRouter['resolve']) => ResolvedRoute | Url | undefined
+
+export type RouterLinkProps = {
+  /**
+   * The url string to navigate to or a callback that returns a url string
+   */
+  to: Url | ResolvedRoute | ToCallback,
+  /**
+   * Determines what assets are prefetched when router-link is rendered for this route. Overrides route level prefetch.
+   */
+  prefetch?: PrefetchConfig,
+}

--- a/src/components/routerLink.vue
+++ b/src/components/routerLink.vue
@@ -15,26 +15,12 @@
 
 <script setup lang="ts">
   import { computed } from 'vue'
-  import { PrefetchConfig } from '@/types/prefetch'
-  import { RegisteredRouter } from '@/types/register'
   import { RouterPushOptions } from '@/types/routerPush'
   import { Url, isUrl } from '@/types/url'
   import { ResolvedRoute } from '@/types/resolved'
   import { useRouter } from '@/compositions/useRouter'
   import { useLink } from '@/compositions/useLink'
-
-  export type ToCallback = (resolve: RegisteredRouter['resolve']) => ResolvedRoute | Url | undefined
-
-  type RouterLinkProps = {
-    /**
-     * The url string to navigate to or a callback that returns a url string
-     */
-    to: Url | ResolvedRoute | ToCallback,
-    /**
-     * Determines what assets are prefetched when router-link is rendered for this route. Overrides route level prefetch.
-     */
-    prefetch?: PrefetchConfig,
-  }
+  import { RouterLinkProps, ToCallback } from '@/components/routerLink'
 
   const props = withDefaults(defineProps<RouterLinkProps & RouterPushOptions>(), {
     // because prefetch can be a boolean vue automatically sets the default to false.


### PR DESCRIPTION
Adds `RouterLinkProps` type to our export

Request from [our discord](https://discord.com/channels/1240867447033172138/1240868059196030977/1394252118805975130)

> would be nice if RouterLinkProps was exported, for some reason ComponentProps<typeof RouterLink> from vue-component-type-helpers throws an error

Moved types out of the vue file into a TS file of the same name. Including those types in the barrel, thus the bundle