### PR TITLE
using readonly Rejection[] similar to Routes type

### DIFF
--- a/src/services/createComponentHooks.ts
+++ b/src/services/createComponentHooks.ts
@@ -4,7 +4,7 @@ import { createUseRouterHooks } from '@/compositions/useRouterHooks'
 import { AddRouterAfterRouteHook, AddRouterBeforeRouteHook, AfterRouteHookLifecycle, BeforeRouteHookLifecycle, RouterAfterRouteHook, RouterBeforeRouteHook } from '@/types/hooks'
 import { Routes } from '@/types/route'
 import { Router, RouterRejections, RouterRoutes } from '@/types/router'
-import { Rejection } from '@/types/rejection'
+import { Rejections } from '@/types/rejection'
 
 function createComponentBeforeHook<TRouter extends Router>(routerKey: InjectionKey<TRouter>, lifecycle: BeforeRouteHookLifecycle): AddRouterBeforeRouteHook<RouterRoutes<TRouter>, RouterRejections<TRouter>>
 function createComponentBeforeHook(routerKey: symbol, lifecycle: BeforeRouteHookLifecycle): AddRouterBeforeRouteHook {
@@ -42,7 +42,7 @@ function createComponentAfterHook(routerKey: symbol, lifecycle: AfterRouteHookLi
 
 type ComponentHooks<
   TRoutes extends Routes,
-  TRejections extends Rejection[]
+  TRejections extends Rejections
 > = {
   onBeforeRouteLeave: AddRouterBeforeRouteHook<TRoutes, TRejections>,
   onBeforeRouteUpdate: AddRouterBeforeRouteHook<TRoutes, TRejections>,

--- a/src/services/createRouterCallbackContext.ts
+++ b/src/services/createRouterCallbackContext.ts
@@ -10,7 +10,7 @@ import { InjectionKey } from 'vue'
 import { BuiltInRejectionType } from './createRouterReject'
 import { AsString } from '@/types/utilities'
 import { Routes } from '@/types/route'
-import { Rejection } from '@/types/rejection'
+import { Rejections } from '@/types/rejection'
 
 /**
  * Defines the structure of a successful callback response.
@@ -49,7 +49,7 @@ export type CallbackContextAbort = () => void
 
 export type RouterCallbackContext<
   TRoutes extends Routes = Routes,
-  TRejections extends Rejection[] = Rejection[]
+  TRejections extends Rejections = Rejections
 > = {
   reject: RouterReject<TRejections>,
   push: RouterPush<TRoutes>,
@@ -64,7 +64,7 @@ export function createRouterCallbackContext<TRouter extends Router>(_routerKey: 
 
 export function createRouterCallbackContext<
   TRoutes extends Routes,
-  TRejections extends Rejection[]
+  TRejections extends Rejections
 >(): RouterCallbackContext<TRoutes, TRejections>
 
 export function createRouterCallbackContext(): RouterCallbackContext {

--- a/src/services/createRouterPlugin.ts
+++ b/src/services/createRouterPlugin.ts
@@ -1,12 +1,12 @@
 import { CreateRouterPluginOptions, RouterPlugin, PluginRouteHooks } from '@/types/routerPlugin'
 import { createRouteHooks } from './createRouteHooks'
 import { asArray } from '@/utilities'
-import { Rejection } from '@/types/rejection'
+import { Rejections } from '@/types/rejection'
 import { Routes } from '@/types/route'
 
 export function createRouterPlugin<
   TRoutes extends Routes = Routes,
-  TRejections extends Rejection[] = Rejection[]
+  TRejections extends Rejections = Rejections
 >(plugin: CreateRouterPluginOptions<TRoutes, TRejections>): RouterPlugin<TRoutes, TRejections> & PluginRouteHooks<TRoutes, TRejections>
 
 export function createRouterPlugin(plugin: CreateRouterPluginOptions): RouterPlugin {

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -6,7 +6,7 @@ import { Routes } from './route'
 import { RouterReject } from './routerReject'
 import { RouterPush } from './routerPush'
 import { RouterReplace } from './routerReplace'
-import { Rejection } from './rejection'
+import { Rejections } from './rejection'
 import { RouteContext, RouteContextToRejection, RouteContextToRoute } from './routeContext'
 
 /**
@@ -91,7 +91,7 @@ export type RouteHookTiming = 'global' | 'component'
 
 type BeforeRouteHookRegistration<
   TRoutes extends Routes,
-  TRejections extends Rejection[]
+  TRejections extends Rejections
 > = {
   lifecycle: 'onBeforeRouteEnter' | 'onBeforeRouteUpdate' | 'onBeforeRouteLeave',
   hook: RouterBeforeRouteHook<TRoutes, TRejections>,
@@ -100,12 +100,12 @@ type BeforeRouteHookRegistration<
 
 export type AddComponentBeforeRouteHook<
   TRoutes extends Routes = Routes,
-  TRejections extends Rejection[] = Rejection[]
+  TRejections extends Rejections = Rejections
 > = (hook: BeforeRouteHookRegistration<TRoutes, TRejections>) => RouteHookRemove
 
 type AfterRouteHookRegistration<
   TRoutes extends Routes = Routes,
-  TRejections extends Rejection[] = Rejection[]
+  TRejections extends Rejections = Rejections
 > = {
   lifecycle: 'onAfterRouteEnter' | 'onAfterRouteUpdate' | 'onAfterRouteLeave',
   hook: RouterAfterRouteHook<TRoutes, TRejections>,
@@ -114,7 +114,7 @@ type AfterRouteHookRegistration<
 
 export type AddComponentAfterRouteHook<
   TRoutes extends Routes = Routes,
-  TRejections extends Rejection[] = Rejection[]
+  TRejections extends Rejections = Rejections
 > = (hook: AfterRouteHookRegistration<TRoutes, TRejections>) => RouteHookRemove
 
 export type AddGlobalRouteHooks = (hooks: RouterRouteHooks) => void
@@ -203,7 +203,7 @@ export type RouteHookResponse = BeforeRouteHookResponse | AfterRouteHookResponse
 
 type RouterHookContext<
   TRoutes extends Routes,
-  TRejections extends Rejection[]
+  TRejections extends Rejections
 > = {
   from: RouterResolvedRouteUnion<TRoutes> | null,
   reject: RouterReject<TRejections>,
@@ -213,7 +213,7 @@ type RouterHookContext<
 
 type RouterBeforeRouteHookContext<
   TRoutes extends Routes,
-  TRejections extends Rejection[]
+  TRejections extends Rejections
 > = RouterHookContext<TRoutes, TRejections> & {
   abort: CallbackContextAbort,
 }
@@ -225,27 +225,27 @@ export type HookContext<TRoutes extends Routes = Routes> = {
 
 export type RouterBeforeRouteHook<
   TRoutes extends Routes = Routes,
-  TRejections extends Rejection[] = Rejection[]
+  TRejections extends Rejections = Rejections
 > = (to: RouterResolvedRouteUnion<TRoutes>, context: RouterBeforeRouteHookContext<TRoutes, TRejections>) => MaybePromise<void>
 
 export type AddRouterBeforeRouteHook<
   TRoutes extends Routes = Routes,
-  TRejections extends Rejection[] = Rejection[]
+  TRejections extends Rejections = Rejections
 > = (hook: RouterBeforeRouteHook<TRoutes, TRejections>) => RouteHookRemove
 
 type RouterAfterRouteHookContext<
   TRoutes extends Routes = Routes,
-  TRejections extends Rejection[] = Rejection[]
+  TRejections extends Rejections = Rejections
 > = RouterHookContext<TRoutes, TRejections>
 
 export type RouterAfterRouteHook<
   TRoutes extends Routes = Routes,
-  TRejections extends Rejection[] = Rejection[]
+  TRejections extends Rejections = Rejections
 > = (to: RouterResolvedRouteUnion<TRoutes>, context: RouterAfterRouteHookContext<TRoutes, TRejections>) => MaybePromise<void>
 
 export type AddRouterAfterRouteHook<
   TRoutes extends Routes = Routes,
-  TRejections extends Rejection[] = Rejection[]
+  TRejections extends Rejections = Rejections
 > = (hook: RouterAfterRouteHook<TRoutes, TRejections>) => RouteHookRemove
 
 export type RouterRouteHookBeforeRunner = (context: HookContext) => Promise<BeforeRouteHookResponse>
@@ -253,7 +253,7 @@ export type RouterRouteHookAfterRunner = (context: HookContext) => Promise<After
 
 export type RouterErrorHookContext<
   TRoutes extends Routes = Routes,
-  TRejections extends Rejection[] = Rejection[]
+  TRejections extends Rejections = Rejections
 > = {
   to: RouterResolvedRouteUnion<TRoutes>,
   from: RouterResolvedRouteUnion<TRoutes> | null,
@@ -265,12 +265,12 @@ export type RouterErrorHookContext<
 
 export type RouterErrorHook<
   TRoutes extends Routes = Routes,
-  TRejections extends Rejection[] = Rejection[]
+  TRejections extends Rejections = Rejections
 > = (error: unknown, context: RouterErrorHookContext<TRoutes, TRejections>) => void
 
 export type AddRouterErrorHook<
   TRoutes extends Routes = Routes,
-  TRejections extends Rejection[] = Rejection[]
+  TRejections extends Rejections = Rejections
 > = (hook: RouterErrorHook<TRoutes, TRejections>) => RouteHookRemove
 
 export type RouterRouteHookErrorRunnerContext<TRoutes extends Routes = Routes> = {

--- a/src/types/rejection.ts
+++ b/src/types/rejection.ts
@@ -1,5 +1,10 @@
 import { Component } from 'vue'
 
+/**
+ * Represents an immutable array of Rejection instances.
+ */
+export type Rejections = readonly Rejection[]
+
 export type Rejection<TType extends string = string> = {
   /**
    * The type of rejection.
@@ -11,15 +16,15 @@ export type Rejection<TType extends string = string> = {
   component: Component,
 }
 
-export type RejectionType<TRejections extends Rejection[] | undefined> =
+export type RejectionType<TRejections extends Rejections | undefined> =
 unknown extends TRejections
   ? never
-  : Rejection[] extends TRejections
+  : Rejections extends TRejections
     ? string
     : undefined extends TRejections
       ? string
-      : TRejections extends Rejection[]
+      : TRejections extends Rejections
         ? TRejections[number]['type']
         : never
 
-export type ExtractRejections<T> = T extends { rejections: infer TRejections extends Rejection[] } ? TRejections : []
+export type ExtractRejections<T> = T extends { rejections: infer TRejections extends Rejections } ? TRejections : []

--- a/src/types/routeContext.ts
+++ b/src/types/routeContext.ts
@@ -1,17 +1,17 @@
-import { Rejection } from './rejection'
-import { GenericRoute, Route } from './route'
+import { Rejection, Rejections } from './rejection'
+import { GenericRoute, Routes } from './route'
 
 export type RouteContext = GenericRoute | Rejection
 
-export type ToRouteContext<TContext extends RouteContext[] | undefined> = TContext extends RouteContext[]
+export type ToRouteContext<TContext extends RouteContext[] | readonly RouteContext[] | undefined> = TContext extends RouteContext[]
   ? TContext
   : []
 
 export type RouteContextToRoute<TContext extends RouteContext[] | undefined> =
 RouteContext[] extends TContext
-  ? Route[]
+  ? Routes
   : undefined extends TContext
-    ? Route[]
+    ? Routes
     : FilterRouteContextRoutes<TContext>
 
 type FilterRouteContextRoutes<TContext extends RouteContext[] | undefined> =
@@ -23,9 +23,9 @@ TContext extends [infer First, ...infer Rest extends RouteContext[]]
 
 export type RouteContextToRejection<TContext extends RouteContext[] | undefined> =
 RouteContext[] extends TContext
-  ? Rejection[]
+  ? Rejections
   : undefined extends TContext
-    ? Rejection[]
+    ? Rejections
     : FilterRouteContextRejections<TContext>
 
 type FilterRouteContextRejections<TContext extends RouteContext[] | undefined> =

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -12,7 +12,7 @@ import { RouterReject } from '@/types/routerReject'
 import { RouterPlugin } from '@/types/routerPlugin'
 import { RoutesName } from '@/types/routesMap'
 import { ToRouteContext } from '@/types/routeContext'
-import { ExtractRejections, Rejection } from '@/types/rejection'
+import { ExtractRejections, Rejections } from '@/types/rejection'
 
 /**
  * Options to initialize a {@link Router} instance.
@@ -42,7 +42,7 @@ export type RouterOptions = WithHooks & {
   /**
    * Components assigned to each type of rejection your router supports.
    */
-  rejections?: Rejection[],
+  rejections?: Rejections,
 
   /**
    * When false, createRouterAssets must be used for component and hooks. Assets exported by the library

--- a/src/types/routerPlugin.ts
+++ b/src/types/routerPlugin.ts
@@ -1,7 +1,7 @@
 import { BeforeRouteHook, AfterRouteHook, RouteHookRemove } from './hooks'
 import { Routes } from './route'
 import { MaybeArray, MaybePromise } from './utilities'
-import { Rejection } from './rejection'
+import { Rejections } from './rejection'
 import { RouterRouteHooks } from '@/models/RouterRouteHooks'
 import { ResolvedRoute } from './resolved'
 import { RouterReject } from './routerReject'
@@ -13,7 +13,7 @@ export type EmptyRouterPlugin = RouterPlugin<[], []>
 
 export type CreateRouterPluginOptions<
   TRoutes extends Routes = Routes,
-  TRejections extends Rejection[] = Rejection[]
+  TRejections extends Rejections = Rejections
 > = {
   routes?: TRoutes,
   rejections?: TRejections,
@@ -45,7 +45,7 @@ export type CreateRouterPluginOptions<
 
 export type RouterPlugin<
   TRoutes extends Routes = Routes,
-  TRejections extends Rejection[] = Rejection[]
+  TRejections extends Rejections = Rejections
 > = {
   /**
    * The routes supplied by the plugin.
@@ -66,7 +66,7 @@ export type RouterPlugin<
 
 type PluginBeforeRouteHookContext<
   TRoutes extends Routes,
-  TRejections extends Rejection[]
+  TRejections extends Rejections
 > = {
   from: ResolvedRoute | null,
   reject: RouterReject<TRejections>,
@@ -77,7 +77,7 @@ type PluginBeforeRouteHookContext<
 
 type PluginAfterRouteHookContext<
   TRoutes extends Routes,
-  TRejections extends Rejection[]
+  TRejections extends Rejections
 > = {
   from: ResolvedRoute | null,
   reject: RouterReject<TRejections>,
@@ -87,27 +87,27 @@ type PluginAfterRouteHookContext<
 
 export type PluginBeforeRouteHook<
   TRoutes extends Routes = Routes,
-  TRejections extends Rejection[] = Rejection[]
+  TRejections extends Rejections = Rejections
 > = (to: ResolvedRoute, context: PluginBeforeRouteHookContext<TRoutes, TRejections>) => MaybePromise<void>
 
 export type PluginAfterRouteHook<
   TRoutes extends Routes = Routes,
-  TRejections extends Rejection[] = Rejection[]
+  TRejections extends Rejections = Rejections
 > = (to: ResolvedRoute, context: PluginAfterRouteHookContext<TRoutes, TRejections>) => MaybePromise<void>
 
 type AddPluginBeforeRouteHook<
   TRoutes extends Routes,
-  TRejections extends Rejection[]
+  TRejections extends Rejections
 > = (hook: PluginBeforeRouteHook<TRoutes, TRejections>) => RouteHookRemove
 
 type AddPluginAfterRouteHook<
   TRoutes extends Routes,
-  TRejections extends Rejection[]
+  TRejections extends Rejections
 > = (hook: PluginAfterRouteHook<TRoutes, TRejections>) => RouteHookRemove
 
 export type PluginErrorHookContext<
   TRoutes extends Routes = Routes,
-  TRejections extends Rejection[] = Rejection[]
+  TRejections extends Rejections = Rejections
 > = {
   to: ResolvedRoute,
   from: ResolvedRoute | null,
@@ -119,17 +119,17 @@ export type PluginErrorHookContext<
 
 export type PluginErrorHook<
   TRoutes extends Routes = Routes,
-  TRejections extends Rejection[] = Rejection[]
+  TRejections extends Rejections = Rejections
 > = (error: unknown, context: PluginErrorHookContext<TRoutes, TRejections>) => void
 
 export type AddPluginErrorHook<
   TRoutes extends Routes = Routes,
-  TRejections extends Rejection[] = Rejection[]
+  TRejections extends Rejections = Rejections
 > = (hook: PluginErrorHook<TRoutes, TRejections>) => RouteHookRemove
 
 export type PluginRouteHooks<
   TRoutes extends Routes = Routes,
-  TRejections extends Rejection[] = Rejection[]
+  TRejections extends Rejections = Rejections
 > = {
   /**
    * Registers a global hook to be called before a route is entered.

--- a/src/types/routerReject.ts
+++ b/src/types/routerReject.ts
@@ -1,5 +1,5 @@
 import { BuiltInRejectionType } from '@/services/createRouterReject'
-import { Rejection, RejectionType } from '@/types/rejection'
+import { Rejections, RejectionType } from '@/types/rejection'
 
-export type RouterReject<TRejections extends Rejection[] | undefined> =
+export type RouterReject<TRejections extends Rejections | undefined> =
 <TSource extends (RejectionType<TRejections> | BuiltInRejectionType)>(type: TSource) => void


### PR DESCRIPTION
While updating documentation I went to add this example to plugins.md

```ts
import { createRouterPlugin } from '@kitbag/router'

const routes = [
  createRoute({ name: 'home', path: '/' }),
] as const

const rejections = [
  createRejection({ type: 'RequiresAuth' }),
] as const

const plugin = createRouterPlugin({
  routes,
  rejections,
})
```

which gave me the following error on `createRouterPlugin` under the `rejections` property. 

> The type `readonly [Rejection<'RequiresAuth'>]` is readonly and cannot be assigned to the mutable type `Rejection[]`

and confirmed a similar error on `createRouter` when rejections is readonly and passed into router options. This is also consistent with how we handle `Routes` which is `readonly Route[]`.