### PR TITLE
add onError hook support to route level

### DIFF
--- a/src/services/createExternalRoute.ts
+++ b/src/services/createExternalRoute.ts
@@ -27,7 +27,7 @@ export function createExternalRoute(options: CreateRouteOptions & (WithoutHost |
   const meta = options.meta ?? {}
   const host = toWithParams(options.host)
   const context = options.context ?? []
-  const { store, onBeforeRouteEnter } = createHooksFactory()
+  const { store, onBeforeRouteEnter, onError } = createHooksFactory()
   const rawRoute = markRaw({ id, meta: {}, state: {}, ...options })
 
   const route = {
@@ -45,6 +45,7 @@ export function createExternalRoute(options: CreateRouteOptions & (WithoutHost |
     state: {},
     context,
     onBeforeRouteEnter,
+    onError,
   } satisfies Route & ExternalRouteHooks
 
   const merged = isWithParent(options) ? combineRoutes(options.parent, route) : route

--- a/src/services/getRouteHooks.ts
+++ b/src/services/getRouteHooks.ts
@@ -1,23 +1,42 @@
 import { ResolvedRoute } from '@/types/resolved'
 import { isRouteEnter, isRouteLeave, isRouteUpdate } from '@/services/hooks'
 import { Hooks } from '@/models/hooks'
+import { AfterHook, BeforeHook } from '@/types/hooks'
+
+function wrapHookCatch(route: ResolvedRoute | null): <T extends BeforeHook | AfterHook>(hook: T) => T {
+  const hooks = route?.hooks.flatMap((store) => Array.from(store.onError)) ?? []
+
+  if (!hooks.length) {
+    return (hook) => hook
+  }
+
+  return <T extends BeforeHook | AfterHook>(hook: T): T => ((to: any, context: any) => {
+    try {
+      return hook(to, context)
+    } catch (error) {
+      hooks.forEach((runErrorHook) => runErrorHook(error, { ...context, to, source: 'hook' }))
+    }
+  }) as T
+}
 
 export function getBeforeHooksFromRoutes(to: ResolvedRoute, from: ResolvedRoute | null): Hooks {
   const hooks = new Hooks()
+  const toErrorWrapper = wrapHookCatch(to)
+  const fromErrorWrapper = wrapHookCatch(from)
 
   to.hooks.forEach((store, depth) => {
     if (isRouteEnter(to, from, depth)) {
-      return store.onBeforeRouteEnter.forEach((hook) => hooks.onBeforeRouteEnter.add(hook))
+      return store.onBeforeRouteEnter.forEach((hook) => hooks.onBeforeRouteEnter.add(toErrorWrapper(hook)))
     }
 
     if (isRouteUpdate(to, from, depth)) {
-      return store.onBeforeRouteUpdate.forEach((hook) => hooks.onBeforeRouteUpdate.add(hook))
+      return store.onBeforeRouteUpdate.forEach((hook) => hooks.onBeforeRouteUpdate.add(toErrorWrapper(hook)))
     }
   })
 
   from?.hooks.forEach((store, depth) => {
     if (isRouteLeave(to, from, depth)) {
-      return store.onBeforeRouteLeave.forEach((hook) => hooks.onBeforeRouteLeave.add(hook))
+      return store.onBeforeRouteLeave.forEach((hook) => hooks.onBeforeRouteLeave.add(fromErrorWrapper(hook)))
     }
   })
 
@@ -26,20 +45,22 @@ export function getBeforeHooksFromRoutes(to: ResolvedRoute, from: ResolvedRoute 
 
 export function getAfterHooksFromRoutes(to: ResolvedRoute, from: ResolvedRoute | null): Hooks {
   const hooks = new Hooks()
+  const toErrorWrapper = wrapHookCatch(to)
+  const fromErrorWrapper = wrapHookCatch(from)
 
   to.hooks.forEach((store, depth) => {
     if (isRouteEnter(to, from, depth)) {
-      return store.onAfterRouteEnter.forEach((hook) => hooks.onAfterRouteEnter.add(hook))
+      return store.onAfterRouteEnter.forEach((hook) => hooks.onAfterRouteEnter.add(toErrorWrapper(hook)))
     }
 
     if (isRouteUpdate(to, from, depth)) {
-      return store.onAfterRouteUpdate.forEach((hook) => hooks.onAfterRouteUpdate.add(hook))
+      return store.onAfterRouteUpdate.forEach((hook) => hooks.onAfterRouteUpdate.add(toErrorWrapper(hook)))
     }
   })
 
   from?.hooks.forEach((store, depth) => {
     if (isRouteLeave(to, from, depth)) {
-      return store.onAfterRouteLeave.forEach((hook) => hooks.onAfterRouteLeave.add(hook))
+      return store.onAfterRouteLeave.forEach((hook) => hooks.onAfterRouteLeave.add(fromErrorWrapper(hook)))
     }
   })
 

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -35,6 +35,11 @@ export type InternalRouteHooks<TContext extends RouteContext[] | undefined = und
    * Registers a route hook to be called after the route is updated.
    */
   onAfterRouteUpdate: AddAfterHook<RouteContextToRoute<TContext>, RouteContextToRejection<TContext>>,
+  /**
+    * Registers a hook to be called when an error occurs.
+    * If the hook returns true, the error is considered handled and the other hooks are not run. If all hooks return false the error is rethrown
+    */
+  onError: AddErrorHook<RouteContextToRoute<TContext>, RouteContextToRejection<TContext>>,
 }
 
 export type ExternalRouteHooks<TContext extends RouteContext[] | undefined = undefined> = {
@@ -42,6 +47,11 @@ export type ExternalRouteHooks<TContext extends RouteContext[] | undefined = und
    * Registers a route hook to be called before the route is entered.
    */
   onBeforeRouteEnter: AddBeforeHook<RouteContextToRoute<TContext>, RouteContextToRejection<TContext>>,
+  /**
+    * Registers a hook to be called when an error occurs.
+    * If the hook returns true, the error is considered handled and the other hooks are not run. If all hooks return false the error is rethrown
+    */
+  onError: AddErrorHook<RouteContextToRoute<TContext>, RouteContextToRejection<TContext>>,
 }
 
 export type HookTiming = 'global' | 'component'


### PR DESCRIPTION
In [a recent PR](https://github.com/kitbagjs/router/pull/600) we added a new `onError` hook to the router. This PR extends support for this hook to individual routes.

```ts
const route = createRoute({ name: 'my-route' })

route.onError((error, context) => {
  ...
})
```

Just like the router hooks, these route level hooks are passed the error as well as the same context

  | Property | Type | Description |
  |--|--|--|
  | to       | RouterResolvedRouteUnion<TRoutes>        | The destination route that was being navigated to when the error occurred                             |
  | from     | RouterResolvedRouteUnion<TRoutes> \| null | The source route being navigated from. Will be null if there is no previous route                     |
  | source   | 'props' \| 'hook' \| 'component'           | The origin of the error - indicates whether the error occurred in route props, a hook, or a component |
  | reject   | RouterReject<TRejections>                | Function to reject the navigation with a custom rejection                                             |
  | push     | RouterPush<TRoutes>                      | Function to navigate to a different route using push navigation                                       |
  | replace  | RouterReplace<TRoutes>                   | Function to navigate to a different route using replace navigation 

```ts
const route = createRoute({ name: 'my-route' })

route.onError((error, { to, from, source, push, replace, reject }) => {
  if (error instanceof MyExpectedError) {
    push(...)
  }

  throw reject('AppError')
})
```