### PR TITLE
Add support for automatic reloading of the window if a vite:prefetchError event is detected

### DIFF
--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -33,6 +33,7 @@ import { getRoutesForRouter } from './getRoutesForRouter'
 import { getGlobalHooksForRouter } from './getGlobalHooksForRouter'
 import { componentsStoreKey, createComponentsStore } from './createComponentsStore'
 import { initZod, zotParamsDetected } from './zod'
+import { createRouterPreloadErrorRefresh } from './createRouterPreloadErrorRefresh'
 
 type RouterUpdateOptions = {
   replace?: boolean,
@@ -81,6 +82,7 @@ export function createRouter<
 >(routesOrArrayOfRoutes: TRoutes | TRoutes[], options?: TOptions, plugins: TPlugin[] = []): Router<TRoutes, TOptions, TPlugin> {
   const routes = getRoutesForRouter(routesOrArrayOfRoutes, plugins, options?.base)
   const hookStore = createRouterHooks()
+  const preloadErrorRefresh = createRouterPreloadErrorRefresh({ refreshOnPreloadError: options?.refreshOnPreloadError })
 
   hookStore.addGlobalRouteHooks(getGlobalHooksForRouter(options, plugins))
 
@@ -333,6 +335,8 @@ export function createRouter<
     // So we're making an assumption here that when installing a router its the same as the RegisteredRouter
     app.provide(routerInjectionKey, router as any)
 
+    preloadErrorRefresh.initialize()
+
     start()
   }
 
@@ -355,6 +359,7 @@ export function createRouter<
     onAfterRouteEnter: hookStore.onAfterRouteEnter,
     onAfterRouteUpdate: hookStore.onAfterRouteUpdate,
     onAfterRouteLeave: hookStore.onAfterRouteLeave,
+    onBeforePreloadErrorRefresh: preloadErrorRefresh.onBeforePreloadErrorRefresh,
     prefetch: options?.prefetch,
     start,
     started,

--- a/src/services/createRouterPreloadErrorRefresh.ts
+++ b/src/services/createRouterPreloadErrorRefresh.ts
@@ -1,0 +1,65 @@
+import { isBrowser } from '@/utilities/isBrowser'
+import { onUnmounted } from 'vue'
+
+type RouterPreloadErrorOptions = {
+  refreshOnPreloadError?: boolean,
+}
+
+type RouterPreloadError = {
+  initialize: () => void,
+  onBeforePreloadErrorRefresh: (hook: RouterPreloadErrorHook) => void,
+}
+
+type RouterPreloadErrorHookParameters = {
+  event: Event,
+  abort: () => void,
+}
+
+export type RouterPreloadErrorHook = (parameters: RouterPreloadErrorHookParameters) => void
+
+export function createRouterPreloadErrorRefresh({ refreshOnPreloadError = true }: RouterPreloadErrorOptions): RouterPreloadError {
+  const hooks = new Set<RouterPreloadErrorHook>()
+
+  function initialize(): void {
+    if (isBrowser() && refreshOnPreloadError) {
+      window.addEventListener('vite:preloadError', (event) => {
+        try {
+          hooks.forEach((hook) => {
+            hook({ event, abort })
+          })
+
+          window.location.reload()
+        } catch (error) {
+          if (error instanceof RouterPreloadErrorAbort) {
+            return
+          }
+
+          throw error
+        }
+      })
+    }
+  }
+
+  function onBeforePreloadErrorRefresh(hook: RouterPreloadErrorHook): void {
+    hooks.add(hook)
+
+    onUnmounted(() => {
+      hooks.delete(hook)
+    })
+  }
+
+  function abort(): void {
+    throw new RouterPreloadErrorAbort()
+  }
+
+  return {
+    initialize,
+    onBeforePreloadErrorRefresh,
+  }
+}
+
+class RouterPreloadErrorAbort extends Error {
+  public constructor() {
+    super('Router preload error aborted')
+  }
+}

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -11,6 +11,7 @@ import { RouterResolve, RouterResolveOptions } from '@/types/RouterResolve'
 import { RouterReject } from './routerReject'
 import { RouterPlugin } from './routerPlugin'
 import { KeysOfUnion } from './utilities'
+import { RouterPreloadErrorHook } from '@/services/createRouterPreloadErrorRefresh'
 
 /**
  * Options to initialize a {@link Router} instance.
@@ -41,6 +42,10 @@ export type RouterOptions = WithHooks & {
    * Components assigned to each type of rejection your router supports.
    */
   rejections?: Partial<Record<string, Component>>,
+  /**
+   * Whether to refresh the router when a vite preload error occurs.
+   */
+  refreshOnPreloadError?: boolean,
 }
 
 export type Router<
@@ -117,6 +122,10 @@ export type Router<
    * Registers a hook to be called after a route is updated.
    */
   onAfterRouteUpdate: AddAfterRouteHook,
+  /**
+   * Registers a hook to be called before a preload error occurs.
+   */
+  onBeforePreloadErrorRefresh: (hook: RouterPreloadErrorHook) => void,
   /**
   * Given a URL, returns true if host does not match host stored on router instance
   */


### PR DESCRIPTION
# Description
Attempting to add automatic detection of vite preload errors that will automatically refresh the app. Based off of [this article](https://paulau.dev/blog/handle-version-skew-after-new-deployment-with-vite-and-vue-router/) by @romansp 

This is untested and I need to write some tests as well as figure out how to test if this actually works in the real world. 