### PR TITLE
disable no-unused-vars in spec-d files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -10,4 +10,10 @@ export default [
       '@typescript-eslint/no-explicit-any': ['off'],
     },
   },
+  {
+    files: ['**/*.spec-d.ts'],
+    rules: {
+      '@typescript-eslint/no-unused-vars': ['off'],
+    },
+  },
 ]

--- a/src/services/combinePath.spec-d.ts
+++ b/src/services/combinePath.spec-d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { expectTypeOf, test } from 'vitest'
 import { withParams, WithParams } from '@/services/withParams'
 import { combinePath } from './combinePath'

--- a/src/services/createRoute.spec-d.ts
+++ b/src/services/createRoute.spec-d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { describe, expectTypeOf, test } from 'vitest'
 import { createRoute } from './createRoute'
 import { Identity } from '@/types/utilities'

--- a/src/services/createRouter.spec-d.ts
+++ b/src/services/createRouter.spec-d.ts
@@ -112,7 +112,6 @@ describe('hooks', () => {
 
 describe('rejections', () => {
   test('built in rejections are valid', () => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const _router = createRouter([])
     type Source = Parameters<typeof _router.reject>[0]
     type Expect = BuiltInRejectionType
@@ -126,7 +125,6 @@ describe('rejections', () => {
       component,
     })
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const _router = createRouter([], {
       rejections: [myCustomRejection],
     })
@@ -146,7 +144,6 @@ describe('rejections', () => {
       rejections: [myPluginRejection],
     })
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const _router = createRouter([], {}, [plugin])
 
     type Source = Parameters<typeof _router.reject>[0]

--- a/src/services/valibot.spec-d.ts
+++ b/src/services/valibot.spec-d.ts
@@ -11,7 +11,6 @@ test('withParams accepts valibot schemas', () => {
 })
 
 test('ExtractParamType returns the correct type for valibot params', () => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const param = boolean()
   type Input = ExtractParamType<typeof param>
 

--- a/src/services/withParams.spec-d.ts
+++ b/src/services/withParams.spec-d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { expectTypeOf, test } from 'vitest'
 import { withParams, WithParams } from '@/services/withParams'
 

--- a/src/services/zod.spec-d.ts
+++ b/src/services/zod.spec-d.ts
@@ -11,7 +11,6 @@ test('withParams accepts zod schemas', () => {
 })
 
 test('ExtractParamType returns the correct type for zod params', () => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const param = z.boolean()
   type Input = ExtractParamType<typeof param>
 

--- a/src/types/resolved.spec-d.ts
+++ b/src/types/resolved.spec-d.ts
@@ -5,7 +5,6 @@ import { withParams } from '@/services/withParams'
 import { createRoute } from '@/services/createRoute'
 
 test('given a specific Route, params are narrow', () => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const testRoute = createRoute({
     name: 'parentA',
     path: '/parentA/[paramA]',

--- a/src/types/route.spec-d.ts
+++ b/src/types/route.spec-d.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { describe, expectTypeOf, test } from 'vitest'
 import { withParams } from '@/services/withParams'
 import { withDefault } from '@/services/withDefault'

--- a/src/types/routeWithParams.spec-d.ts
+++ b/src/types/routeWithParams.spec-d.ts
@@ -8,7 +8,6 @@ test('RouteGetByName works as expected', () => {
     path: '/parentA/[paramA]',
   })
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const childA = createRoute({
     parent: parentA,
     name: 'parentA.childA',


### PR DESCRIPTION
we **frequently** will define variables in spec-d.ts files that are "unused" from an eslint perspective

```ts
const source = withParams('/something-without-params', {})
type Source = typeof source
```

Previously our solution was to just add "eslint-disable" comments, this PR updates the eslint config to automatically disable that rule when inside of a `.spec-d.ts` file