### PR TITLE
rename generic "url" to "urlString"

### DIFF
--- a/src/components/routerLink.browser.spec.ts
+++ b/src/components/routerLink.browser.spec.ts
@@ -9,7 +9,7 @@ import { getPrefetchConfigValue } from '@/utilities/prefetch'
 import { component } from '@/utilities/testHelpers'
 import { visibilityObserverKey } from '@/compositions/useVisibilityObserver'
 import { VisibilityObserver } from '@/services/createVisibilityObserver'
-import { Url } from '@/types/url'
+import { UrlString } from '@/types/urlString'
 import { RouterPushOptions } from '@/types/routerPush'
 import { RouterLink } from '@/main'
 
@@ -256,7 +256,7 @@ test('to prop as Url renders and routes correctly', async () => {
   expect(router.route.name).toBe('route')
 })
 
-test.each<{ to: Url, match: boolean, exactMatch: boolean }>([
+test.each<{ to: UrlString, match: boolean, exactMatch: boolean }>([
   { to: '/parent-route', match: true, exactMatch: false },
   { to: '/parent-route/child-route', match: true, exactMatch: true },
   { to: '/other', match: false, exactMatch: false },
@@ -355,7 +355,7 @@ test('isMatch correctly matches parent when sibling has the same url', async () 
   expect(link.classes()).not.toContain('router-link--exact-match')
 })
 
-test.each<{ to: Url, active: boolean, exactActive: boolean }>([
+test.each<{ to: UrlString, active: boolean, exactActive: boolean }>([
   { to: '/parent-route', active: true, exactActive: false },
   { to: '/parent-route/child-route/pass', active: true, exactActive: true },
   { to: '/parent-route/child-route/fail', active: false, exactActive: false },

--- a/src/components/routerLink.ts
+++ b/src/components/routerLink.ts
@@ -1,4 +1,4 @@
-import { isUrl, Url } from '@/types/url'
+import { isUrlString, UrlString } from '@/types/urlString'
 import { ResolvedRoute } from '@/types/resolved'
 import { computed, defineComponent, EmitsOptions, h, InjectionKey, SetupContext, SlotsType, VNode } from 'vue'
 import { createUseRouter } from '@/compositions/useRouter'
@@ -17,7 +17,7 @@ type RouterLinkSlots = {
   }) => VNode[],
 }
 
-// Infering the return type of the component is more accurate than defining it manually
+// Inferring the return type of the component is more accurate than defining it manually
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 export function createRouterLink<TRouter extends Router>(routerKey: InjectionKey<TRouter>) {
   const useRouter = createUseRouter(routerKey)
@@ -28,7 +28,7 @@ export function createRouterLink<TRouter extends Router>(routerKey: InjectionKey
 
     const route = computed<ResolvedRoute | undefined>(() => getResolvedRoute(props.to))
 
-    const href = computed<Url | undefined>(() => getHref(props.to))
+    const href = computed<UrlString | undefined>(() => getHref(props.to))
 
     const options = computed(() => {
       const { to, ...options } = props
@@ -51,24 +51,24 @@ export function createRouterLink<TRouter extends Router>(routerKey: InjectionKey
       'router-link--exact-active': isExactActive.value,
     }))
 
-    function getResolvedRoute(to: Url | ResolvedRoute | ToCallback<TRouter> | undefined): ResolvedRoute | undefined {
+    function getResolvedRoute(to: UrlString | ResolvedRoute | ToCallback<TRouter> | undefined): ResolvedRoute | undefined {
       if (typeof to === 'function') {
         const callbackValue = to(router.resolve)
 
         return getResolvedRoute(callbackValue)
       }
 
-      return isUrl(to) ? router.find(to) : to
+      return isUrlString(to) ? router.find(to) : to
     }
 
-    function getHref(to: Url | ResolvedRoute | ToCallback<TRouter> | undefined): Url | undefined {
+    function getHref(to: UrlString | ResolvedRoute | ToCallback<TRouter> | undefined): UrlString | undefined {
       if (typeof to === 'function') {
         const callbackValue = to(router.resolve)
 
         return getHref(callbackValue)
       }
 
-      if (isUrl(to)) {
+      if (isUrlString(to)) {
         return to
       }
 

--- a/src/compositions/useLink.ts
+++ b/src/compositions/useLink.ts
@@ -4,7 +4,7 @@ import { createUseRouter } from '@/compositions/useRouter'
 import { ResolvedRoute } from '@/types/resolved'
 import { RouterPushOptions } from '@/types/routerPush'
 import { RouteParamsByKey } from '@/types/routeWithParams'
-import { Url, isUrl } from '@/types/url'
+import { UrlString, isUrlString } from '@/types/urlString'
 import { AllPropertiesAreOptional } from '@/types/utilities'
 import { createIsRoute } from '@/guards/routes'
 import { combineUrlSearchParams } from '@/utilities/urlSearchParams'
@@ -22,7 +22,7 @@ type UseLinkArgs<
 
 type UseLinkFunction<TRouter extends Router> = {
   <TRouteKey extends RouterRouteName<TRouter>>(name: MaybeRefOrGetter<TRouteKey>, ...args: UseLinkArgs<TRouter, TRouteKey>): UseLink,
-  (url: MaybeRefOrGetter<Url>, options?: MaybeRefOrGetter<UseLinkOptions>): UseLink,
+  (url: MaybeRefOrGetter<UrlString>, options?: MaybeRefOrGetter<UseLinkOptions>): UseLink,
   (resolvedRoute: MaybeRefOrGetter<ResolvedRoute | undefined>, options?: MaybeRefOrGetter<UseLinkOptions>): UseLink,
   (source: MaybeRefOrGetter<string | ResolvedRoute | undefined>, paramsOrOptions?: MaybeRefOrGetter<Record<PropertyKey, unknown> | UseLinkOptions>, maybeOptions?: MaybeRefOrGetter<UseLinkOptions>): UseLink,
 }
@@ -45,7 +45,7 @@ export function createUseLink<TRouter extends Router>(routerKey: InjectionKey<TR
         return sourceValue
       }
 
-      if (isUrl(sourceValue)) {
+      if (isUrlString(sourceValue)) {
         return router.find(sourceValue, toValue(maybeOptions))
       }
 
@@ -58,7 +58,7 @@ export function createUseLink<TRouter extends Router>(routerKey: InjectionKey<TR
       }
 
       const sourceValue = toValue(source)
-      if (isUrl(sourceValue)) {
+      if (isUrlString(sourceValue)) {
         return sourceValue
       }
 
@@ -76,7 +76,7 @@ export function createUseLink<TRouter extends Router>(routerKey: InjectionKey<TR
     const linkOptions = computed<UseLinkOptions>(() => {
       const sourceValue = toValue(source)
 
-      return typeof sourceValue !== 'string' || isUrl(sourceValue) ? toValue(paramsOrOptions) : toValue(maybeOptions)
+      return typeof sourceValue !== 'string' || isUrlString(sourceValue) ? toValue(paramsOrOptions) : toValue(maybeOptions)
     })
 
     const { element, commit } = usePrefetching(() => ({
@@ -96,7 +96,7 @@ export function createUseLink<TRouter extends Router>(routerKey: InjectionKey<TR
       }
 
       const sourceValue = toValue(source)
-      if (isUrl(sourceValue) || typeof sourceValue === 'object') {
+      if (isUrlString(sourceValue) || typeof sourceValue === 'object') {
         return router.push(sourceValue, options)
       }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@ export * from './types/routerReplace'
 export * from './types/routerResolve'
 export * from './types/routerResolve'
 export * from './types/routerRoute'
-export * from './types/url'
+export * from './types/urlString'
 export * from './types/useLink'
 
 // Errors

--- a/src/services/createResolvedRouteForUrl.ts
+++ b/src/services/createResolvedRouteForUrl.ts
@@ -5,7 +5,7 @@ import { Routes } from '@/types/route'
 import { parseUrl } from '@/services/urlParser'
 import { createResolvedRouteQuery } from '@/services/createResolvedRouteQuery'
 import { getStateValues } from '@/services/state'
-import { asUrl } from '@/types/url'
+import { asUrlString } from '@/types/urlString'
 
 export function createResolvedRouteForUrl(routes: Routes, url: string, state?: Partial<unknown>): ResolvedRoute | undefined {
   const matches = getMatchesForUrl(routes, url)
@@ -27,6 +27,6 @@ export function createResolvedRouteForUrl(routes: Routes, url: string, state?: P
     params: getRouteParamValues(route, url),
     state: getStateValues(route.state, state),
     hash,
-    href: asUrl(url),
+    href: asUrlString(url),
   }
 }

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -14,7 +14,7 @@ import { Router, RouterOptions } from '@/types/router'
 import { RouterPush, RouterPushOptions } from '@/types/routerPush'
 import { RouterReplace, RouterReplaceOptions } from '@/types/routerReplace'
 import { RoutesName } from '@/types/routesMap'
-import { Url, isUrl } from '@/types/url'
+import { UrlString, isUrlString } from '@/types/urlString'
 import { createUniqueIdSequence, isFirstUniqueSequenceId } from '@/services/createUniqueIdSequence'
 import { createVisibilityObserver } from './createVisibilityObserver'
 import { visibilityObserverKey } from '@/compositions/useVisibilityObserver'
@@ -239,11 +239,11 @@ export function createRouter<
   }
 
   const push: RouterPush<TRoutes | TPlugin['routes']> = (
-    source: Url | RoutesName<TRoutes | TPlugin['routes']> | ResolvedRoute,
+    source: UrlString | RoutesName<TRoutes | TPlugin['routes']> | ResolvedRoute,
     paramsOrOptions?: Record<string, unknown> | RouterPushOptions,
     maybeOptions?: RouterPushOptions,
   ) => {
-    if (isUrl(source)) {
+    if (isUrlString(source)) {
       const options: RouterPushOptions = { ...paramsOrOptions }
       const url = combineUrl(source, {
         searchParams: options.query,
@@ -274,11 +274,11 @@ export function createRouter<
   }
 
   const replace: RouterReplace<TRoutes | TPlugin['routes']> = (
-    source: Url | RoutesName<TRoutes | TPlugin['routes']> | ResolvedRoute,
+    source: UrlString | RoutesName<TRoutes | TPlugin['routes']> | ResolvedRoute,
     paramsOrOptions?: Record<string, unknown> | RouterReplaceOptions,
     maybeOptions?: RouterReplaceOptions,
   ) => {
-    if (isUrl(source)) {
+    if (isUrlString(source)) {
       const options: RouterPushOptions = { ...paramsOrOptions, replace: true }
 
       return push(source, options)

--- a/src/services/createRouterCallbackContext.ts
+++ b/src/services/createRouterCallbackContext.ts
@@ -4,7 +4,7 @@ import { ContextRejectionError } from '@/errors/contextRejectionError'
 import { RouterPush, RouterPushOptions } from '@/types/routerPush'
 import { RouterReject } from '@/types/routerReject'
 import { RouterReplace } from '@/types/routerReplace'
-import { isUrl } from '@/types/url'
+import { isUrlString } from '@/types/urlString'
 import { BuiltInRejectionType } from './createRouterReject'
 import { AsString } from '@/types/utilities'
 import { Routes } from '@/types/route'
@@ -73,7 +73,7 @@ export function createRouterCallbackContext({ to }: { to: ResolvedRoute }): Rout
   }
 
   const replace: RouterCallbackContext['replace'] = (source: any, paramsOrOptions?: any, maybeOptions?: any) => {
-    if (isUrl(source)) {
+    if (isUrlString(source)) {
       const options: RouterPushOptions = paramsOrOptions ?? {}
       throw new ContextPushError([source, { ...options, replace: true }])
     }

--- a/src/services/urlAssembly.ts
+++ b/src/services/urlAssembly.ts
@@ -2,7 +2,7 @@ import { setParamValue } from '@/services/params'
 import { setParamValueOnUrl } from '@/services/paramsFinder'
 import { getParamName, isOptionalParamSyntax } from '@/services/routeRegex'
 import { Route } from '@/types/route'
-import { Url } from '@/types/url'
+import { UrlString } from '@/types/urlString'
 import { createUrl } from '@/services/urlCreator'
 import { parseUrl } from '@/services/urlParser'
 import { combineUrlSearchParams } from '@/utilities/urlSearchParams'
@@ -15,7 +15,7 @@ type AssembleUrlOptions = {
   hash?: string,
 }
 
-export function assembleUrl(route: Route, options: AssembleUrlOptions = {}): Url {
+export function assembleUrl(route: Route, options: AssembleUrlOptions = {}): UrlString {
   const { params: paramValues = {}, query: queryValues } = options
   const routeQuery = assembleQueryParamValues(route.query, paramValues)
   const searchParams = combineUrlSearchParams(routeQuery, queryValues)

--- a/src/services/urlCombine.ts
+++ b/src/services/urlCombine.ts
@@ -1,10 +1,10 @@
-import { Url, UrlParts } from '@/types/url'
+import { UrlString, UrlParts } from '@/types/urlString'
 import { parseUrl } from '@/services/urlParser'
 import { createUrl } from '@/services/urlCreator'
 import { combineUrlSearchParams } from '@/utilities/urlSearchParams'
 import { stringHasValue } from '@/utilities/guards'
 
-export function combineUrl(previous: Url | Partial<UrlParts>, updated: Url | Partial<UrlParts>): Url {
+export function combineUrl(previous: UrlString | Partial<UrlParts>, updated: UrlString | Partial<UrlParts>): UrlString {
   const previousUrlParts = typeof previous === 'string' ? parseUrl(previous) : previous
   const updatedUrlParts = typeof updated === 'string' ? parseUrl(updated) : updated
 

--- a/src/services/urlCreator.ts
+++ b/src/services/urlCreator.ts
@@ -1,6 +1,6 @@
-import { asUrl, Url, UrlParts } from '@/types/url'
+import { asUrlString, UrlString, UrlParts } from '@/types/urlString'
 
-export function createUrl({ protocol, host, pathname, search, searchParams, hash }: Partial<UrlParts>): Url {
+export function createUrl({ protocol, host, pathname, search, searchParams, hash }: Partial<UrlParts>): UrlString {
   const url = new URL('https://localhost')
 
   if (protocol) {
@@ -27,5 +27,5 @@ export function createUrl({ protocol, host, pathname, search, searchParams, hash
 
   const value = url.toString().replace(/^https:\/\/localhost\/*/, '/')
 
-  return asUrl(value)
+  return asUrlString(value)
 }

--- a/src/services/urlParser.ts
+++ b/src/services/urlParser.ts
@@ -1,4 +1,4 @@
-import { UrlParts } from '@/types/url'
+import { UrlParts } from '@/types/urlString'
 
 export function parseUrl(value: string): UrlParts {
   const isRelative = !value.startsWith('http')

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -2,7 +2,7 @@ import { Hooks } from '@/models/hooks'
 import { ExtractRouteParamTypesReading } from '@/types/params'
 import { Route, Routes } from '@/types/route'
 import { ExtractRouteStateParamsAsOptional } from '@/types/state'
-import { Url } from '@/types/url'
+import { UrlString } from '@/types/urlString'
 
 /**
  * Represents a route that the router has matched to current browser location.
@@ -45,7 +45,7 @@ export type ResolvedRoute<TRoute extends Route = Route> = Readonly<{
   /**
    * String value of the resolved URL.
    */
-  href: Url,
+  href: UrlString,
   /**
    * The stores for routes including ancestors.
    * Order of routes will be from greatest ancestor to narrowest matched.

--- a/src/types/routerLink.ts
+++ b/src/types/routerLink.ts
@@ -1,16 +1,16 @@
 import { PrefetchConfig } from '@/types/prefetch'
-import { Url } from '@/types/url'
+import { UrlString } from '@/types/urlString'
 import { ResolvedRoute } from '@/types/resolved'
 import { Router } from '@/types/router'
 import { RouterPushOptions } from '@/types/routerPush'
 
-export type ToCallback<TRouter extends Router> = (resolve: TRouter['resolve']) => ResolvedRoute | Url | undefined
+export type ToCallback<TRouter extends Router> = (resolve: TRouter['resolve']) => ResolvedRoute | UrlString | undefined
 
 export type RouterLinkProps<TRouter extends Router> = RouterPushOptions & {
   /**
    * The url string to navigate to or a callback that returns a url string
    */
-  to: Url | ResolvedRoute | ToCallback<TRouter>,
+  to: UrlString | ResolvedRoute | ToCallback<TRouter>,
   /**
    * Determines what assets are prefetched when router-link is rendered for this route. Overrides route level prefetch.
    */

--- a/src/types/routerPush.ts
+++ b/src/types/routerPush.ts
@@ -2,7 +2,7 @@ import { Routes } from '@/types/route'
 import { RoutesName } from '@/types/routesMap'
 import { RouteParamsByKey } from '@/types/routeWithParams'
 import { RouteStateByName } from '@/types/state'
-import { Url } from '@/types/url'
+import { UrlString } from '@/types/urlString'
 import { AllPropertiesAreOptional } from '@/types/utilities'
 import { QuerySource } from '@/types/querySource'
 import { ResolvedRoute } from '@/types/resolved'
@@ -40,5 +40,5 @@ export type RouterPush<
 > = {
   <TSource extends RoutesName<TRoutes>>(name: TSource, ...args: RouterPushArgs<TRoutes, TSource>): Promise<void>,
   (route: ResolvedRoute, options?: RouterPushOptions): Promise<void>,
-  (url: Url, options?: RouterPushOptions): Promise<void>,
+  (url: UrlString, options?: RouterPushOptions): Promise<void>,
 }

--- a/src/types/routerReplace.ts
+++ b/src/types/routerReplace.ts
@@ -2,7 +2,7 @@ import { Routes } from '@/types/route'
 import { RoutesName } from '@/types/routesMap'
 import { RouteParamsByKey } from '@/types/routeWithParams'
 import { RouteStateByName } from '@/types/state'
-import { Url } from '@/types/url'
+import { UrlString } from '@/types/urlString'
 import { AllPropertiesAreOptional } from '@/types/utilities'
 import { QuerySource } from '@/types/querySource'
 import { ResolvedRoute } from '@/types/resolved'
@@ -27,5 +27,5 @@ export type RouterReplace<
 > = {
   <TSource extends RoutesName<TRoutes>>(name: TSource, ...args: RouterReplaceArgs<TRoutes, TSource>): Promise<void>,
   (route: ResolvedRoute, options?: RouterReplaceOptions): Promise<void>,
-  (url: Url, options?: RouterReplaceOptions): Promise<void>,
+  (url: UrlString, options?: RouterReplaceOptions): Promise<void>,
 }

--- a/src/types/urlString.ts
+++ b/src/types/urlString.ts
@@ -1,6 +1,6 @@
 import { QuerySource } from './querySource'
 
-export type Url = `http://${string}` | `https://${string}` | `/${string}`
+export type UrlString = `http://${string}` | `https://${string}` | `/${string}`
 
 export type UrlParts = {
   protocol?: string,
@@ -17,7 +17,7 @@ export type UrlParts = {
  * @returns `true` if the value is a valid URL, otherwise `false`.
  * @group Type Guards
  */
-export function isUrl(value: unknown): value is Url {
+export function isUrlString(value: unknown): value is UrlString {
   if (typeof value !== 'string') {
     return false
   }
@@ -32,8 +32,8 @@ export function isUrl(value: unknown): value is Url {
  * @param value - The string to convert.
  * @returns The valid URL.
  */
-export function asUrl(value: string): Url {
-  if (isUrl(value)) {
+export function asUrlString(value: string): UrlString {
+  if (isUrlString(value)) {
     return value
   }
 

--- a/src/types/useLink.ts
+++ b/src/types/useLink.ts
@@ -3,7 +3,7 @@ import { PrefetchConfig } from '@/types/prefetch'
 import { ResolvedRoute } from '@/types/resolved'
 import { RouterPushOptions } from '@/types/routerPush'
 import { RouterReplaceOptions } from '@/types/routerReplace'
-import { Url } from '@/types/url'
+import { UrlString } from '@/types/urlString'
 
 export type UseLink = {
   /**
@@ -17,7 +17,7 @@ export type UseLink = {
   /**
    * Resolved URL with params interpolated and query applied. Same value as `router.resolve`.
    */
-  href: ComputedRef<Url | undefined>,
+  href: ComputedRef<UrlString | undefined>,
   /**
    * True if route matches current URL or is ancestor of route that matches current URL
    */


### PR DESCRIPTION
We're working on introducing a new utility that will be named `Url` with a `createUrl` service. This PR enables that change by renaming our existing `Url` -> `UrlString`.