### PR TITLE
v0.24.3 - fix broken types bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kitbag/router",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@kitbag/router",
-      "version": "0.24.2",
+      "version": "0.24.3",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "homepage": "https://github.com/kitbagjs/router#readme",
   "scripts": {
     "build": "vite build",
+    "prepublishOnly": "npm run build",
     "build:watch": "vite build --watch --minify=false",
     "dev": "vite build --watch --minify=false",
     "test": "vitest",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@kitbag/router",
   "private": false,
-  "version": "0.24.2",
+  "version": "0.24.3",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/kitbagjs/router/issues"


### PR DESCRIPTION
## Summary
- Republish to fix the broken types entry shipped in v0.24.2: `dist/kitbag-router.d.ts` went out as just `export {}`, so every named import (`createRejection`, `createRouter`, etc.) appeared as a missing export to consumers. The runtime `.js` bundle was fine — only the `.d.ts` entry was empty.
- Add a `prepublishOnly` script so `npm publish` always runs `npm run build` first, preventing a stale/partial dist from being published again.

## Test plan
- [ ] After merge + publish, install `@kitbag/router@0.24.3` in a fresh project and confirm `import { createRejection } from '@kitbag/router'` resolves
- [ ] Confirm `dist/kitbag-router.d.ts` in the published tarball contains `export * from './src/main'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)