### PR TITLE
Fix params reactivity when destructured using toRefs

### DIFF
--- a/src/services/createRouter.spec.ts
+++ b/src/services/createRouter.spec.ts
@@ -283,6 +283,36 @@ test('params are writable', async () => {
   })
 })
 
+test('params can be destructured', async () => {
+  const root = createRoute({
+    name: 'root',
+    component,
+    path: '/[paramA]/[paramB]',
+  })
+
+  const { route, start, push } = createRouter([root], {
+    initialUrl: '/one/two',
+  })
+
+  await start()
+
+  const { paramA, paramB } = toRefs(route.params)
+
+  expect(paramA.value).toBe('one')
+  expect(paramB.value).toBe('two')
+
+  await push('root', { paramA: 'three', paramB: 'four' })
+
+  expect(paramA.value).toBe('three')
+  expect(paramB.value).toBe('four')
+
+  paramA.value = 'five'
+
+  await flushPromises()
+
+  expect(route.params.paramA).toBe('five')
+})
+
 test('query is writable', async () => {
   const root = createRoute({
     name: 'root',

--- a/src/services/createRouterRoute.ts
+++ b/src/services/createRouterRoute.ts
@@ -53,15 +53,26 @@ export function createRouterRoute<TRoute extends ResolvedRoute>(routerKey: Injec
 
   const { id, matched, matches, hooks, name, hash, href } = toRefs(route)
 
+  const paramsProxy = new Proxy({}, {
+    get(_target, property, receiver) {
+      return Reflect.get(route.params, property, receiver)
+    },
+    set(_target, property, value) {
+      update(property, value)
+
+      return true
+    },
+    ownKeys() {
+      return Reflect.ownKeys(route.params)
+    },
+    getOwnPropertyDescriptor(_target, prop) {
+      return Reflect.getOwnPropertyDescriptor(route.params, prop)
+    },
+  })
+
   const params = computed({
     get() {
-      return new Proxy(route.params, {
-        set(_target, property, value) {
-          update(property, value)
-
-          return true
-        },
-      })
+      return paramsProxy
     },
     set(params) {
       update(params)


### PR DESCRIPTION
# Description
This simple example was reported as not working by a user in discord

```ts
const route = useRoute('name');
const { tab } = toRefs(route.params);
```

The issue was with how we were creating the proxy for params. 
1. The proxy was being created within the computed property's getter. This means the proxy is recreated each time params are updated, which breaks reactivity anything that isn't using direct property access like `route.params.paramA`.
2. The proxy itself did not have enumerable properties so `toRefs` could not detect the actual reactive properties

Added a new unit test which failed to reproduce the issue and then fixed the issue with the proxy by creating the proxy outside of the computed getter and adding traps for enumerations. 