### PR TITLE
move type-level tests into spec-d where possible

### DIFF
--- a/src/services/createRoute.spec-d.ts
+++ b/src/services/createRoute.spec-d.ts
@@ -814,3 +814,32 @@ describe('hooks', () => {
     })
   })
 })
+
+test('given parent, context is combined', () => {
+  const parentRejection = createRejection({ type: 'aRejection' })
+  const childRelated = createRoute({ name: 'bRoute' })
+
+  const parent = createRoute({
+    meta: {
+      foo: 123,
+    },
+    context: [parentRejection],
+  })
+
+  const child = createRoute({
+    parent,
+    context: [childRelated],
+    meta: {
+      bar: 'zoo',
+    },
+  })
+
+  child.onAfterRouteEnter((_to, { push, reject }) => {
+    expectTypeOf(reject).parameters.toEqualTypeOf<['NotFound' | 'aRejection']>()
+
+    // ok
+    push('bRoute')
+    // @ts-expect-error should not accept an invalid route name
+    push('fakeRoute')
+  })
+})

--- a/src/services/createRoute.spec.ts
+++ b/src/services/createRoute.spec.ts
@@ -107,19 +107,6 @@ test('given parent, context is combined', () => {
     },
   })
 
-  child.onAfterRouteEnter((_to, { push, reject }) => {
-    // ok
-    push('bRoute')
-    // @ts-expect-error should not accept an invalid route name
-    push('fakeRoute')
-    // ok
-    reject('aRejection')
-    // ok
-    reject('NotFound')
-    // @ts-expect-error should not accept an invalid rejection type
-    reject('fakeRejection')
-  })
-
   expect(child.context).toMatchObject([parentRejection, childRelated])
 })
 

--- a/src/services/createRouter.browser.spec.ts
+++ b/src/services/createRouter.browser.spec.ts
@@ -51,20 +51,6 @@ describe('options.rejections', () => {
       rejections: [customRejection],
     })
 
-    route.onBeforeRouteUpdate((_to, { push }) => {
-      // ok
-      push('root')
-      // @ts-expect-error does not know about routes outside of context
-      push('fakeRoute')
-    })
-
-    router.onBeforeRouteUpdate((_to, { push }) => {
-      // ok
-      push('root')
-      // @ts-expect-error does not know about routes outside of router
-      push('fakeRoute')
-    })
-
     const root = {
       template: '<RouterView/>',
     }

--- a/src/services/createRouter.spec-d.ts
+++ b/src/services/createRouter.spec-d.ts
@@ -171,10 +171,13 @@ describe('options.rejections in hooks', () => {
       rejections: [customRejection],
     })
 
-    route.onBeforeRouteUpdate((_to, { reject }) => {
-      type RejectParam = Parameters<typeof reject>[0]
+    route.onBeforeRouteUpdate((_to, { reject, push }) => {
+      expectTypeOf(reject).parameters.toEqualTypeOf<[BuiltInRejectionType]>()
 
-      expectTypeOf<RejectParam>().toEqualTypeOf<BuiltInRejectionType>()
+      // ok
+      push('root')
+      // @ts-expect-error does not know about routes outside of context
+      push('fakeRoute')
     })
   })
 
@@ -195,10 +198,13 @@ describe('options.rejections in hooks', () => {
       rejections: [customRejection],
     })
 
-    router.onBeforeRouteUpdate((_to, { reject }) => {
-      type RejectParam = Parameters<typeof reject>[0]
+    router.onBeforeRouteUpdate((_to, { reject, push }) => {
+      expectTypeOf(reject).parameters.toEqualTypeOf<[BuiltInRejectionType | 'CustomRejection']>()
 
-      expectTypeOf<RejectParam>().toEqualTypeOf<BuiltInRejectionType | 'CustomRejection'>()
+      // ok
+      push('root')
+      // @ts-expect-error does not know about routes outside of router
+      push('fakeRoute')
     })
   })
 })


### PR DESCRIPTION
There are still quite a few instances of `@ts-expect-error` in non-spec-d tests. I would love to have moved more but I struggled to find the right way to write tests when
- testing a function like `push`, which has overloads and is hard to use
- testing immutability of properties

I still moved these hard to test assertions into spec-d files, since testing the types is the goal there.