### PR TITLE
code review suggestions

### DIFF
--- a/src/services/createResolvedRoute.ts
+++ b/src/services/createResolvedRoute.ts
@@ -14,7 +14,7 @@ export function createResolvedRoute(route: Route, params: Record<string, unknown
   })
   const { query, hash } = parseUrl(href)
 
-  const getTitle: GetTitle = (to) => {
+  const getTitle: GetTitle = async (to) => {
     if (isRouteWithTitle(route)) {
       return route.getTitle(to)
     }

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -188,11 +188,7 @@ export function createRouter<
         throw new Error(`Switch is not exhaustive for after hook response status: ${JSON.stringify(exhaustive)}`)
     }
 
-    const title = await to.getTitle(to)
-
-    if (title) {
-      setDocumentTitle(title)
-    }
+    to.getTitle(to).then(setDocumentTitle)
 
     history.startListening()
   }

--- a/src/services/createRouterReject.ts
+++ b/src/services/createRouterReject.ts
@@ -50,7 +50,7 @@ export function createRouterReject(rejections: Rejection[]): CreateRouterReject 
       state: {},
       href: '/',
       hash: '',
-      getTitle: () => undefined,
+      getTitle: async () => undefined,
     }
   }
 

--- a/src/types/titles.browser.spec.ts
+++ b/src/types/titles.browser.spec.ts
@@ -2,6 +2,7 @@ import { beforeEach, expect, test, vi } from 'vitest'
 import { createRoute } from '@/services/createRoute'
 import { component } from '@/utilities/testHelpers'
 import { createRouter } from '@/main'
+import { flushPromises } from '@vue/test-utils'
 
 const setDocumentTitle = vi.hoisted(() => vi.fn())
 
@@ -29,26 +30,12 @@ test('route with title updates document title', async () => {
     initialUrl: '/',
   })
 
-  await router.start()
+  router.start()
+
+  await flushPromises()
 
   expect(callback).toHaveBeenCalledTimes(1)
   expect(setDocumentTitle).toHaveBeenCalledWith(title)
-})
-
-test('route without title does not update document title', async () => {
-  const route = createRoute({
-    name: 'root',
-    path: '/',
-    component,
-  })
-
-  const router = createRouter([route], {
-    initialUrl: '/',
-  })
-
-  await router.start()
-
-  expect(setDocumentTitle).not.toHaveBeenCalled()
 })
 
 test('route with title and parent with title does not call parent getTitle', async () => {
@@ -74,7 +61,9 @@ test('route with title and parent with title does not call parent getTitle', asy
     initialUrl: '/parent/child',
   })
 
-  await router.start()
+  router.start()
+
+  await flushPromises()
 
   expect(parentGetTitle).not.toHaveBeenCalled()
   expect(childGetTitle).toHaveBeenCalledTimes(1)
@@ -109,7 +98,9 @@ test('route with title and parent with title does call parent getTitle when call
     initialUrl: '/parent/child',
   })
 
-  await router.start()
+  router.start()
+
+  await flushPromises()
 
   expect(parentGetTitle).toHaveBeenCalledTimes(1)
   expect(childGetTitle).toHaveBeenCalledTimes(1)
@@ -151,7 +142,9 @@ test('route with title and parent with title does call parent getTitle when call
     initialUrl: '/parent/child/grandchild',
   })
 
-  await router.start()
+  router.start()
+
+  await flushPromises()
 
   expect(parentGetTitle).toHaveBeenCalledTimes(1)
   expect(grandchildGetTitle).toHaveBeenCalledTimes(1)
@@ -178,7 +171,9 @@ test('route without title and parent with title updates document title', async (
     initialUrl: '/parent/child',
   })
 
-  await router.start()
+  router.start()
+
+  await flushPromises()
 
   expect(setDocumentTitle).toHaveBeenCalledWith('parent')
 })

--- a/src/types/titles.ts
+++ b/src/types/titles.ts
@@ -8,7 +8,7 @@ export type SetTitleContext = {
 }
 
 export type SetTitleCallback<TRoute extends Route = Route> = (to: ResolvedRouteUnion<TRoute>, context: SetTitleContext) => MaybePromise<string>
-export type GetTitle<TRoute extends Route = Route> = (to: ResolvedRouteUnion<TRoute>) => MaybePromise<string | undefined>
+export type GetTitle<TRoute extends Route = Route> = (to: ResolvedRouteUnion<TRoute>) => Promise<string | undefined>
 export type SetTitle<TRoute extends Route = Route> = (callback: SetTitleCallback<TRoute>) => void
 
 export type RouteTitle<TRoute extends Route = Route> = {
@@ -36,7 +36,7 @@ export function createRouteTitle(parent: Route | undefined): RouteTitle {
     setTitleCallback = callback
   }
 
-  const getTitle: GetTitle = (to) => {
+  const getTitle: GetTitle = async (to) => {
     const getParentTitle = async (): Promise<string | undefined> => {
       if (parent && isRouteWithTitle(parent)) {
         return parent.getTitle(to)

--- a/src/utilities/setDocumentTitle.ts
+++ b/src/utilities/setDocumentTitle.ts
@@ -1,7 +1,10 @@
 import { isBrowser } from '@/utilities/isBrowser'
 
+let defaultTitle: string
+
 export function setDocumentTitle(title: string | undefined): void {
-  if (isBrowser() && title !== undefined) {
-    document.title = title
+  if (isBrowser()) {
+    defaultTitle ??= document.title
+    document.title = title ?? defaultTitle
   }
 }


### PR DESCRIPTION
This PR adds 2 suggestions

1.) `getTitle` is now always a promise, which enables us to pretty easily trigger the setting of document title without awaiting. 

```ts
to.getTitle(to).then(setDocumentTitle)
```

2.) `setDocumentTitle` accepts `undefined`, and will revert to whatever the initial document title was