### PR TITLE
hotfix: insert base route logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "homepage": "https://github.com/kitbagjs/router#readme",
   "scripts": {
     "build": "vite build",
+    "build:watch": "vite build --watch --minify=false",
     "dev": "vite build --watch --minify=false",
     "test": "vitest",
     "lint": "eslint ./src",

--- a/src/services/getRoutesForRouter.ts
+++ b/src/services/getRoutesForRouter.ts
@@ -17,7 +17,6 @@ type RouterRoutes = {
  * @throws {DuplicateNamesError} If there are duplicate names in the routes.
  */
 export function getRoutesForRouter(routes: Routes | Routes[], plugins: RouterPlugin[] = [], base?: string): RouterRoutes {
-  // Map of route name to route
   const routerRoutes = new Map<string, Route>()
 
   const allRoutes = [
@@ -40,9 +39,7 @@ export function getRoutesForRouter(routes: Routes | Routes[], plugins: RouterPlu
       return
     }
 
-    insertBaseRoute(route, base)
-
-    routerRoutes.set(route.name, route)
+    routerRoutes.set(route.name, insertBaseRoute(route, base))
 
     for (const context of route.context) {
       if (contextIsRoute(context)) {

--- a/src/services/insertBaseRoute.spec.ts
+++ b/src/services/insertBaseRoute.spec.ts
@@ -22,3 +22,13 @@ test('given value for base, returns route with base prefixed', () => {
 
   expect(response.stringify()).toBe('/kitbag/foo')
 })
+
+test('given route with path "/" and base, returns route without trailing slash', () => {
+  const base = '/kitbag'
+
+  const route = createRoute({ name: 'foo', path: '/' })
+
+  const response = insertBaseRoute(route, base)
+
+  expect(response.stringify()).toBe('/kitbag')
+})

--- a/src/services/insertBaseRoute.ts
+++ b/src/services/insertBaseRoute.ts
@@ -2,10 +2,19 @@ import { Route } from '@/types/route'
 import { stringHasValue } from '@/utilities/guards'
 import { createUrl } from '@/services/createUrl'
 import { combineUrl } from '@/services/combineUrl'
+import { isUrlWithSchema } from '@/types/url'
 
 export function insertBaseRoute(route: Route, base?: string): Route {
   if (!stringHasValue(base)) {
     return route
+  }
+
+  // edge case
+  if (isUrlWithSchema(route) && route.schema.path.value === '/') {
+    return {
+      ...route,
+      ...createUrl({ path: base }),
+    }
   }
 
   return {


### PR DESCRIPTION
we recently pivoted out logic inside [getRoutesForRouter](https://github.com/kitbagjs/router/blob/main/src/services/getRoutesForRouter.ts) AND [insertBaseRoute](https://github.com/kitbagjs/router/blob/main/src/services/insertBaseRoute.ts)

At some point we failed to account for the fact that `insertBaseRoute` no longer modifies the route and instead returns a new route. This means that while we _are_ currently calling `insertBaseRoute`, it isn't doing anything.

Separately, we also started [removing trailing slashes](https://github.com/kitbagjs/router/pull/666) by default. So I added a hot fix inside insert base route logic to account for the "root" or "home" . Basically if the path is `path: "/"`, don't combine, just use the base. Otherwise we'd see `/my-base/` for the root route.

This might end up being our default behavior for all routes in the future