### PR TITLE
fix: route reject types

### DIFF
--- a/src/services/createRoute.spec.ts
+++ b/src/services/createRoute.spec.ts
@@ -107,6 +107,19 @@ test('given parent, context is combined', () => {
     },
   })
 
+  child.onAfterRouteEnter((_to, { push, reject }) => {
+    // ok
+    push('bRoute')
+    // @ts-expect-error should not accept an invalid route name
+    push('fakeRoute')
+    // ok
+    reject('aRejection')
+    // ok
+    reject('NotFound')
+    // @ts-expect-error should not accept an invalid rejection type
+    reject('fakeRejection')
+  })
+
   expect(child.context).toMatchObject([parentRejection, childRelated])
 })
 

--- a/src/types/routeContext.ts
+++ b/src/types/routeContext.ts
@@ -1,6 +1,6 @@
 import { CreateRouteOptions } from './createRouteOptions'
 import { Rejection, Rejections } from './rejection'
-import { GenericRoute, Routes } from './route'
+import { GenericRoute, Route, Routes } from './route'
 
 export type RouteContext = GenericRoute | Rejection
 
@@ -11,8 +11,12 @@ export type ToRouteContext<TContext extends RouteContext[] | readonly RouteConte
 export type ExtractRouteContext<
   TOptions extends CreateRouteOptions
 > = TOptions extends { context: infer TContext extends RouteContext[] }
-  ? TContext
-  : []
+  ? TOptions extends { parent: infer TParent extends Route }
+    ? [...ToRouteContext<TParent['context']>, ...TContext]
+    : TContext
+  : TOptions extends { parent: infer TParent extends Route }
+    ? ToRouteContext<TParent['context']>
+    : []
 
 export type ExtractRouteContextRoutes<
   TOptions extends CreateRouteOptions


### PR DESCRIPTION
Our types for route hooks reject weren't working. As you can see in the test I added, it would fail if you tried using a rejection type defined by the parent `context`.

<img width="1154" height="446" alt="Screenshot 2026-02-03 at 18 52 00@2x" src="https://github.com/user-attachments/assets/4196d349-8a97-4beb-b723-478ea0410aa9" />
