### PR TITLE
drop defaultTitle from setDocumentTitle logic

### DIFF
--- a/src/utilities/setDocumentTitle.ts
+++ b/src/utilities/setDocumentTitle.ts
@@ -2,16 +2,16 @@ import { ResolvedRoute } from '@/types/resolved'
 import { isRoute } from '@/types/route'
 import { isBrowser } from '@/utilities/isBrowser'
 
-let defaultTitle: string | undefined
-
 export function setDocumentTitle(to: ResolvedRoute | null): void {
   if (!isRoute(to) || !isBrowser()) {
     return
   }
 
-  defaultTitle ??= document.title
-
   to.title.then((value) => {
-    document.title = value ?? defaultTitle ?? ''
+    if (value === undefined) {
+      return
+    }
+
+    document.title = value
   })
 }


### PR DESCRIPTION
closes #765 

When we added the document title support to routes, we predicted routes that would control title and routes that wouldn't. The idea was to capture the "default title" (probably whatever is in the index.html) when the router is initialized and then go back to that title whenever we're navigating to a route that doesn't control the title. What this failed to consider are use cases like the one sent by @deadbaed, where the title is set elsewhere (in this case a component) the router's current logic doesn't consider a title that will change, or one that gets set later in the lifecycle. 

The solution is to simply drop the attempt to revert to a default title and leave the problem in user's hands. Probably either setting a default title in a "root" `route.setTitle` if you want the functionality we previously attempted to have by default