### PR TITLE
Export RegisteredRoutesName

### DIFF
--- a/src/types/register.ts
+++ b/src/types/register.ts
@@ -3,6 +3,7 @@ import { Route, Routes } from '@/types/route'
 import { Router, RouterOptions } from '@/types/router'
 import { RouterPush } from '@/types/routerPush'
 import { RouterReplace } from '@/types/routerReplace'
+import { RoutesName } from './routesMap'
 
 /**
  * Represents the state of currently registered router, and route meta. Used to provide correct type context for
@@ -29,6 +30,7 @@ export type RegisteredRouter<T = Register> = T extends { router: infer TRouter }
 
 /**
  * Represents the Router routes property within {@link Register}
+ * @deprecated will be removed in a future version
  */
 export type RegisteredRoutes<T = Register> = T extends { router: Router<infer TRoutes extends Routes> }
   ? TRoutes
@@ -50,15 +52,24 @@ export type RouteMeta<T = Register> = T extends { routeMeta: infer RouteMeta ext
 
 /**
  * Represents the type for router `push`, with types for routes registered within {@link Register}
+ * @deprecated will be removed in a future version
  */
 export type RegisteredRouterPush = RouterPush<RegisteredRoutes>
 
 /**
  * Represents the type for router `replace`, with types for routes registered within {@link Register}
+ * @deprecated will be removed in a future version
  */
 export type RegisteredRouterReplace = RouterReplace<RegisteredRoutes>
 
 /**
  * Type for Router Reject method. Triggers rejections registered within {@link Register}
+ * @deprecated will be removed in a future version
  */
 export type RegisteredRouterReject = (type: RegisteredRejectionType) => void
+
+/**
+ * Represents the union of all possible route names registered within {@link Register}
+ * @deprecated will be removed in a future version
+ */
+export type RegisteredRoutesName = RoutesName<RegisteredRoutes>


### PR DESCRIPTION
# Description
Removed in https://github.com/kitbagjs/router/pull/563 but being used by end users and we don't offer a replacement yet. So adding back the type but marking it and other register types as deprecated