### PR TITLE
remove some test helpers

### DIFF
--- a/src/services/createRouterRoute.spec.ts
+++ b/src/services/createRouterRoute.spec.ts
@@ -1,27 +1,30 @@
 import { expect, test, vi } from 'vitest'
 import { reactive } from 'vue'
 import { createRouterRoute, isRouterRoute } from '@/services/createRouterRoute'
-import { mockResolvedRoute, mockRoute } from '@/utilities/testHelpers'
+import { createRoute } from './createRoute'
+import { createResolvedRoute } from './createResolvedRoute'
 
 test('isRouterRoute returns correct response', () => {
-  const resolved = mockResolvedRoute(mockRoute('isRouterRoute'), [])
+  const route = createRoute({ name: 'isRouterRoute' })
+  const resolved = createResolvedRoute(route, {})
   const push = vi.fn()
   const routerKey = Symbol()
 
-  const route = createRouterRoute(routerKey, reactive(resolved), push)
+  const routerRoute = createRouterRoute(routerKey, reactive(resolved), push)
 
-  expect(isRouterRoute(routerKey, route)).toBe(true)
+  expect(isRouterRoute(routerKey, routerRoute)).toBe(true)
   expect(isRouterRoute(routerKey, {})).toBe(false)
 })
 
 test('sending state, includes state in push options', () => {
-  const resolved = mockResolvedRoute(mockRoute('state'), [])
+  const route = createRoute({ name: 'state' })
+  const resolved = createResolvedRoute(route, {})
   const push = vi.fn()
   const routerKey = Symbol()
 
-  const route = createRouterRoute(routerKey, reactive(resolved), push)
+  const routerRoute = createRouterRoute(routerKey, reactive(resolved), push)
 
-  route.update({}, { state: { foo: 'foo' } })
+  routerRoute.update({}, { state: { foo: 'foo' } })
 
   expect(push).toBeCalledWith(
     'state',
@@ -29,7 +32,7 @@ test('sending state, includes state in push options', () => {
     { state: { foo: 'foo' } },
   )
 
-  route.update('param', 123, { state: { bar: 'bar' } })
+  routerRoute.update('param', 123, { state: { bar: 'bar' } })
 
   expect(push).toBeCalledWith(
     'state',

--- a/src/utilities/testHelpers.ts
+++ b/src/utilities/testHelpers.ts
@@ -1,8 +1,4 @@
-import { vi } from 'vitest'
-import { withParams } from '@/services/withParams'
-import { createResolvedRouteQuery } from '@/services/createResolvedRouteQuery'
 import { createRoute } from '@/services/createRoute'
-import { ResolvedRoute } from '@/types/resolved'
 
 export const random = {
   number(options: { min?: number, max?: number } = {}): number {
@@ -66,35 +62,3 @@ export const routes = [
     component,
   }),
 ] as const
-
-export function mockRoute(name: string): ResolvedRoute['matched'] {
-  return {
-    id: Math.random().toString(),
-    name,
-    path: withParams(`/${name}`, {}),
-    component,
-    onBeforeRouteEnter: [vi.fn()],
-    onBeforeRouteUpdate: [vi.fn()],
-    onBeforeRouteLeave: [vi.fn()],
-    meta: {},
-    state: {},
-  }
-}
-
-export function mockResolvedRoute(matched: ResolvedRoute['matched'], matches: ResolvedRoute['matched'][]): ResolvedRoute {
-  if (!matched.name) {
-    throw new Error('name is required')
-  }
-
-  return {
-    id: matched.id,
-    matched,
-    matches,
-    name: matched.name,
-    query: createResolvedRouteQuery(),
-    params: {},
-    state: {},
-    href: '/',
-    hash: '',
-  }
-}


### PR DESCRIPTION
This PR removes 2 test utilities
- mockRoute
- mockResolvedRoute

My motivation
- in my experience, these utilities offer little value over just calling `createRoute` and `createResolvedRoute` in the test
- as these types change, these utilities also need to be maintained
- when updates are made to these utilities, it tends to be non-realistic - like `createResolvedRoute` will expect that `hooks` array like `matches`. The simple fix is to just send an empty array, which is not actually accurate and might cause false positives or false negatives.
- they're only used in 2 test files