### PR TITLE
Add the current route to the route context

### DIFF
--- a/src/services/createExternalRoute.ts
+++ b/src/services/createExternalRoute.ts
@@ -7,6 +7,7 @@ import { checkDuplicateParams } from '@/utilities/checkDuplicateKeys'
 import { toWithParams } from '@/services/withParams'
 import { createHooksFactory } from '@/services/createHooksFactory'
 import { ExternalRouteHooks } from '@/types/hooks'
+import { ExtractRouteContext } from '@/types/routeContext'
 
 export function createExternalRoute<
   const TOptions extends CreateRouteOptions & WithHost & WithoutParent
@@ -16,7 +17,7 @@ export function createExternalRoute<
 export function createExternalRoute<
   const TOptions extends CreateRouteOptions & WithoutHost & WithParent
 >(options: TOptions): ToRoute<TOptions>
-  & ExternalRouteHooks<ToRoute<TOptions>, TOptions['context']>
+  & ExternalRouteHooks<ToRoute<TOptions>, ExtractRouteContext<TOptions>>
 
 export function createExternalRoute(options: CreateRouteOptions & (WithoutHost | WithHost)): Route {
   const id = createRouteId()

--- a/src/services/createRoute.ts
+++ b/src/services/createRoute.ts
@@ -7,6 +7,7 @@ import { checkDuplicateParams } from '@/utilities/checkDuplicateKeys'
 import { toWithParams, withParams } from '@/services/withParams'
 import { createHooksFactory } from '@/services/createHooksFactory'
 import { InternalRouteHooks } from '@/types/hooks'
+import { ExtractRouteContext } from '@/types/routeContext'
 
 type CreateRouteWithProps<
   TOptions extends CreateRouteOptions,
@@ -25,7 +26,7 @@ export function createRoute<
   const TOptions extends CreateRouteOptions,
   const TProps extends CreateRouteProps<TOptions>
 >(options: TOptions, ...args: CreateRouteWithProps<TOptions, TProps>): ToRoute<TOptions, TProps>
-  & InternalRouteHooks<ToRoute<TOptions>, TOptions['context']>
+  & InternalRouteHooks<ToRoute<TOptions>, ExtractRouteContext<TOptions>>
 
 export function createRoute(options: CreateRouteOptions, props?: CreateRouteProps): Route {
   const id = createRouteId()

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -18,27 +18,27 @@ export type InternalRouteHooks<
   /**
    * Registers a route hook to be called before the route is entered.
    */
-  onBeforeRouteEnter: AddBeforeHook<TRoute, RouteContextToRoute<TContext>, RouteContextToRejection<TContext>>,
+  onBeforeRouteEnter: AddBeforeHook<TRoute, [TRoute] | RouteContextToRoute<TContext>, RouteContextToRejection<TContext>>,
   /**
    * Registers a route hook to be called before the route is left.
    */
-  onBeforeRouteLeave: AddBeforeHook<TRoute, RouteContextToRoute<TContext>, RouteContextToRejection<TContext>>,
+  onBeforeRouteLeave: AddBeforeHook<TRoute, [TRoute] | RouteContextToRoute<TContext>, RouteContextToRejection<TContext>>,
   /**
    * Registers a route hook to be called before the route is updated.
    */
-  onBeforeRouteUpdate: AddBeforeHook<TRoute, RouteContextToRoute<TContext>, RouteContextToRejection<TContext>>,
+  onBeforeRouteUpdate: AddBeforeHook<TRoute, [TRoute] | RouteContextToRoute<TContext>, RouteContextToRejection<TContext>>,
   /**
    * Registers a route hook to be called after the route is entered.
    */
-  onAfterRouteEnter: AddAfterHook<TRoute, RouteContextToRoute<TContext>, RouteContextToRejection<TContext>>,
+  onAfterRouteEnter: AddAfterHook<TRoute, [TRoute] | RouteContextToRoute<TContext>, RouteContextToRejection<TContext>>,
   /**
    * Registers a route hook to be called after the route is left.
    */
-  onAfterRouteLeave: AddAfterHook<TRoute, RouteContextToRoute<TContext>, RouteContextToRejection<TContext>>,
+  onAfterRouteLeave: AddAfterHook<TRoute, [TRoute] | RouteContextToRoute<TContext>, RouteContextToRejection<TContext>>,
   /**
    * Registers a route hook to be called after the route is updated.
    */
-  onAfterRouteUpdate: AddAfterHook<TRoute, RouteContextToRoute<TContext>, RouteContextToRejection<TContext>>,
+  onAfterRouteUpdate: AddAfterHook<TRoute, [TRoute] | RouteContextToRoute<TContext>, RouteContextToRejection<TContext>>,
 }
 
 export type ExternalRouteHooks<
@@ -48,7 +48,7 @@ export type ExternalRouteHooks<
   /**
    * Registers a route hook to be called before the route is entered.
    */
-  onBeforeRouteEnter: AddBeforeHook<TRoute, RouteContextToRoute<TContext>, RouteContextToRejection<TContext>>,
+  onBeforeRouteEnter: AddBeforeHook<TRoute, [TRoute] | RouteContextToRoute<TContext>, RouteContextToRejection<TContext>>,
 }
 
 export type HookTiming = 'global' | 'component'

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -3,7 +3,7 @@ import { Route } from '@/types/route'
 import { RouterReject } from './routerReject'
 import { RouterPush } from './routerPush'
 import { RouterReplace } from './routerReplace'
-import { RouteContext, RouteContextToRejection, RouteContextToRoute } from './routeContext'
+import { ExtractRouteContextRejections, ExtractRouteContextRoutes } from './routeContext'
 import { ResolvedRoute } from './resolved'
 import { RouteUpdate } from './routeUpdate'
 
@@ -14,18 +14,12 @@ export type PropsCallbackContext<
   TRoute extends Route = Route,
   TOptions extends CreateRouteOptions = CreateRouteOptions
 > = {
-  reject: RouterReject<RouteContextToRejection<ExtractRouteContext<TOptions>>>,
-  push: RouterPush<RouteContextToRoute<ExtractRouteContext<TOptions>>>,
-  replace: RouterReplace<RouteContextToRoute<ExtractRouteContext<TOptions>>>,
+  reject: RouterReject<ExtractRouteContextRejections<TOptions>>,
+  push: RouterPush<[TRoute] | ExtractRouteContextRoutes<TOptions>>,
+  replace: RouterReplace<[TRoute] | ExtractRouteContextRoutes<TOptions>>,
   update: RouteUpdate<ResolvedRoute<TRoute>>,
   parent: PropsCallbackParent<TOptions['parent']>,
 }
-
-type ExtractRouteContext<
-  TOptions extends CreateRouteOptions
-> = TOptions extends { context: infer TContext extends RouteContext[] }
-  ? TContext
-  : []
 
 export type PropsCallbackParent<
   TParent extends Route | undefined = Route | undefined

--- a/src/types/routeContext.ts
+++ b/src/types/routeContext.ts
@@ -1,3 +1,4 @@
+import { CreateRouteOptions } from './createRouteOptions'
 import { Rejection, Rejections } from './rejection'
 import { GenericRoute, Routes } from './route'
 
@@ -6,6 +7,20 @@ export type RouteContext = GenericRoute | Rejection
 export type ToRouteContext<TContext extends RouteContext[] | readonly RouteContext[] | undefined> = TContext extends RouteContext[]
   ? TContext
   : []
+
+export type ExtractRouteContext<
+  TOptions extends CreateRouteOptions
+> = TOptions extends { context: infer TContext extends RouteContext[] }
+  ? TContext
+  : []
+
+export type ExtractRouteContextRoutes<
+  TOptions extends CreateRouteOptions
+> = RouteContextToRoute<ExtractRouteContext<TOptions>>
+
+export type ExtractRouteContextRejections<
+  TOptions extends CreateRouteOptions
+> = RouteContextToRejection<ExtractRouteContext<TOptions>>
 
 export type RouteContextToRoute<TContext extends RouteContext[] | undefined> =
 RouteContext[] extends TContext


### PR DESCRIPTION
# Description
Adds the current route to the route context so that the current route is valid when calling `push` and `replace`. This means that these utilities will automatically have utility even without using the `context` property. 

```ts
const route = createRoute({
  name: 'myRoute',
  path: '/my/path/[myParam]'
})

route.onBeforeRouteEnter((to, { push }) => {
  if(myCondition) {
    push('myRoute', { myParam: 'myValue' }) // valid and type safe
  }
})
```