### PR TITLE
Fix circular type annotation issue with Register type

### DIFF
--- a/src/services/createRoute.ts
+++ b/src/services/createRoute.ts
@@ -1,6 +1,6 @@
 import { markRaw } from 'vue'
 import { createRouteId } from '@/services/createRouteId'
-import { CreateRouteOptions, PropsGetter, CreateRouteProps, ToRoute, combineRoutes, isWithParent } from '@/types/createRouteOptions'
+import { CreateRouteOptions, PropsGetter, CreateRouteProps, ToRoute, combineRoutes, isWithParent, RouterViewPropsGetter } from '@/types/createRouteOptions'
 import { toName } from '@/types/name'
 import { Route } from '@/types/route'
 import { checkDuplicateParams } from '@/utilities/checkDuplicateKeys'
@@ -11,13 +11,15 @@ import { InternalRouteHooks } from '@/types/hooks'
 type CreateRouteWithProps<
   TOptions extends CreateRouteOptions,
   TProps extends CreateRouteProps<TOptions>
-> = CreateRouteProps<TOptions> extends PropsGetter<TOptions>
-  ? Partial<ReturnType<CreateRouteProps<TOptions>>> extends ReturnType<CreateRouteProps<TOptions>>
-    ? [ props?: TProps ]
-    : [ props: TProps ]
-  : Partial<CreateRouteProps<TOptions>> extends CreateRouteProps<TOptions>
-    ? [ props?: TProps ]
-    : [ props: TProps ]
+> = CreateRouteProps<TOptions> extends RouterViewPropsGetter<TOptions>
+  ? [ props?: RouterViewPropsGetter<TOptions> ]
+  : CreateRouteProps<TOptions> extends PropsGetter<TOptions>
+    ? Partial<ReturnType<CreateRouteProps<TOptions>>> extends ReturnType<CreateRouteProps<TOptions>>
+      ? [ props?: TProps ]
+      : [ props: TProps ]
+    : Partial<CreateRouteProps<TOptions>> extends CreateRouteProps<TOptions>
+      ? [ props?: TProps ]
+      : [ props: TProps ]
 
 export function createRoute<
   const TOptions extends CreateRouteOptions,

--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -12,13 +12,13 @@ import { ResolvedRoute } from './resolved'
 import { ComponentProps } from '@/services/component'
 import { PropsCallbackContext } from './props'
 import { MaybePromise } from './utilities'
-import { RouterView } from '@/main'
 import { ToMeta } from './meta'
 import { ToState } from './state'
 import { ToName } from './name'
 import { WithHooks } from './hooks'
 import { ToWithParams, WithParams } from '@/services/withParams'
 import { RouteContext, ToRouteContext } from './routeContext'
+import { RouterViewProps } from '@/components/routerView'
 
 export type WithHost<THost extends string | WithParams = string | WithParams> = {
   /**
@@ -125,6 +125,10 @@ export type PropsGetter<
   TComponent extends Component = Component
 > = (route: ResolvedRoute<ToRoute<TOptions, undefined>>, context: PropsCallbackContext<TOptions>) => MaybePromise<ComponentProps<TComponent>>
 
+export type RouterViewPropsGetter<
+  TOptions extends CreateRouteOptions = CreateRouteOptions
+> = (route: ResolvedRoute<ToRoute<TOptions, undefined>>, context: PropsCallbackContext<TOptions>) => MaybePromise<RouterViewProps & Record<string, unknown>>
+
 type ComponentPropsAreOptional<
   TComponent extends Component
 > = Partial<ComponentProps<TComponent>> extends ComponentProps<TComponent>
@@ -143,7 +147,7 @@ export type CreateRouteProps<
   ? PropsGetter<TOptions, TOptions['component']>
   : TOptions['components'] extends Record<string, Component>
     ? RoutePropsRecord<TOptions, TOptions['components']>
-    : PropsGetter<TOptions, typeof RouterView>
+    : RouterViewPropsGetter<TOptions>
 
 type ToMatch<
   TOptions extends CreateRouteOptions,


### PR DESCRIPTION
## Description
Every since https://github.com/kitbagjs/router/pull/563 where `createRouterAssets` was introduced we've been chasing our tails around circular type annotation issues. 

<img width="572" height="263" alt="image" src="https://github.com/user-attachments/assets/0add0da8-409c-4050-bdaf-5e82f85d520e" />

Finally tracked this down to referencing `typeof RouterView` in `CreateRouteOptions` because when no component is provided `RouterView` is used as the default. But we can easily just statically type this based on the prop type for `RouterView` rather than trying to infer it. Which appears to fix the circular annotation issue. 
