### PR TITLE
Remove deprecated utilities and options

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -42,24 +42,6 @@ export { tupleOf } from './services/tupleOf'
 export { createParam } from './services/createParam'
 export { createRouter } from './services/createRouter'
 
-// backwards compatible withParams
-import { withParams } from './services/withParams'
-/**
- * @deprecated use `withParams` instead
- * @hidden we don't want to expose this in the api docs
- */
-export const path = withParams
-/**
- * @deprecated use `withParams` instead
- * @hidden we don't want to expose this in the api docs
-*/
-export const host = withParams
-/**
- * @deprecated use `withParams` instead
- * @hidden we don't want to expose this in the api docs
- */
-export const query = withParams
-
 // Assets
 import { routerInjectionKey } from './keys'
 import { createRouterAssets, RouterAssets } from './services/createRouterAssets'

--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -111,12 +111,6 @@ export type CreateRouteOptions<
    * Related routes and rejections for the route. The context is exposed to the hooks and props callback functions for this route.
    */
   context?: RouteContext[],
-  /**
-   * Props have been moved to the second argument of `createRoute`. This property can no longer be used.
-   *
-   * @deprecated
-   */
-  props?: never,
 }
 
 export type PropsGetter<


### PR DESCRIPTION
# Description
Removing the long deprecated `path`, `query`, and `host` utilities which have been replaced by the `withParams` utility. Also removing the long deprecated `CreateRouteOptions.props` property when creating routes which has been moved to the second argument of `createRoute`. 

## Migration

### `path`, `query`, and `host` utilities
```ts
const route = createRoute({
  path: path('/[param]', {
    param: Boolean
  }
})
```
Becomes
```ts
const route = createRoute({
  path: withParams('/[param]', {
    param: Boolean
  }
})
```
**This is the same for `query` and `host`**

### `CreateRouteOptions.props`
```ts
const route = createRoute({
   component: MyComponentThatHasProps,
   props: () => { ... }
})
```
becomes
```ts
const route = createRoute({
   component: MyComponentThatHasProps,
}, () => { ... })
```