### PR TITLE
export useRejection

### DIFF
--- a/src/compositions/useRejection.ts
+++ b/src/compositions/useRejection.ts
@@ -1,14 +1,13 @@
 import { InjectionKey, inject } from 'vue'
 import { RouterNotInstalledError } from '@/errors/routerNotInstalledError'
-import { RouterRejection } from '@/services/createRouterReject'
+import { RouterRejection, RouterRejections } from '@/services/createRouterReject'
 import { createRouterKeyStore } from '@/services/createRouterKeyStore'
 import { Router } from '@/types/router'
 
 export const getRouterRejectionInjectionKey = createRouterKeyStore<RouterRejection>()
 
-type UseRejectionFunction = () => RouterRejection
-
-export function createUseRejection(routerKey: InjectionKey<Router>): UseRejectionFunction {
+export function createUseRejection<TRouter extends Router>(routerKey: InjectionKey<TRouter>): () => RouterRejection<RouterRejections<TRouter>>
+export function createUseRejection(routerKey: InjectionKey<Router>): () => RouterRejection {
   const routerRejectionKey = getRouterRejectionInjectionKey(routerKey)
 
   return (): RouterRejection => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -166,6 +166,14 @@ export const useQueryValue: RouterAssets<RegisteredRouter>['useQueryValue'] = ro
  */
 export const useLink: RouterAssets<RegisteredRouter>['useLink'] = routerAssets.useLink
 
+/**
+ * A composition to access the rejection from the router.
+ *
+ * @returns The rejection from the router.
+ * @group Compositions
+ */
+export const useRejection: RouterAssets<RegisteredRouter>['useRejection'] = routerAssets.useRejection
+
 declare module 'vue' {
   export interface GlobalComponents {
     RouterView: typeof RouterView,

--- a/src/services/createRouterAssets.ts
+++ b/src/services/createRouterAssets.ts
@@ -9,6 +9,7 @@ import { createUseQueryValue } from '@/compositions/useQueryValue'
 import { createUseLink } from '@/compositions/useLink'
 import { createIsRoute } from '@/guards/routes'
 import { AddBeforeLeaveHook, AddBeforeUpdateHook, AddAfterLeaveHook, AddAfterUpdateHook } from '@/types/hooks'
+import { createUseRejection } from '@/compositions/useRejection'
 
 export type RouterAssets<TRouter extends Router> = {
   /**
@@ -125,6 +126,14 @@ export type RouterAssets<TRouter extends Router> = {
    * @group Compositions
    */
   useLink: ReturnType<typeof createUseLink<TRouter>>,
+
+  /**
+   * A composition to access the rejection from the router.
+   *
+   * @returns The rejection from the router.
+   * @group Compositions
+   */
+  useRejection: ReturnType<typeof createUseRejection<TRouter>>,
 }
 
 export function createRouterAssets<TRouter extends Router>(router: TRouter): RouterAssets<TRouter>
@@ -148,6 +157,7 @@ export function createRouterAssets<TRouter extends Router>(routerOrRouterKey: TR
   const useRouter = createUseRouter(routerKey)
   const useQueryValue = createUseQueryValue(routerKey)
   const useLink = createUseLink(routerKey)
+  const useRejection = createUseRejection(routerKey)
 
   return {
     onBeforeRouteLeave,
@@ -161,5 +171,6 @@ export function createRouterAssets<TRouter extends Router>(routerOrRouterKey: TR
     useRouter,
     useQueryValue,
     useLink,
+    useRejection,
   }
 }

--- a/src/services/createRouterReject.ts
+++ b/src/services/createRouterReject.ts
@@ -4,6 +4,8 @@ import { createResolvedRouteQuery } from '@/services/createResolvedRouteQuery'
 import { createRouteId } from '@/services/createRouteId'
 import { ResolvedRoute } from '@/types/resolved'
 import { Rejection } from '@/types/rejection'
+import { Router } from '@/types/router'
+import { RouterReject } from '@/types/routerReject'
 
 export type BuiltInRejectionType = 'NotFound'
 
@@ -11,7 +13,8 @@ export type RouterSetReject = (type: string | null) => void
 
 type GetRejectionRoute = (type: string) => ResolvedRoute
 
-export type RouterRejection = Ref<Rejection | null>
+export type RouterRejection<T extends Rejection = Rejection> = Ref<T | null>
+export type RouterRejections<TRouter extends Router> = TRouter['reject'] extends RouterReject<infer TRejections extends Rejection[]> ? TRejections[number] : never
 
 export type CreateRouterReject = {
   setRejection: RouterSetReject,


### PR DESCRIPTION
We talk about [useRejection](https://router.kitbag.dev/advanced-concepts/rejections.html#get-rejection) in docs, but a user in [our discord server](https://discord.gg/zw7dpcc5HV) pointed out that it's not actually exported!

This PR adds `useRejection` to `createRouterAssets`, attempts to use generics from router key, and most importantly exports it!