### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@kitbag/router",
   "private": false,
   "version": "0.20.11",
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/kitbagjs/router/issues"
   },


### PR DESCRIPTION
# Description
Noticed on npm the license was "none" and google says its because we need to add it to the package.json