### PR TITLE
Update docs to use the addView syntax

### DIFF
--- a/docs/advanced-concepts/prefetching.md
+++ b/docs/advanced-concepts/prefetching.md
@@ -12,18 +12,20 @@ import { defineAsyncComponent } from 'vue'
 const user = createRoute({
   name: 'user',
   path: '/user/[id]',
-}).addView(defineAsyncComponent(() => import('./UserPage.vue'))) // [!code focus]
+})
+.addView(defineAsyncComponent(() => import('./UserPage.vue'))) // [!code focus]
 ```
 
 ## Prefetching Props
 
 When your route uses the [props callback](/core-concepts/component-props), Kitbag Router can start fetching your component props before they are needed.
 
-```ts {4-8}
+```ts {5-8}
 const user = createRoute({
   name: 'user',
   path: '/user/[id]',
-}).addView(defineAsyncComponent(() => import('./UserPage.vue')), async (route) => {
+})
+.addView(defineAsyncComponent(() => import('./UserPage.vue')), async (route) => {
   const user = await userStore.getById(route.params.id)
   return { user }
 })
@@ -102,12 +104,14 @@ If you want to enable or disable prefetching for specific routes, you can do so 
 const about = createRoute({
   path: '/about',
   prefetch: true, // enable prefetching for this route
-}).addView(() => import('./About.vue'))
+})
+.addView(() => import('./About.vue'))
 
 const contact = createRoute({
   path: '/contact',
   prefetch: false, // disable prefetching for this route
-}).addView(() => import('./Contact.vue'))
+})
+.addView(() => import('./Contact.vue'))
 ```
 
 ### Per-Link Configuration

--- a/docs/advanced-concepts/prefetching.md
+++ b/docs/advanced-concepts/prefetching.md
@@ -12,21 +12,19 @@ import { defineAsyncComponent } from 'vue'
 const user = createRoute({
   name: 'user',
   path: '/user/[id]',
-  component: defineAsyncComponent(() => import('./UserPage.vue')), // [!code focus]
-})
+}).addView(defineAsyncComponent(() => import('./UserPage.vue'))) // [!code focus]
 ```
 
 ## Prefetching Props
 
 When your route uses the [props callback](/core-concepts/component-props), Kitbag Router can start fetching your component props before they are needed.
 
-```ts {5-9}
+```ts {4-8}
 const user = createRoute({
   name: 'user',
   path: '/user/[id]',
-  component: defineAsyncComponent(() => import('./UserPage.vue')),
-}, async (({ id }) => {
-  const user = await userStore.getById(id)
+}).addView(defineAsyncComponent(() => import('./UserPage.vue')), async (route) => {
+  const user = await userStore.getById(route.params.id)
   return { user }
 })
 ```
@@ -103,15 +101,13 @@ If you want to enable or disable prefetching for specific routes, you can do so 
 ```ts
 const about = createRoute({
   path: '/about',
-  component: () => import('./About.vue'),
   prefetch: true, // enable prefetching for this route
-})
+}).addView(() => import('./About.vue'))
 
 const contact = createRoute({
   path: '/contact',
-  component: () => import('./Contact.vue'),
   prefetch: false, // disable prefetching for this route
-})
+}).addView(() => import('./Contact.vue'))
 ```
 
 ### Per-Link Configuration

--- a/docs/advanced-concepts/route-meta.md
+++ b/docs/advanced-concepts/route-meta.md
@@ -9,19 +9,17 @@ const routes = [
   createRoute({ 
     name: 'home',
     path: '/',
-    component: Home,
     meta: {
       pageTitle: 'Kitbag Home'
     }
-  }),
+  }).addView(Home),
   createRoute({ 
     name: 'path',
     path: '/about',
-    component: About,
     meta: {
       pageTitle: 'Learn More About Kitbag'
     }
-  }),
+  }).addView(About),
 ] as const
 
 const router = createRouter(routes)

--- a/docs/advanced-concepts/route-meta.md
+++ b/docs/advanced-concepts/route-meta.md
@@ -12,14 +12,17 @@ const routes = [
     meta: {
       pageTitle: 'Kitbag Home'
     }
-  }).addView(Home),
+  })
+  .addView(Home),
+
   createRoute({ 
     name: 'path',
     path: '/about',
     meta: {
       pageTitle: 'Learn More About Kitbag'
     }
-  }).addView(About),
+  })
+  .addView(About),
 ] as const
 
 const router = createRouter(routes)

--- a/docs/advanced-concepts/route-narrowing.md
+++ b/docs/advanced-concepts/route-narrowing.md
@@ -8,29 +8,25 @@ import { createRoute, createRouter } from '@kitbag/router'
 const home = createRoute({
   name: 'home',
   path: '/',
-  component: ...,
-})
+}).addView(...)
 
 const user = createRoute({
   name: 'user',
   path: '/user/[userId]',
-  component: ...,
-})
+}).addView(...)
 
 const profile = createRoute({
   parent: user,
   name: 'user.profile',
   path: '/profile',
   query: '?tab=[tab]',
-  component: ...,
-})
+}).addView(...)
 
 const settings = createRoute({
   parent: user,
   name: 'user.settings',
   path: '/settings',
-  component: ...,
-})
+}).addView(...)
 
 const router = createRouter([home, user, profile, settings])
 

--- a/docs/advanced-concepts/route-narrowing.md
+++ b/docs/advanced-concepts/route-narrowing.md
@@ -8,25 +8,25 @@ import { createRoute, createRouter } from '@kitbag/router'
 const home = createRoute({
   name: 'home',
   path: '/',
-}).addView(...)
+})
 
 const user = createRoute({
   name: 'user',
   path: '/user/[userId]',
-}).addView(...)
+})
 
 const profile = createRoute({
   parent: user,
   name: 'user.profile',
   path: '/profile',
   query: '?tab=[tab]',
-}).addView(...)
+})
 
 const settings = createRoute({
   parent: user,
   name: 'user.settings',
   path: '/settings',
-}).addView(...)
+})
 
 const router = createRouter([home, user, profile, settings])
 

--- a/docs/core-concepts/component-props.md
+++ b/docs/core-concepts/component-props.md
@@ -1,13 +1,12 @@
 # Component Props
 
-With Kitbag Router, you can define a `props` callback on your route. Your callback is given the [`ResolvedRoute`](/api/types/ResolvedRoute) for the route and what it returns will be bound to the component when the component gets mounted inside the `<router-view />`
+With Kitbag Router, you can pass a `props` getter when adding a view with [`addView`](/core-concepts/routes#views). Your callback is given the [`ResolvedRoute`](/api/types/ResolvedRoute) for the route and what it returns will be bound to the component when the component gets mounted inside the `<router-view />`
 
-```ts {5}
+```ts {4}
 const user = createRoute({
   name: 'user',
   path: '/user/[id]',
-  component: UserComponent,
-}, (route) => ({ userId: route.params.id }))
+}).addView(UserComponent, (route) => ({ userId: route.params.id }))
 ```
 
 This is obviously useful for assigning static values or route params down to your view components props but it also gives you
@@ -17,20 +16,15 @@ This is obviously useful for assigning static values or route params down to you
 - Support for async prop fetching.
 
 ## Named Views
-When using the [`components`](/core-concepts/routes.html#components) property the `props` argument must be an object. Each component can have its own props callback.
+Each [named view](/core-concepts/routes#named-views) can have its own props getter. Just pass the getter after the component when calling `addView`.
 
-```ts {5-6,9-10}
+```ts {5-6}
 const user = createRoute({
   name: 'user',
   path: '/user/[id]',
-  components: {
-    default: UserComponent,
-    sidebar: UserSidebarComponent,
-  }
-}, {
-  default: (route) => ({ userId: route.params.id }),
-  sidebar: (route) => ({ userId: route.params.id })
 })
+  .addView(UserComponent, (route) => ({ userId: route.params.id }))
+  .addView('sidebar', UserSidebarComponent, (route) => ({ userId: route.params.id }))
 ```
 
 ## Params Type
@@ -45,12 +39,11 @@ Your callback will throw a Typescript error if it returns anything other than th
 
 The props call back supports promises. This means you can do much more than just forward values from params or insert static values. For example, we can take an id route param and fetch the `User` before mounting the component.
 
-```ts {5-9}
+```ts {4-8}
 const user = createRoute({
   name: 'user',
   path: '/user/[id]',
-  component: UserComponent,
-}, async (route) => {
+}).addView(UserComponent, async (route) => {
   const user = await userStore.getById(route.params.id)
 
   return { user }
@@ -64,27 +57,26 @@ The [callback context](/core-concepts/component-props#context) includes a `paren
 ```ts
 const blogPost = createRoute({
   name: 'blog',
-  path: '/blog/[blogPostId]'
-}, async (route) => {
-  const post = await getBlockPostById(route.params.blogPostId)
+  path: '/blog/[blogPostId]',
+}).addView(BlogPost, async (route) => {
+  const post = await getBlogPostById(route.params.blogPostId)
 
   return {
-    post
+    post,
   }
 })
 
 const blogPostTabs = createRoute({
   parent: blogPost,
   name: 'tabs',
-  query: '?tab=[tab]'
-  component: PostTabs,
-}, async (route, { parent }) => {
+  query: '?tab=[tab]',
+}).addView(PostTabs, async (route, { parent }) => {
   const tab = route.query.tab
   const { post } = await parent.props
 
-  return { 
+  return {
     tab,
-    post
+    post,
   }
 })
 ```
@@ -112,8 +104,7 @@ Unlike [hooks](/advanced-concepts/hooks), props are not awaited during navigatio
 const user = createRoute({
   name: 'user',
   path: '/user/[id]',
-  component: UserComponent,
-}, async (route, { reject }) => {
+}).addView(UserComponent, async (route, { reject }) => {
   try {
     const user = await userStore.getById(route.params.id)
 
@@ -121,7 +112,7 @@ const user = createRoute({
   } catch (error) {
     reject('NotFound')
   }
-}))
+})
 ```
 
 ## Global Injection
@@ -133,7 +124,7 @@ import { inject } from 'vue'
 
 const route = createRoute({
   ...
-}, async () => {
+}).addView(SomeComponent, async () => {
   const value = inject('global')
 
   return { value }

--- a/docs/core-concepts/component-props.md
+++ b/docs/core-concepts/component-props.md
@@ -2,11 +2,12 @@
 
 With Kitbag Router, you can pass a `props` getter when adding a view with [`addView`](/core-concepts/routes#views). Your callback is given the [`ResolvedRoute`](/api/types/ResolvedRoute) for the route and what it returns will be bound to the component when the component gets mounted inside the `<router-view />`
 
-```ts {4}
+```ts {5}
 const user = createRoute({
   name: 'user',
   path: '/user/[id]',
-}).addView(UserComponent, (route) => ({ userId: route.params.id }))
+})
+.addView(UserComponent, (route) => ({ userId: route.params.id }))
 ```
 
 This is obviously useful for assigning static values or route params down to your view components props but it also gives you
@@ -23,8 +24,8 @@ const user = createRoute({
   name: 'user',
   path: '/user/[id]',
 })
-  .addView(UserComponent, (route) => ({ userId: route.params.id }))
-  .addView('sidebar', UserSidebarComponent, (route) => ({ userId: route.params.id }))
+.addView(UserComponent, (route) => ({ userId: route.params.id }))
+.addView('sidebar', UserSidebarComponent, (route) => ({ userId: route.params.id }))
 ```
 
 ## Params Type
@@ -39,11 +40,12 @@ Your callback will throw a Typescript error if it returns anything other than th
 
 The props call back supports promises. This means you can do much more than just forward values from params or insert static values. For example, we can take an id route param and fetch the `User` before mounting the component.
 
-```ts {4-8}
+```ts {5-9}
 const user = createRoute({
   name: 'user',
   path: '/user/[id]',
-}).addView(UserComponent, async (route) => {
+})
+.addView(UserComponent, async (route) => {
   const user = await userStore.getById(route.params.id)
 
   return { user }
@@ -58,7 +60,8 @@ The [callback context](/core-concepts/component-props#context) includes a `paren
 const blogPost = createRoute({
   name: 'blog',
   path: '/blog/[blogPostId]',
-}).addView(BlogPost, async (route) => {
+})
+.addView(BlogPost, async (route) => {
   const post = await getBlogPostById(route.params.blogPostId)
 
   return {
@@ -70,7 +73,8 @@ const blogPostTabs = createRoute({
   parent: blogPost,
   name: 'tabs',
   query: '?tab=[tab]',
-}).addView(PostTabs, async (route, { parent }) => {
+})
+.addView(PostTabs, async (route, { parent }) => {
   const tab = route.query.tab
   const { post } = await parent.props
 
@@ -104,7 +108,8 @@ Unlike [hooks](/advanced-concepts/hooks), props are not awaited during navigatio
 const user = createRoute({
   name: 'user',
   path: '/user/[id]',
-}).addView(UserComponent, async (route, { reject }) => {
+})
+.addView(UserComponent, async (route, { reject }) => {
   try {
     const user = await userStore.getById(route.params.id)
 
@@ -124,7 +129,8 @@ import { inject } from 'vue'
 
 const route = createRoute({
   ...
-}).addView(SomeComponent, async () => {
+})
+.addView(SomeComponent, async () => {
   const value = inject('global')
 
   return { value }

--- a/docs/core-concepts/routes.md
+++ b/docs/core-concepts/routes.md
@@ -84,12 +84,73 @@ const blogPost = createRoute({
 })
 ```
 
-## Component
+## Views
 
-The `component` property is used to define the component that will be rendered when the route is active. Component is optional and a [RouterView](/components/router-view) will be rendered if no component is provided.
+Use the chainable `addView` method to define which component(s) render when the route is active. Call it once for a single view, or chain it to register multiple views. If no view is added, a [RouterView](/components/router-view) is rendered by default.
 
 ```ts {6}
-import HomeView from './components/HomeView.svelte'
+import HomeView from './components/HomeView.vue'
+
+const home = createRoute({
+  name: 'home',
+  path: '/',
+}).addView(HomeView)
+```
+
+### Named Views
+
+Pass a name as the first argument to register a [named view](/components/router-view). A route can mix a default view with named views.
+
+```ts {8-9}
+import HomeView from './components/HomeView.vue'
+import HomeSidebar from './components/HomeSidebar.vue'
+
+const home = createRoute({
+  name: 'home',
+  path: '/',
+})
+  .addView(HomeView)
+  .addView('sidebar', HomeSidebar)
+```
+
+### Props
+
+Pass a props getter as the last argument to bind props to the view's component. It's a callback that returns an object (or a promise of one); everything returned is bound to the component. See [Component Props](/core-concepts/component-props) for more details.
+
+```ts {6}
+import UserView from './components/UserView.vue'
+
+const user = createRoute({
+  name: 'user',
+  path: '/user/[id]',
+}).addView(UserView, (route) => ({ userId: route.params.id }))
+```
+
+The getter is **required** when the component has required props, and optional otherwise. For named views, pass the getter after the component.
+
+#### Arguments
+
+The props callback receives two arguments:
+
+| Argument | Description |
+| -------- | ----------- |
+| route | The resolved route, including any params. See [Params](/core-concepts/params) for more details. |
+| context | An object with helper methods for navigation (`push`, `replace`, `reject`, `update`) and the `parent` route's props. See [PropsCallbackContext](/api/types/PropsCallbackContext) for more details. |
+
+#### Return Type
+
+The props callback must return an object or a promise that resolves to an object. The object must satisfy the props for the component. If the component has required props, TypeScript will error until the getter returns a matching object.
+
+## Component
+
+::: warning
+The `component` property is deprecated. Use [`addView`](#views) instead.
+:::
+
+The `component` property is used to define the component that will be rendered when the route is active.
+
+```ts {6}
+import HomeView from './components/HomeView.vue'
 
 const home = createRoute({
   name: 'home',
@@ -100,7 +161,11 @@ const home = createRoute({
 
 ## Components
 
-The `components` property is used to define multiple components for named views. This is used instead of the `component` property.
+::: warning
+The `components` property is deprecated. Use [`addView`](#named-views) with named views instead.
+:::
+
+The `components` property is used to define multiple components for named views.
 
 ```ts {7-10}
 import HomeView from './components/HomeView.vue'
@@ -118,6 +183,10 @@ const home = createRoute({
 
 ## Props
 
+::: warning
+The `props` argument is deprecated. Pass the props getter to [`addView`](#props) instead.
+:::
+
 The `props` argument is used to provide props for route components. It must be a callback function that returns an object. Everything returned from the callback will be bound to the component.
 
 ```ts {7}
@@ -130,53 +199,38 @@ const home = createRoute({
 }, () => ({ userId: 1 }))
 ```
 
-### Arguments
-
-The props callback receives two arguments:
-
-| Argument | Description |
-| -------- | ----------- |
-| params | An object containing the values of any params from the route. See [Params](/core-concepts/params) for more details. |
-| context | An object containing helper methods for navigation (`push`, `replace`, `reject`). See [PropsCallbackContext](/api/types/PropsCallbackContext) for more details. |
-
-### Return Type
-
-The props callback must return an object or a promise that resolves to an object. The object must satisfy the props for the component.
-
 ## Meta
 
 The `meta` property is used to define metadata for the route. Meta is optional and can be used to define static metadata for the route to reference in the [router route](/core-concepts/router-route) or in [hooks](/advanced-concepts/hooks)
 
-```ts {7-9}
+```ts {6-8}
 import HomeView from './components/HomeView.vue'
 
 const home = createRoute({
   name: 'home',
   path: '/',
-  component: HomeView,
   meta: {
     title: 'Home',
   },
-})
+}).addView(HomeView)
 ```
 
 ## State
 
 The `state` property is used to define optional data that can stored on the route in the browser's history. State is always optional, but it can be used to pass data to the route when navigating or to preserve state when navigating away from the route.
 
-```ts {7-11}
+```ts {6-10}
 import ContactView from './components/HomeView.vue'
 
 const contact = createRoute({
   name: 'contact',
   path: '/',
-  component: ContactView,
   state: {
     firstName: String,
     lastName: String,
     message: String,
   },
-})
+}).addView(ContactView)
 ```
 
 ## Hooks
@@ -189,8 +243,7 @@ import HomeView from './components/HomeView.vue'
 const home = createRoute({
   name: 'home',
   path: '/',
-  component: HomeView,
-})
+}).addView(HomeView)
 
 home.onBeforeRouteEnter(() => {
   console.log('before route enter')
@@ -236,8 +289,7 @@ The context for a route is the collection of routes and rejections that are asso
 const newHomePage = createRoute({
   name: 'new-home',
   path: '/',
-  component: NewHomePage,
-})
+}).addView(NewHomePage)
 
 const home = createRoute({
   name: 'home',

--- a/docs/core-concepts/routes.md
+++ b/docs/core-concepts/routes.md
@@ -88,13 +88,14 @@ const blogPost = createRoute({
 
 Use the chainable `addView` method to define which component(s) render when the route is active. Call it once for a single view, or chain it to register multiple views. If no view is added, a [RouterView](/components/router-view) is rendered by default.
 
-```ts {6}
+```ts {7}
 import HomeView from './components/HomeView.vue'
 
 const home = createRoute({
   name: 'home',
   path: '/',
-}).addView(HomeView)
+})
+.addView(HomeView)
 ```
 
 ### Named Views
@@ -109,21 +110,22 @@ const home = createRoute({
   name: 'home',
   path: '/',
 })
-  .addView(HomeView)
-  .addView('sidebar', HomeSidebar)
+.addView(HomeView)
+.addView('sidebar', HomeSidebar)
 ```
 
 ### Props
 
 Pass a props getter as the last argument to bind props to the view's component. It's a callback that returns an object (or a promise of one); everything returned is bound to the component. See [Component Props](/core-concepts/component-props) for more details.
 
-```ts {6}
+```ts {7}
 import UserView from './components/UserView.vue'
 
 const user = createRoute({
   name: 'user',
   path: '/user/[id]',
-}).addView(UserView, (route) => ({ userId: route.params.id }))
+})
+.addView(UserView, (route) => ({ userId: route.params.id }))
 ```
 
 The getter is **required** when the component has required props, and optional otherwise. For named views, pass the getter after the component.
@@ -212,7 +214,8 @@ const home = createRoute({
   meta: {
     title: 'Home',
   },
-}).addView(HomeView)
+})
+.addView(HomeView)
 ```
 
 ## State
@@ -230,7 +233,8 @@ const contact = createRoute({
     lastName: String,
     message: String,
   },
-}).addView(ContactView)
+})
+.addView(ContactView)
 ```
 
 ## Hooks
@@ -243,7 +247,8 @@ import HomeView from './components/HomeView.vue'
 const home = createRoute({
   name: 'home',
   path: '/',
-}).addView(HomeView)
+})
+.addView(HomeView)
 
 home.onBeforeRouteEnter(() => {
   console.log('before route enter')
@@ -289,7 +294,8 @@ The context for a route is the collection of routes and rejections that are asso
 const newHomePage = createRoute({
   name: 'new-home',
   path: '/',
-}).addView(NewHomePage)
+})
+.addView(NewHomePage)
 
 const home = createRoute({
   name: 'home',

--- a/docs/migrating-vue-router.md
+++ b/docs/migrating-vue-router.md
@@ -41,7 +41,6 @@ Kitbag Router does support repeatable params like [vue-router](https://router.vu
 {
   name: 'repeated-params',
   path: '/[chapters]',
-  component: ...
 },
 ```
 
@@ -71,7 +70,6 @@ Which is applied to the route with `withParams`.
 {
   name: 'repeated-params',
   path: withParams('/[chapters]', { chapters: stringArrayParam }),// [!code focus]
-  component: ...
 },
 ```
 
@@ -85,8 +83,7 @@ In order to setup redirects for your routes, you'll have to use route [hooks](/a
 const newRoute = createRoute({
   name: 'new-route',
   path: '/new',
-  component: ...
-})
+}).addView(...)
 
 const oldRoute = createRoute({
   name: 'old-route',
@@ -107,8 +104,7 @@ If you need additional routes that ultimately result in another route being load
 const actualRoute = createRoute({
   name: 'actual-route',
   path: '/new',
-  component: ...
-})
+}).addView(...)
 
 const aliasRouteA = createRoute({
   name: 'alias-route-a',

--- a/docs/migrating-vue-router.md
+++ b/docs/migrating-vue-router.md
@@ -83,7 +83,7 @@ In order to setup redirects for your routes, you'll have to use route [hooks](/a
 const newRoute = createRoute({
   name: 'new-route',
   path: '/new',
-}).addView(...)
+})
 
 const oldRoute = createRoute({
   name: 'old-route',
@@ -104,7 +104,7 @@ If you need additional routes that ultimately result in another route being load
 const actualRoute = createRoute({
   name: 'actual-route',
   path: '/new',
-}).addView(...)
+})
 
 const aliasRouteA = createRoute({
   name: 'alias-route-a',

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -24,8 +24,8 @@ const Home = { template: '<div>Home</div>' }
 const About = { template: '<div>About</div>' }
 
 const routes = [
-  createRoute({ name: 'home', path: '/', component: Home }),
-  createRoute({ name: 'path', path: '/about', component: About }),
+  createRoute({ name: 'home', path: '/' }).addView(Home),
+  createRoute({ name: 'path', path: '/about' }).addView(About),
 ] as const
 ```
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -24,8 +24,11 @@ const Home = { template: '<div>Home</div>' }
 const About = { template: '<div>About</div>' }
 
 const routes = [
-  createRoute({ name: 'home', path: '/' }).addView(Home),
-  createRoute({ name: 'path', path: '/about' }).addView(About),
+  createRoute({ name: 'home', path: '/' })
+  .addView(Home),
+
+  createRoute({ name: 'path', path: '/about' })
+  .addView(About),
 ] as const
 ```
 


### PR DESCRIPTION
# Description

Follow-up to #786 — updates the docs to use the new `addView` syntax.

- `core-concepts/routes` now documents views via `addView` (default and named), and marks the `component`/`components`/`props` options as deprecated.
- `core-concepts/component-props` leads with the `addView` props getter.
- Incidental examples across quick-start, prefetching, route-meta, route-narrowing, and the vue-router migration guide are updated to the new syntax.

No changes to the rejection `component` option (that's a separate API) or the auto-generated API reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
