### PR TITLE
docs: fix code typo on Rejections page

### DIFF
--- a/docs/advanced-concepts/rejections.md
+++ b/docs/advanced-concepts/rejections.md
@@ -50,7 +50,7 @@ const notFoundRejection = createRejection({
 })
 
 export const router = createRouter(routes, {
-  rejections: [authNeededRejection]
+  rejections: [notFoundRejection]
 })
 ```
 


### PR DESCRIPTION
Fixing copy-paste code issue on Rejections page in docs 