### PR TITLE
add title property to route, sets document.title

### DIFF
--- a/src/services/createRouter.browser.spec.ts
+++ b/src/services/createRouter.browser.spec.ts
@@ -75,3 +75,40 @@ describe('options.rejections', () => {
     expect(wrapper.html()).toBe('<div>This is a custom rejection</div>')
   })
 })
+
+test('document title is set', async () => {
+  const root = createRoute({
+    name: 'root',
+    component,
+    path: '/',
+    title: 'Root Title',
+  })
+
+  const routeWithTitle = createRoute({
+    name: 'parent',
+    component,
+    path: '/parent',
+    title: 'Parent Title',
+  })
+
+  const routeWithTitleFunction = createRoute({
+    parent: routeWithTitle,
+    name: 'child',
+    component,
+    path: '/child',
+    title: (parent) => `${parent} + Child Title`,
+  })
+
+  const router = createRouter([root, routeWithTitle, routeWithTitleFunction], { initialUrl: '/' })
+  await router.start()
+
+  expect(document.title).toBe('Root Title')
+
+  await router.push('parent')
+
+  expect(document.title).toBe('Parent Title')
+
+  await router.push('child')
+
+  expect(document.title).toBe('Parent Title + Child Title')
+})

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -9,6 +9,7 @@ import { createRouterHooks, getRouterHooksKey } from '@/services/createRouterHoo
 import { createRouterReject } from '@/services/createRouterReject'
 import { getInitialUrl } from '@/services/getInitialUrl'
 import { setStateValues } from '@/services/state'
+import { setDocumentTitle } from '@/services/setDocumentTitle'
 import { Routes } from '@/types/route'
 import { Router, RouterOptions } from '@/types/router'
 import { RouterPush, RouterPushOptions } from '@/types/routerPush'
@@ -165,6 +166,7 @@ export function createRouter<
 
     if (!isExternal(url)) {
       setPropsAndUpdateRoute(navigationId, to, from)
+      setDocumentTitle(to)
     }
 
     const afterResponse = await hooks.runAfterRouteHooks({ to, from })

--- a/src/services/setDocumentTitle.ts
+++ b/src/services/setDocumentTitle.ts
@@ -1,0 +1,22 @@
+import { ResolvedRoute } from '@/types/resolved'
+import { isBrowser } from '@/utilities/isBrowser'
+
+export function setDocumentTitle(to: ResolvedRoute): void {
+  if (!isBrowser()) {
+    return
+  }
+
+  const title = to.matches.reduce<string | null>((title, { title: matchTitle }) => {
+    if (!matchTitle) {
+      return title
+    }
+
+    if (typeof matchTitle === 'function') {
+      return matchTitle(title)
+    }
+
+    return matchTitle
+  }, null)
+
+  document.title = title ?? ''
+}

--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -107,6 +107,10 @@ export type CreateRouteOptions<
    * Related routes and rejections for the route. The context is exposed to the hooks and props callback functions for this route.
    */
   context?: RouteContext[],
+  /**
+   * The string value to be assigned to the document title when the route is matched.
+   */
+  title?: string | ((parent: string | null) => string),
 }
 
 export type PropsGetter<


### PR DESCRIPTION
This PR adds a new optional `title` property to `createRoute` options. The value is either `String` | `(parent: string | null) => string`.

```ts
createRoute({
  name: 'settings',
  title: 'Settings',
  ...
})

createRoute({
  name: 'settings.profile',
  title: (parent) => `${parent} - Profile`,
  ...
})
```

<img width="456" height="82" alt="Screenshot 2026-02-09 at 08 56 49@2x" src="https://github.com/user-attachments/assets/67cf90eb-d21b-4554-9e67-ca30c61d95ec" />

**(Documentation needed)**

It would also be cool to provide `params`, but for the types to work correctly we'd have to find another position for the param so we can properly infer the generics defined in the 1st argument of `createRoute` (same problem as the props callback)

Perhaps we wait on this PR and update the 2nd argument of `createRoute` to be an options record?

```ts
createRoute({
  name: 'foo',
  path: '/foo/[bar]',
}, {
  props: () => ...
  title: () => ...
})
```