### PR TITLE
fix: return component value in RouterView slot context

### DIFF
--- a/src/components/routerView.ts
+++ b/src/components/routerView.ts
@@ -15,7 +15,7 @@ export type RouterViewProps = {
 type RouterViewSlots = {
   default?: (props: {
     route: RouterRoute,
-    component: Component,
+    component: Component | null,
     rejection: UnwrapRef<RouterRejection>,
   }) => VNode,
 }
@@ -66,7 +66,7 @@ export function createRouterView<TRouter extends Router>(routerKey: InjectionKey
       if (context.slots.default) {
         return context.slots.default({
           route,
-          component,
+          component: component.value,
           rejection: rejection.value,
         })
       }


### PR DESCRIPTION
fixes bug reported by user in discord. When using RouterView slot (like when using transitions)

```html
<router-view>
  <template #default="{ component }">
    <transition name="fade">
      <component :is="component" />
    </transition>
  </template>
</router-view>
```

the `component` is typed wrong and appears to _actually_ be a computed, causes console warning

<img width="1454" height="204" alt="Screenshot 2026-02-06 at 13 53 40@2x" src="https://github.com/user-attachments/assets/e07bc4e3-097f-453d-a8ab-a0704cd9ab92" />
