### PR TITLE
Optimize router.resolve by using a map

### DIFF
--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -91,7 +91,7 @@ export function createRouter<
     ...plugins.flatMap((plugin) => plugin.rejections),
     ...options?.rejections ?? [],
   ]
-  const routes = getRoutesForRouter(routesOrArrayOfRoutes, plugins, options?.base)
+  const { routes, getRouteByName } = getRoutesForRouter(routesOrArrayOfRoutes, plugins, options?.base)
   const hooks = createRouterHooks()
 
   hooks.addGlobalRouteHooks(getGlobalHooksForRouter(plugins))
@@ -229,7 +229,7 @@ export function createRouter<
     params: Record<string, unknown> = {},
     options: RouterResolveOptions = {},
   ) => {
-    const match = routes.find((route) => route.name === source)
+    const match = getRouteByName(source)
 
     if (!match) {
       throw new RouteNotFoundError(source)

--- a/src/services/getRoutesForRouter.spec.ts
+++ b/src/services/getRoutesForRouter.spec.ts
@@ -7,16 +7,14 @@ import { createRouterPlugin } from '@/services/createRouterPlugin'
 test('given routes without names, removes routes from response', () => {
   const foo = createRoute({ name: 'foo' })
 
-  const routes = [
+  const { routes } = getRoutesForRouter([
     foo,
     createRoute({ component, name: '' }),
     createRoute({ component, name: undefined }),
     createRoute({ component }),
-  ]
+  ])
 
-  const response = getRoutesForRouter(routes)
-
-  expect(response).toMatchObject([foo])
+  expect(routes).toMatchObject([foo])
 })
 
 test('given named routes inside plugins, includes them in the response', () => {
@@ -32,9 +30,9 @@ test('given named routes inside plugins, includes them in the response', () => {
     }),
   ]
 
-  const response = getRoutesForRouter([], plugins)
+  const { routes } = getRoutesForRouter([], plugins)
 
-  expect(response).toMatchObject([pluginFoo])
+  expect(routes).toMatchObject([pluginFoo])
 })
 
 test('given named routes inside route context, includes them in the response', () => {
@@ -42,20 +40,19 @@ test('given named routes inside route context, includes them in the response', (
   const fooRoute = createRoute({ name: 'foo', context: [relatedRoute] })
   const barRoute = createRoute({ name: 'bar', context: [relatedRoute] })
   const zooRoute = createRoute({ name: 'zoo', context: [relatedRoute] })
-  const routes = [
-    fooRoute,
-    barRoute,
-    zooRoute,
-  ]
   const plugins = [
     createRouterPlugin({
-      routes,
+      routes: [
+        fooRoute,
+        barRoute,
+        zooRoute,
+      ],
     }),
   ]
 
-  const response = getRoutesForRouter([], plugins)
+  const { routes } = getRoutesForRouter([], plugins)
 
-  expect(response).toMatchObject([
+  expect(routes).toMatchObject([
     fooRoute,
     relatedRoute,
     barRoute,
@@ -68,15 +65,14 @@ test('given named routes inside route context of plugin routes, includes them in
   const fooRoute = createRoute({ name: 'foo', context: [relatedRoute] })
   const barRoute = createRoute({ name: 'bar', context: [relatedRoute] })
   const zooRoute = createRoute({ name: 'zoo', context: [relatedRoute] })
-  const routes = [
+
+  const { routes } = getRoutesForRouter([
     fooRoute,
     barRoute,
     zooRoute,
-  ]
+  ])
 
-  const response = getRoutesForRouter(routes)
-
-  expect(response).toMatchObject([
+  expect(routes).toMatchObject([
     fooRoute,
     relatedRoute,
     barRoute,
@@ -93,4 +89,17 @@ test('circular context is ignored', () => {
   routeB.context.push(routeA)
 
   expect(() => getRoutesForRouter([routeA, routeB])).not.toThrow()
+})
+
+test('getRouteByName returns the route by name', () => {
+  const route = createRoute({ name: 'foo' })
+  const { getRouteByName } = getRoutesForRouter([route])
+
+  expect(getRouteByName('foo')).toBe(route)
+})
+
+test('getRouteByName returns undefined if the route is not found', () => {
+  const { getRouteByName } = getRoutesForRouter([])
+
+  expect(getRouteByName('foo')).toBeUndefined()
 })

--- a/src/services/getRoutesForRouter.ts
+++ b/src/services/getRoutesForRouter.ts
@@ -5,13 +5,18 @@ import { isNamedRoute } from '@/utilities/isNamedRoute'
 import { RouteContext } from '@/types/routeContext'
 import { insertBaseRoute } from './insertBaseRoute'
 
+type RouterRoutes = {
+  routes: Routes,
+  getRouteByName: (name: string) => Route | undefined,
+}
+
 /**
  * Takes in routes and plugins and returns a list of routes with the base route inserted if provided.
  * Also checks for duplicate names in the routes.
  *
  * @throws {DuplicateNamesError} If there are duplicate names in the routes.
  */
-export function getRoutesForRouter(routes: Routes | Routes[], plugins: RouterPlugin[] = [], base?: string): Routes {
+export function getRoutesForRouter(routes: Routes | Routes[], plugins: RouterPlugin[] = [], base?: string): RouterRoutes {
   // Map of route name to route
   const routerRoutes = new Map<string, Route>()
 
@@ -61,7 +66,10 @@ export function getRoutesForRouter(routes: Routes | Routes[], plugins: RouterPlu
     addRoute(route)
   }
 
-  return Array.from(routerRoutes.values())
+  return {
+    routes: Array.from(routerRoutes.values()),
+    getRouteByName: (name: string) => routerRoutes.get(name),
+  }
 }
 
 function contextIsRoute(context: RouteContext): context is Route {


### PR DESCRIPTION
# Description
We're already using a map internally in `getRoutesForRouter`. But we just return an array of routes and then later in resolve we end up looping all the routes just to match on the name. 

Updating `getRoutesForRouter` to return both `routes` and a `getRouteByName` method that used the map to speed up resolving routes.

No functional change for users.