### PR TITLE
return `satisfies` to create route and create external route

### DIFF
--- a/src/services/createExternalRoute.ts
+++ b/src/services/createExternalRoute.ts
@@ -45,7 +45,7 @@ export function createExternalRoute(options: CreateRouteOptions & (WithoutHost |
     state: {},
     context,
     onBeforeRouteEnter,
-  }
+  } satisfies Route & ExternalRouteHooks
 
   const merged = isWithParent(options) ? combineRoutes(options.parent, route) : route
 

--- a/src/services/createRoute.ts
+++ b/src/services/createRoute.ts
@@ -53,7 +53,7 @@ export function createRoute(options: CreateRouteOptions, props?: CreateRouteProp
     host: withParams(),
     prefetch: options.prefetch,
     ...hooks,
-  }
+  } satisfies Route & InternalRouteHooks
 
   const merged = isWithParent(options) ? combineRoutes(options.parent, route) : route
 

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -3,7 +3,7 @@ import { Route } from '@/types/route'
 import { RouterReject } from './routerReject'
 import { RouterPush } from './routerPush'
 import { RouterReplace } from './routerReplace'
-import { RouteContextToRejection, RouteContextToRoute } from './routeContext'
+import { RouteContext, RouteContextToRejection, RouteContextToRoute } from './routeContext'
 
 /**
  * Context provided to props callback functions
@@ -11,11 +11,17 @@ import { RouteContextToRejection, RouteContextToRoute } from './routeContext'
 export type PropsCallbackContext<
   TOptions extends CreateRouteOptions = CreateRouteOptions
 > = {
-  reject: RouterReject<RouteContextToRejection<TOptions['context']>>,
-  push: RouterPush<RouteContextToRoute<TOptions['context']>>,
-  replace: RouterReplace<RouteContextToRoute<TOptions['context']>>,
+  reject: RouterReject<RouteContextToRejection<ExtractRouteContext<TOptions>>>,
+  push: RouterPush<RouteContextToRoute<ExtractRouteContext<TOptions>>>,
+  replace: RouterReplace<RouteContextToRoute<ExtractRouteContext<TOptions>>>,
   parent: PropsCallbackParent<TOptions['parent']>,
 }
+
+type ExtractRouteContext<
+  TOptions extends CreateRouteOptions
+> = TOptions extends { context: infer TContext extends RouteContext[] }
+  ? TContext
+  : []
 
 export type PropsCallbackParent<
   TParent extends Route | undefined = Route | undefined

--- a/src/types/routeContext.ts
+++ b/src/types/routeContext.ts
@@ -1,5 +1,5 @@
 import { Rejection } from './rejection'
-import { GenericRoute } from './route'
+import { GenericRoute, Route } from './route'
 
 export type RouteContext = GenericRoute | Rejection
 
@@ -9,9 +9,9 @@ export type ToRouteContext<TContext extends RouteContext[] | undefined> = TConte
 
 export type RouteContextToRoute<TContext extends RouteContext[] | undefined> =
 RouteContext[] extends TContext
-  ? []
+  ? Route[]
   : undefined extends TContext
-    ? []
+    ? Route[]
     : FilterRouteContextRoutes<TContext>
 
 type FilterRouteContextRoutes<TContext extends RouteContext[] | undefined> =
@@ -23,9 +23,9 @@ TContext extends [infer First, ...infer Rest extends RouteContext[]]
 
 export type RouteContextToRejection<TContext extends RouteContext[] | undefined> =
 RouteContext[] extends TContext
-  ? []
+  ? Rejection[]
   : undefined extends TContext
-    ? []
+    ? Rejection[]
     : FilterRouteContextRejections<TContext>
 
 type FilterRouteContextRejections<TContext extends RouteContext[] | undefined> =


### PR DESCRIPTION
This PR reverts a couple changes from #616 that required loosening type in createRoute and createExternalRoute services. When given an empty object for options (or any options without the `context` property) TS was using `unknown`.  All we needed here was a `ExtractRouteContext` type that narrows the type of context in situations where it's supplied something that doesn't match `RouteContext[]`. 

I chose to use `infer`, but even if I just checked `TOptions['context']` the result is the same. 