### PR TITLE
Simplify the output from ToRoute by stripping out component and components

### DIFF
--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -8,7 +8,7 @@ import { Route } from '@/types/route'
 import { ResolvedRoute } from './resolved'
 import { ComponentProps } from '@/services/component'
 import { PropsCallbackContext } from './props'
-import { MaybePromise } from './utilities'
+import { Identity, MaybePromise } from './utilities'
 import { ToMeta } from './meta'
 import { ToState } from './state'
 import { ToName } from './name'
@@ -40,6 +40,12 @@ export function isWithParent<T extends Record<string, unknown>>(options: T): opt
 export type WithoutParent = {
   parent?: never,
 }
+
+/**
+ * This type is used to strip the component and components properties from the options object
+ * when creating a Route to simplify and minimize the output type.
+ */
+type WithoutComponents = { component: never, components: never }
 
 export function isWithComponent<T extends Record<string, unknown>>(options: T): options is T & { component: Component } {
   return 'component' in options && Boolean(options.component)
@@ -140,7 +146,7 @@ export type CreateRouteProps<
 
 type ToMatch<
   TOptions extends CreateRouteOptions,
-  TProps extends CreateRouteProps<TOptions> | undefined
+  TProps
 > = Omit<TOptions, 'props' | 'meta' | 'name'> & {
   id: string,
   name: ToName<TOptions['name']>,
@@ -156,7 +162,7 @@ type ToMatches<
   TProps extends CreateRouteProps<TOptions> | undefined
 > = TOptions extends { parent: infer TParent extends Route }
   ? [...TParent['matches'], ToMatch<TOptions, TProps>]
-  : [ToMatch<TOptions, TProps>]
+  : [ToMatch<Identity<TOptions & WithoutComponents>, TProps>]
 
 export type ToRoute<
   TOptions extends CreateRouteOptions,
@@ -166,7 +172,7 @@ export type ToRoute<
   : TOptions extends { parent: infer TParent extends Route }
     ? Route<
       ToName<TOptions['name']>,
-      CombineUrl<TParent, ToUrl<TOptions>>,
+      CombineUrl<TParent, ToUrl<TOptions & WithoutComponents>>,
       CombineMeta<ToMeta<TParent['meta']>, ToMeta<TOptions['meta']>>,
       CombineState<ToState<TParent['state']>, ToState<TOptions['state']>>,
       ToMatches<TOptions, CreateRouteProps<TOptions> extends TProps ? undefined : TProps>,
@@ -174,7 +180,7 @@ export type ToRoute<
     >
     : Route<
       ToName<TOptions['name']>,
-      ToUrl<TOptions>,
+      ToUrl<Identity<TOptions & WithoutComponents>>,
       ToMeta<TOptions['meta']>,
       ToState<TOptions['state']>,
       ToMatches<TOptions, CreateRouteProps<TOptions> extends TProps ? undefined : TProps>,


### PR DESCRIPTION
# Description
When calling `createRoute` the options object is passed to several type utilities such as `ToUrl`, `ToMatches`, and `ToMatch`. These types are conditional types and are evaluated lazily. This mean that the entire options object type is included in the return type 3 separate times. This significantly bloats the return type. 

I believe this is the underlying cause of https://github.com/kitbagjs/router/issues/717 because when components are added to routes the entire component type shows up in the return type 3 separate times. Component types for SFC are very long and complex. Which I believe is what ultimately leads to the TS7056 error. 

Though this adds a bit of complexity to the types I think this is a good change even if it doesn't solve the mentioned issue. 

## Example
This route (which is actually pretty simple since it doesn't use SFCs) 
```ts
  const parent = createRoute({
    name: 'parent',
    components: {
      one: component,
      two: component,
      three: component,
    },
  }, {
    one: () => ({ foo: 123 }),
    two: () => ({ bar: 456 }),
  })
```

Would produce this for just 1 of the three places where route options were used
```ts
ToUrl<{
    readonly name: "parent";
    readonly components: {
        readonly one: {
            template: string;
        };
        readonly two: {
            template: string;
        };
        readonly three: {
            template: string;
        };
    };
}> & { ... } 
```

After this change all 3 places have components stripped out of the return type
```ts
ToUrl<{
    readonly name: "parent";
}> & { ... }
```