### PR TITLE
fix types for date and JSON params

### DIFF
--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -77,13 +77,17 @@ Param extends TParam
   ? unknown
   : TParam extends ParamGetSet<infer Type>
     ? Type
-    : TParam extends ParamGetter
-      ? ReturnType<TParam>
-      : TParam extends StandardSchemaV1
-        ? StandardSchemaV1.InferOutput<TParam>
-        : TParam extends LiteralParam
-          ? TParam
-          : string
+    : TParam extends DateConstructor
+      ? Date
+      : TParam extends JSON
+        ? unknown
+        : TParam extends ParamGetter
+          ? ReturnType<TParam>
+          : TParam extends StandardSchemaV1
+            ? StandardSchemaV1.InferOutput<TParam>
+            : TParam extends LiteralParam
+              ? TParam
+              : string
 
 export type ParamIsOptional<TParam extends string> = TParam extends `?${string}` ? true : false
 export type ParamIsGreedy<TParam extends string> = TParam extends `${string}*` ? true : false


### PR DESCRIPTION
We had a user [in discord](https://discord.com/channels/1240867447033172138/1476922913444593694) mention that the the types system was expecting him to supply "string" to JSON. This is incorrect, JSON should be using `unknown` for its types. Looks like the `ExtractParamType` type just needs a couple more explicit cases. We probably assumed each of the primitives would satisfy `ParamGetter` but in actuality both JSON and Date were falling through to the default case (`string`). 