### PR TITLE
Add per-view prefetch config to addView

### DIFF
--- a/docs/advanced-concepts/prefetching.md
+++ b/docs/advanced-concepts/prefetching.md
@@ -156,10 +156,6 @@ const user = createRoute({
 
 Views without their own config fall back to the route's config.
 
-::: warning
-Props for a view can only reference parent props that were also prefetched. If a child view prefetches props but its parent view does not, the parent props will be unavailable during prefetching and a warning is logged.
-:::
-
 ### Per-Link Configuration
 
 You can also control prefetching at the level of individual router-links by passing a prefetch prop.

--- a/docs/advanced-concepts/prefetching.md
+++ b/docs/advanced-concepts/prefetching.md
@@ -20,14 +20,16 @@ const user = createRoute({
 
 When your route uses the [props callback](/core-concepts/component-props), Kitbag Router can start fetching your component props before they are needed.
 
-```ts {5-8}
+```ts {5-10}
 const user = createRoute({
   name: 'user',
   path: '/user/[id]',
 })
-.addView(defineAsyncComponent(() => import('./UserPage.vue')), async (route) => {
-  const user = await userStore.getById(route.params.id)
-  return { user }
+.addView(defineAsyncComponent(() => import('./UserPage.vue')), {
+  props: async (route) => {
+    const user = await userStore.getById(route.params.id)
+    return { user }
+  },
 })
 ```
 
@@ -53,6 +55,7 @@ Prefetching can be configured at various levels. Each nested layer **overrides**
 
 - Global Configuration
 - Per-Route Configuration
+- Per-View Configuration
 - Per-Link Configuration
 
 This means that if prefetching is enabled globally, but disabled for a specific route, that route will not prefetch. Conversely, if prefetching is disabled globally, but enabled for a specific route, that route will prefetch.
@@ -113,6 +116,49 @@ const contact = createRoute({
 })
 .addView(() => import('./Contact.vue'))
 ```
+
+### Per-View Configuration
+
+When a route has multiple views, each one can carry its own prefetch config by passing a `prefetch` option to [addView](/core-concepts/routes#prefetch). This is useful when only some views are worth prefetching.
+
+```ts
+const dashboard = createRoute({
+  path: '/dashboard',
+})
+  .addView(defineAsyncComponent(() => import('./Dashboard.vue')))
+  .addView(defineAsyncComponent(() => import('./Sidebar.vue')), {
+    name: 'sidebar',
+    prefetch: 'eager', // [!code focus]
+  })
+  .addView(defineAsyncComponent(() => import('./HeavyReport.vue')), {
+    name: 'report',
+    prefetch: false, // [!code focus]
+  })
+```
+
+A single view can mix component and props strategies.
+
+```ts
+const user = createRoute({
+  path: '/user/[id]',
+})
+.addView(defineAsyncComponent(() => import('./UserPage.vue')), {
+  props: async (route) => {
+    const user = await userStore.getById(route.params.id)
+    return { user }
+  },
+  prefetch: { // [!code focus]
+    components: 'eager', // [!code focus]
+    props: 'intent', // [!code focus]
+  }, // [!code focus]
+})
+```
+
+Views without their own config fall back to the route's config.
+
+::: warning
+Props for a view can only reference parent props that were also prefetched. If a child view prefetches props but its parent view does not, the parent props will be unavailable during prefetching and a warning is logged.
+:::
 
 ### Per-Link Configuration
 

--- a/docs/core-concepts/component-props.md
+++ b/docs/core-concepts/component-props.md
@@ -2,12 +2,14 @@
 
 With Kitbag Router, you can pass a `props` getter in the options when adding a view with [`addView`](/core-concepts/routes#views). Your callback is given the [`ResolvedRoute`](/api/types/ResolvedRoute) for the route and what it returns will be bound to the component when the component gets mounted inside the `<router-view />`
 
-```ts {5}
+```ts {5-7}
 const user = createRoute({
   name: 'user',
   path: '/user/[id]',
 })
-.addView(UserComponent, { props: (route) => ({ userId: route.params.id }) })
+.addView(UserComponent, {
+  props: (route) => ({ userId: route.params.id }),
+})
 ```
 
 This is obviously useful for assigning static values or route params down to your view components props but it also gives you
@@ -19,13 +21,18 @@ This is obviously useful for assigning static values or route params down to you
 ## Named Views
 Each [named view](/core-concepts/routes#named-views) can have its own props getter. Just pass a `props` getter alongside the view's `name`.
 
-```ts {5-6}
+```ts {5-11}
 const user = createRoute({
   name: 'user',
   path: '/user/[id]',
 })
-.addView(UserComponent, { props: (route) => ({ userId: route.params.id }) })
-.addView(UserSidebarComponent, { name: 'sidebar', props: (route) => ({ userId: route.params.id }) })
+.addView(UserComponent, {
+  props: (route) => ({ userId: route.params.id }),
+})
+.addView(UserSidebarComponent, {
+  name: 'sidebar',
+  props: (route) => ({ userId: route.params.id }),
+})
 ```
 
 ## Params Type

--- a/docs/core-concepts/component-props.md
+++ b/docs/core-concepts/component-props.md
@@ -1,13 +1,13 @@
 # Component Props
 
-With Kitbag Router, you can pass a `props` getter when adding a view with [`addView`](/core-concepts/routes#views). Your callback is given the [`ResolvedRoute`](/api/types/ResolvedRoute) for the route and what it returns will be bound to the component when the component gets mounted inside the `<router-view />`
+With Kitbag Router, you can pass a `props` getter in the options when adding a view with [`addView`](/core-concepts/routes#views). Your callback is given the [`ResolvedRoute`](/api/types/ResolvedRoute) for the route and what it returns will be bound to the component when the component gets mounted inside the `<router-view />`
 
 ```ts {5}
 const user = createRoute({
   name: 'user',
   path: '/user/[id]',
 })
-.addView(UserComponent, (route) => ({ userId: route.params.id }))
+.addView(UserComponent, { props: (route) => ({ userId: route.params.id }) })
 ```
 
 This is obviously useful for assigning static values or route params down to your view components props but it also gives you
@@ -17,15 +17,15 @@ This is obviously useful for assigning static values or route params down to you
 - Support for async prop fetching.
 
 ## Named Views
-Each [named view](/core-concepts/routes#named-views) can have its own props getter. Just pass the getter after the component when calling `addView`.
+Each [named view](/core-concepts/routes#named-views) can have its own props getter. Just pass a `props` getter alongside the view's `name`.
 
 ```ts {5-6}
 const user = createRoute({
   name: 'user',
   path: '/user/[id]',
 })
-.addView(UserComponent, (route) => ({ userId: route.params.id }))
-.addView('sidebar', UserSidebarComponent, (route) => ({ userId: route.params.id }))
+.addView(UserComponent, { props: (route) => ({ userId: route.params.id }) })
+.addView(UserSidebarComponent, { name: 'sidebar', props: (route) => ({ userId: route.params.id }) })
 ```
 
 ## Params Type
@@ -40,15 +40,17 @@ Your callback will throw a Typescript error if it returns anything other than th
 
 The props call back supports promises. This means you can do much more than just forward values from params or insert static values. For example, we can take an id route param and fetch the `User` before mounting the component.
 
-```ts {5-9}
+```ts {5-11}
 const user = createRoute({
   name: 'user',
   path: '/user/[id]',
 })
-.addView(UserComponent, async (route) => {
-  const user = await userStore.getById(route.params.id)
+.addView(UserComponent, {
+  props: async (route) => {
+    const user = await userStore.getById(route.params.id)
 
-  return { user }
+    return { user }
+  },
 })
 ```
 
@@ -61,12 +63,14 @@ const blogPost = createRoute({
   name: 'blog',
   path: '/blog/[blogPostId]',
 })
-.addView(BlogPost, async (route) => {
-  const post = await getBlogPostById(route.params.blogPostId)
+.addView(BlogPost, {
+  props: async (route) => {
+    const post = await getBlogPostById(route.params.blogPostId)
 
-  return {
-    post,
-  }
+    return {
+      post,
+    }
+  },
 })
 
 const blogPostTabs = createRoute({
@@ -74,14 +78,16 @@ const blogPostTabs = createRoute({
   name: 'tabs',
   query: '?tab=[tab]',
 })
-.addView(PostTabs, async (route, { parent }) => {
-  const tab = route.query.tab
-  const { post } = await parent.props
+.addView(PostTabs, {
+  props: async (route, { parent }) => {
+    const tab = route.query.tab
+    const { post } = await parent.props
 
-  return {
-    tab,
-    post,
-  }
+    return {
+      tab,
+      post,
+    }
+  },
 })
 ```
 
@@ -109,14 +115,16 @@ const user = createRoute({
   name: 'user',
   path: '/user/[id]',
 })
-.addView(UserComponent, async (route, { reject }) => {
-  try {
-    const user = await userStore.getById(route.params.id)
+.addView(UserComponent, {
+  props: async (route, { reject }) => {
+    try {
+      const user = await userStore.getById(route.params.id)
 
-    return { user }
-  } catch (error) {
-    reject('NotFound')
-  }
+      return { user }
+    } catch (error) {
+      reject('NotFound')
+    }
+  },
 })
 ```
 
@@ -130,9 +138,11 @@ import { inject } from 'vue'
 const route = createRoute({
   ...
 })
-.addView(SomeComponent, async () => {
-  const value = inject('global')
+.addView(SomeComponent, {
+  props: async () => {
+    const value = inject('global')
 
-  return { value }
+    return { value }
+  },
 })
 ```

--- a/docs/core-concepts/routes.md
+++ b/docs/core-concepts/routes.md
@@ -112,7 +112,7 @@ Everything else about a view is passed in an options object as the second argume
 
 Pass a `name` to register a [named view](/components/router-view). A route can mix a default view with named views.
 
-```ts {8-9}
+```ts {8-11}
 import HomeView from './components/HomeView.vue'
 import HomeSidebar from './components/HomeSidebar.vue'
 
@@ -121,21 +121,25 @@ const home = createRoute({
   path: '/',
 })
 .addView(HomeView)
-.addView(HomeSidebar, { name: 'sidebar' })
+.addView(HomeSidebar, {
+  name: 'sidebar',
+})
 ```
 
 ### Props
 
 Pass a `props` getter to bind props to the view's component. It's a callback that returns an object (or a promise of one); everything returned is bound to the component. See [Component Props](/core-concepts/component-props) for more details.
 
-```ts {7}
+```ts {7-9}
 import UserView from './components/UserView.vue'
 
 const user = createRoute({
   name: 'user',
   path: '/user/[id]',
 })
-.addView(UserView, { props: (route) => ({ userId: route.params.id }) })
+.addView(UserView, {
+  props: (route) => ({ userId: route.params.id }),
+})
 ```
 
 The getter is **required** when the component has required props, and optional otherwise.
@@ -157,13 +161,18 @@ The props callback must return an object or a promise that resolves to an object
 
 Pass a `prefetch` config to control what is prefetched for that view. It overrides the route's config for this view only, which is useful when a route has multiple views and only some are worth prefetching. See [Prefetching](/advanced-concepts/prefetching#per-view-configuration) for more details.
 
-```ts {6-7}
+```ts {5-11}
 const home = createRoute({
   name: 'home',
   path: '/',
 })
-.addView(HomeView, { prefetch: false })
-.addView(HomeSidebar, { name: 'sidebar', prefetch: 'eager' })
+.addView(HomeView, {
+  prefetch: false,
+})
+.addView(HomeSidebar, {
+  name: 'sidebar',
+  prefetch: 'eager',
+})
 ```
 
 ## Component

--- a/docs/core-concepts/routes.md
+++ b/docs/core-concepts/routes.md
@@ -98,9 +98,19 @@ const home = createRoute({
 .addView(HomeView)
 ```
 
+### Options
+
+Everything else about a view is passed in an options object as the second argument.
+
+| Option | Description |
+| ------ | ----------- |
+| name | Registers the view as a [named view](/components/router-view). Defaults to the unnamed view. |
+| props | A getter for the props bound to the component. **Required** when the component has required props. |
+| prefetch | What assets are prefetched for this view. Overrides the route's config for this view only. |
+
 ### Named Views
 
-Pass a name as the first argument to register a [named view](/components/router-view). A route can mix a default view with named views.
+Pass a `name` to register a [named view](/components/router-view). A route can mix a default view with named views.
 
 ```ts {8-9}
 import HomeView from './components/HomeView.vue'
@@ -111,12 +121,12 @@ const home = createRoute({
   path: '/',
 })
 .addView(HomeView)
-.addView('sidebar', HomeSidebar)
+.addView(HomeSidebar, { name: 'sidebar' })
 ```
 
 ### Props
 
-Pass a props getter as the last argument to bind props to the view's component. It's a callback that returns an object (or a promise of one); everything returned is bound to the component. See [Component Props](/core-concepts/component-props) for more details.
+Pass a `props` getter to bind props to the view's component. It's a callback that returns an object (or a promise of one); everything returned is bound to the component. See [Component Props](/core-concepts/component-props) for more details.
 
 ```ts {7}
 import UserView from './components/UserView.vue'
@@ -125,10 +135,10 @@ const user = createRoute({
   name: 'user',
   path: '/user/[id]',
 })
-.addView(UserView, (route) => ({ userId: route.params.id }))
+.addView(UserView, { props: (route) => ({ userId: route.params.id }) })
 ```
 
-The getter is **required** when the component has required props, and optional otherwise. For named views, pass the getter after the component.
+The getter is **required** when the component has required props, and optional otherwise.
 
 #### Arguments
 
@@ -142,6 +152,19 @@ The props callback receives two arguments:
 #### Return Type
 
 The props callback must return an object or a promise that resolves to an object. The object must satisfy the props for the component. If the component has required props, TypeScript will error until the getter returns a matching object.
+
+### Prefetch
+
+Pass a `prefetch` config to control what is prefetched for that view. It overrides the route's config for this view only, which is useful when a route has multiple views and only some are worth prefetching. See [Prefetching](/advanced-concepts/prefetching#per-view-configuration) for more details.
+
+```ts {6-7}
+const home = createRoute({
+  name: 'home',
+  path: '/',
+})
+.addView(HomeView, { prefetch: false })
+.addView(HomeSidebar, { name: 'sidebar', prefetch: 'eager' })
+```
 
 ## Component
 

--- a/src/components/routerLink.browser.spec.ts
+++ b/src/components/routerLink.browser.spec.ts
@@ -712,6 +712,153 @@ describe('prefetch components', () => {
   })
 })
 
+describe('prefetch per view', () => {
+  test('only the views that opt into eager prefetching load their components', async () => {
+    const loaded: string[] = []
+
+    const asyncComponent = (name: string): ReturnType<typeof defineAsyncComponent> => defineAsyncComponent(() => {
+      return new Promise((resolve) => {
+        loaded.push(name)
+        resolve({ default: { template: name } })
+      })
+    })
+
+    const route = createRoute({
+      name: 'route',
+      path: '/route',
+    })
+      .addView(asyncComponent('default'))
+      .addView(asyncComponent('eager'), { name: 'eager', prefetch: 'eager' })
+      .addView(asyncComponent('disabled'), { name: 'disabled', prefetch: false })
+
+    const router = createRouter([route], {
+      initialUrl: '/',
+      prefetch: 'eager',
+    })
+
+    mount(RouterLink, {
+      props: {
+        to: '/route',
+      },
+      global: {
+        plugins: [router],
+      },
+    })
+
+    await flushPromises()
+
+    expect(loaded).toStrictEqual(['default', 'eager'])
+  })
+
+  test('a view config overrides the route config for that view only', async () => {
+    const loaded: string[] = []
+
+    const asyncComponent = (name: string): ReturnType<typeof defineAsyncComponent> => defineAsyncComponent(() => {
+      return new Promise((resolve) => {
+        loaded.push(name)
+        resolve({ default: { template: name } })
+      })
+    })
+
+    const route = createRoute({
+      name: 'route',
+      path: '/route',
+      prefetch: false,
+    })
+      .addView(asyncComponent('default'))
+      .addView(asyncComponent('eager'), { name: 'eager', prefetch: 'eager' })
+
+    const router = createRouter([route], {
+      initialUrl: '/',
+    })
+
+    mount(RouterLink, {
+      props: {
+        to: '/route',
+      },
+      global: {
+        plugins: [router],
+      },
+    })
+
+    await flushPromises()
+
+    expect(loaded).toStrictEqual(['eager'])
+  })
+
+  test('only the views that opt into props prefetching have their getters called', async () => {
+    const defaultProps = vi.fn(() => ({ value: 'default' }))
+    const eagerProps = vi.fn(() => ({ value: 'eager' }))
+
+    const home = createRoute({
+      name: 'home',
+      path: '/',
+    }).addView(() => h(RouterLink, { to: (resolve) => resolve('route') }))
+
+    const route = createRoute({
+      name: 'route',
+      path: '/route',
+    })
+      .addView(echo, { props: defaultProps })
+      .addView(echo, { name: 'eager', props: eagerProps, prefetch: { props: 'eager' } })
+
+    const router = createRouter([home, route], {
+      initialUrl: '/',
+    })
+
+    await router.start()
+
+    mount({ template: '<RouterView />' }, {
+      global: {
+        plugins: [router],
+      },
+    })
+
+    await flushPromises()
+
+    expect(eagerProps).toHaveBeenCalledOnce()
+    expect(defaultProps).not.toHaveBeenCalled()
+  })
+
+  test('a single view can mix component and props strategies', async () => {
+    let componentLoaded = false
+    const props = vi.fn(() => ({ value: 'value' }))
+
+    const home = createRoute({
+      name: 'home',
+      path: '/',
+    }).addView(() => h(RouterLink, { to: (resolve) => resolve('route') }))
+
+    const route = createRoute({
+      name: 'route',
+      path: '/route',
+    }).addView(defineAsyncComponent(() => {
+      return new Promise<typeof echo>((resolve) => {
+        componentLoaded = true
+        resolve(echo)
+      })
+    }), { props, prefetch: { components: 'eager', props: false } })
+
+    const router = createRouter([home, route], {
+      initialUrl: '/',
+      prefetch: { components: false, props: 'eager' },
+    })
+
+    await router.start()
+
+    mount({ template: '<RouterView />' }, {
+      global: {
+        plugins: [router],
+      },
+    })
+
+    await flushPromises()
+
+    expect(componentLoaded).toBe(true)
+    expect(props).not.toHaveBeenCalled()
+  })
+})
+
 describe('prefetch props', () => {
   test.each<PrefetchConfig | undefined>([
     undefined,

--- a/src/components/routerLink.browser.spec.ts
+++ b/src/components/routerLink.browser.spec.ts
@@ -728,8 +728,14 @@ describe('prefetch per view', () => {
       path: '/route',
     })
       .addView(asyncComponent('default'))
-      .addView(asyncComponent('eager'), { name: 'eager', prefetch: 'eager' })
-      .addView(asyncComponent('disabled'), { name: 'disabled', prefetch: false })
+      .addView(asyncComponent('eager'), {
+        name: 'eager',
+        prefetch: 'eager',
+      })
+      .addView(asyncComponent('disabled'), {
+        name: 'disabled',
+        prefetch: false,
+      })
 
     const router = createRouter([route], {
       initialUrl: '/',
@@ -766,7 +772,10 @@ describe('prefetch per view', () => {
       prefetch: false,
     })
       .addView(asyncComponent('default'))
-      .addView(asyncComponent('eager'), { name: 'eager', prefetch: 'eager' })
+      .addView(asyncComponent('eager'), {
+        name: 'eager',
+        prefetch: 'eager',
+      })
 
     const router = createRouter([route], {
       initialUrl: '/',
@@ -799,8 +808,14 @@ describe('prefetch per view', () => {
       name: 'route',
       path: '/route',
     })
-      .addView(echo, { props: defaultProps })
-      .addView(echo, { name: 'eager', props: eagerProps, prefetch: { props: 'eager' } })
+      .addView(echo, {
+        props: defaultProps,
+      })
+      .addView(echo, {
+        name: 'eager',
+        props: eagerProps,
+        prefetch: { props: 'eager' },
+      })
 
     const router = createRouter([home, route], {
       initialUrl: '/',

--- a/src/compositions/usePrefetching.ts
+++ b/src/compositions/usePrefetching.ts
@@ -89,25 +89,28 @@ export function createUsePrefetching<TRouter extends Router>(routerKey: Injectio
 
 function prefetchComponentsForRoute(strategy: PrefetchStrategy, route: ResolvedRoute, configs: PrefetchConfigs): void {
   route.matches.forEach((match, depth) => {
-    const routeStrategy = getPrefetchOption({
-      ...configs,
-      routePrefetch: match.prefetch,
-    }, 'components')
-
-    if (routeStrategy !== strategy) {
-      return
-    }
-
     const views = route.views.at(depth)
 
     if (!views) {
       return
     }
 
-    Object.values(views.components).forEach((component) => {
-      if (isAsyncComponent(component)) {
-        component.__asyncLoader()
+    Object.entries(views.components).forEach(([name, component]) => {
+      if (!isAsyncComponent(component)) {
+        return
       }
+
+      const viewStrategy = getPrefetchOption({
+        ...configs,
+        routePrefetch: match.prefetch,
+        viewPrefetch: views.prefetch?.[name],
+      }, 'components')
+
+      if (viewStrategy !== strategy) {
+        return
+      }
+
+      component.__asyncLoader()
     })
   })
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ export type {
 } from './types/createRouteOptions'
 export type {
   RouteAddView,
+  AddViewOptions,
   AddViewPropsGetter,
   AddViewPropsCallbackContext
 } from './types/addView'

--- a/src/services/addView.browser.spec.ts
+++ b/src/services/addView.browser.spec.ts
@@ -21,8 +21,12 @@ test('renders the default view added via addView', async () => {
 test('renders default and named views added via addView', async () => {
   const route = createRoute({ name: 'route', path: '/' })
     .addView({ template: '_default_' })
-    .addView({ template: '_one_' }, { name: 'one' })
-    .addView({ template: '_two_' }, { name: 'two' })
+    .addView({ template: '_one_' }, {
+      name: 'one',
+    })
+    .addView({ template: '_two_' }, {
+      name: 'two',
+    })
 
   const router = createRouter([route], { initialUrl: '/' })
 
@@ -42,7 +46,9 @@ test('renders default and named views added via addView', async () => {
 })
 
 test('binds props from an addView getter for the default view', async () => {
-  const route = createRoute({ name: 'route', path: '/[param]' }).addView(echo, { props: (route) => ({ value: route.params.param }) })
+  const route = createRoute({ name: 'route', path: '/[param]' }).addView(echo, {
+    props: (route) => ({ value: route.params.param }),
+  })
 
   const router = createRouter([route], { initialUrl: '/hello' })
 
@@ -57,8 +63,14 @@ test('binds props from an addView getter for the default view', async () => {
 
 test('binds props to named views added via addView', async () => {
   const route = createRoute({ name: 'route', path: '/[param]' })
-    .addView(echo, { name: 'one', props: (route) => ({ value: `one-${route.params.param}` }) })
-    .addView(echo, { name: 'two', props: (route) => ({ value: `two-${route.params.param}` }) })
+    .addView(echo, {
+      name: 'one',
+      props: (route) => ({ value: `one-${route.params.param}` }),
+    })
+    .addView(echo, {
+      name: 'two',
+      props: (route) => ({ value: `two-${route.params.param}` }),
+    })
 
   const router = createRouter([route], { initialUrl: '/x' })
 

--- a/src/services/addView.browser.spec.ts
+++ b/src/services/addView.browser.spec.ts
@@ -21,8 +21,8 @@ test('renders the default view added via addView', async () => {
 test('renders default and named views added via addView', async () => {
   const route = createRoute({ name: 'route', path: '/' })
     .addView({ template: '_default_' })
-    .addView('one', { template: '_one_' })
-    .addView('two', { template: '_two_' })
+    .addView({ template: '_one_' }, { name: 'one' })
+    .addView({ template: '_two_' }, { name: 'two' })
 
   const router = createRouter([route], { initialUrl: '/' })
 
@@ -42,7 +42,7 @@ test('renders default and named views added via addView', async () => {
 })
 
 test('binds props from an addView getter for the default view', async () => {
-  const route = createRoute({ name: 'route', path: '/[param]' }).addView(echo, (route) => ({ value: route.params.param }))
+  const route = createRoute({ name: 'route', path: '/[param]' }).addView(echo, { props: (route) => ({ value: route.params.param }) })
 
   const router = createRouter([route], { initialUrl: '/hello' })
 
@@ -57,8 +57,8 @@ test('binds props from an addView getter for the default view', async () => {
 
 test('binds props to named views added via addView', async () => {
   const route = createRoute({ name: 'route', path: '/[param]' })
-    .addView('one', echo, (route) => ({ value: `one-${route.params.param}` }))
-    .addView('two', echo, (route) => ({ value: `two-${route.params.param}` }))
+    .addView(echo, { name: 'one', props: (route) => ({ value: `one-${route.params.param}` }) })
+    .addView(echo, { name: 'two', props: (route) => ({ value: `two-${route.params.param}` }) })
 
   const router = createRouter([route], { initialUrl: '/x' })
 

--- a/src/services/addView.spec-d.ts
+++ b/src/services/addView.spec-d.ts
@@ -14,20 +14,27 @@ describe('addView', () => {
     })
 
     test('optional props with a getter', () => {
-      const route = createRoute({ name: 'route' }).addView(component, () => ({ foo: 'bar' }))
+      const route = createRoute({ name: 'route' }).addView(component, { props: () => ({ foo: 'bar' }) })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<() => { foo: string }>()
     })
 
-    test('required props missing getter', () => {
+    test('required props missing options', () => {
       // @ts-expect-error should require a props getter
       const route = createRoute({ name: 'route' }).addView(echo)
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<undefined>()
     })
 
+    test('required props missing getter', () => {
+      // @ts-expect-error should require a props getter
+      const route = createRoute({ name: 'route' }).addView(echo, { prefetch: false })
+
+      expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<undefined>()
+    })
+
     test('required props with a getter', () => {
-      const route = createRoute({ name: 'route' }).addView(echo, () => ({ value: 'bar', extra: true }))
+      const route = createRoute({ name: 'route' }).addView(echo, { props: () => ({ value: 'bar', extra: true }) })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<() => { value: string, extra: boolean }>()
     })
@@ -35,7 +42,7 @@ describe('addView', () => {
     test('required props with a getter with incorrect type', () => {
       const route = createRoute({ name: 'route' })
         // @ts-expect-error should not accept incorrect type
-        .addView(echo, () => ({ value: true }))
+        .addView(echo, { props: () => ({ value: true }) })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<undefined>()
     })
@@ -43,37 +50,105 @@ describe('addView', () => {
 
   describe('named view', () => {
     test('optional props without a getter is a props no-op', () => {
-      const route = createRoute({ name: 'route' }).addView('sidebar', component)
+      const route = createRoute({ name: 'route' }).addView(component, { name: 'sidebar' })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<undefined>()
     })
 
     test('optional props with a getter produces a record', () => {
-      const route = createRoute({ name: 'route' }).addView('sidebar', component, () => ({ foo: 'bar' }))
+      const route = createRoute({ name: 'route' }).addView(component, { name: 'sidebar', props: () => ({ foo: 'bar' }) })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<{ sidebar: () => { foo: string } }>()
     })
 
     test('required props with a getter produces a record', () => {
-      const route = createRoute({ name: 'route' }).addView('sidebar', echo, () => ({ value: 'bar', extra: true }))
+      const route = createRoute({ name: 'route' }).addView(echo, { name: 'sidebar', props: () => ({ value: 'bar', extra: true }) })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<{ sidebar: () => { value: string, extra: boolean } }>()
+    })
+  })
+
+  describe('prefetch', () => {
+    test('prefetch alongside a getter preserves the props type', () => {
+      const route = createRoute({ name: 'route' }).addView(component, { props: () => ({ foo: 'bar' }), prefetch: 'eager' })
+
+      expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<() => { foo: string }>()
+    })
+
+    test('prefetch without a getter is a props no-op', () => {
+      const route = createRoute({ name: 'route' }).addView(component, { prefetch: false })
+
+      expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<undefined>()
+    })
+
+    test('a named view with a getter and prefetch produces a record', () => {
+      const route = createRoute({ name: 'route' })
+        .addView(component, { name: 'sidebar', props: () => ({ foo: 'bar' }), prefetch: 'eager' })
+
+      expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<{ sidebar: () => { foo: string } }>()
+    })
+
+    test('a named view with prefetch and no getter is a props no-op', () => {
+      const route = createRoute({ name: 'route' }).addView(component, { name: 'sidebar', prefetch: 'eager' })
+
+      expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<undefined>()
+    })
+
+    test('required props with a getter and prefetch', () => {
+      const route = createRoute({ name: 'route' })
+        .addView(echo, { props: () => ({ value: 'bar', extra: true }), prefetch: 'intent' })
+
+      expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<() => { value: string, extra: boolean }>()
+    })
+
+    test('a getter alongside prefetch is still checked against the component props', () => {
+      createRoute({ name: 'route' })
+        // @ts-expect-error should not accept incorrect type
+        .addView(echo, { props: () => ({ value: true }), prefetch: false })
+    })
+
+    test('a getter alongside prefetch still receives the resolved route with typed params', () => {
+      createRoute({ name: 'route', path: '/[paramName]' }).addView(component, {
+        props: (route) => {
+          expectTypeOf(route.params.paramName).toEqualTypeOf<string>()
+
+          return {}
+        },
+        prefetch: 'lazy',
+      })
+    })
+
+    test('accepts a boolean, a strategy, or a config object', () => {
+      createRoute({ name: 'route' }).addView(component, { prefetch: true })
+      createRoute({ name: 'route' }).addView(component, { prefetch: 'lazy' })
+      createRoute({ name: 'route' }).addView(component, { prefetch: { components: 'eager', props: false } })
+
+      // @ts-expect-error should not accept an unknown strategy
+      createRoute({ name: 'route' }).addView(component, { prefetch: 'whenever' })
+
+      // @ts-expect-error should not accept an unknown config option
+      createRoute({ name: 'route' }).addView(component, { prefetch: { styles: true } })
+    })
+
+    test('unknown options are rejected', () => {
+      // @ts-expect-error should not accept an unknown option
+      createRoute({ name: 'route' }).addView(component, { prefetching: true })
     })
   })
 
   describe('multiple views', () => {
     test('default then named promotes to a record with the default under "default"', () => {
       const route = createRoute({ name: 'route' })
-        .addView(component, () => ({ foo: 'bar' }))
-        .addView('sidebar', component, () => ({ baz: 1 }))
+        .addView(component, { props: () => ({ foo: 'bar' }) })
+        .addView(component, { name: 'sidebar', props: () => ({ baz: 1 }) })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<{ default: () => { foo: string }, sidebar: () => { baz: number } }>()
     })
 
     test('two named views produce a record', () => {
       const route = createRoute({ name: 'route' })
-        .addView('one', component, () => ({ foo: 'bar' }))
-        .addView('two', component, () => ({ baz: 1 }))
+        .addView(component, { name: 'one', props: () => ({ foo: 'bar' }) })
+        .addView(component, { name: 'two', props: () => ({ baz: 1 }) })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<{ one: () => { foo: string }, two: () => { baz: number } }>()
     })
@@ -82,7 +157,7 @@ describe('addView', () => {
   describe('backwards compatibility', () => {
     test('addView merges with the deprecated component + props options', () => {
       const route = createRoute({ name: 'route', component }, () => ({ foo: 'bar' }))
-        .addView('sidebar', component, () => ({ baz: 1 }))
+        .addView(component, { name: 'sidebar', props: () => ({ baz: 1 }) })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<{ default: () => { foo: string }, sidebar: () => { baz: number } }>()
     })
@@ -90,7 +165,7 @@ describe('addView', () => {
 
   describe('parent props', () => {
     test('bare parent props (added via addView) are passed to a child', () => {
-      const parent = createRoute({ name: 'parent' }).addView(component, () => ({ foo: 123 }))
+      const parent = createRoute({ name: 'parent' }).addView(component, { props: () => ({ foo: 123 }) })
 
       createRoute({ name: 'child', parent }, (__, { parent }) => {
         expectTypeOf(parent.props).toEqualTypeOf<{ foo: number }>()
@@ -102,8 +177,8 @@ describe('addView', () => {
 
     test('record parent props (added via addView) are passed to a child', () => {
       const parent = createRoute({ name: 'parent' })
-        .addView('one', component, () => ({ foo: 123 }))
-        .addView('two', component, async () => ({ foo: 456 }))
+        .addView(component, { name: 'one', props: () => ({ foo: 123 }) })
+        .addView(component, { name: 'two', props: async () => ({ foo: 456 }) })
 
       createRoute({ name: 'child', parent }, (__, { parent }) => {
         expectTypeOf(parent.props).toEqualTypeOf<{
@@ -118,55 +193,65 @@ describe('addView', () => {
 
   describe('props getter context', () => {
     test('receives the resolved route with typed params', () => {
-      createRoute({ name: 'route', path: '/[paramName]' }).addView(component, (route) => {
-        expectTypeOf(route.params.paramName).toEqualTypeOf<string>()
+      createRoute({ name: 'route', path: '/[paramName]' }).addView(component, {
+        props: (route) => {
+          expectTypeOf(route.params.paramName).toEqualTypeOf<string>()
 
-        return {}
+          return {}
+        },
       })
     })
 
     test('parent context is reconstructed from the route views/matches', () => {
       const parent = createRoute({ name: 'parent' }, async () => ({ foo: 123 }))
 
-      createRoute({ name: 'child', parent }).addView(component, (__, { parent }) => {
-        expectTypeOf(parent.props).toEqualTypeOf<Promise<{ foo: number }>>()
-        expectTypeOf(parent.name).toEqualTypeOf<'parent'>()
+      createRoute({ name: 'child', parent }).addView(component, {
+        props: (__, { parent }) => {
+          expectTypeOf(parent.props).toEqualTypeOf<Promise<{ foo: number }>>()
+          expectTypeOf(parent.name).toEqualTypeOf<'parent'>()
 
-        return {}
+          return {}
+        },
       })
     })
 
     test('reject accepts built-in rejections, and custom rejections from context', () => {
-      createRoute({ name: 'route' }).addView(component, (__, context) => {
-        expectTypeOf<Parameters<typeof context.reject>[0]>().toEqualTypeOf<BuiltInRejectionType>()
+      createRoute({ name: 'route' }).addView(component, {
+        props: (__, context) => {
+          expectTypeOf<Parameters<typeof context.reject>[0]>().toEqualTypeOf<BuiltInRejectionType>()
 
-        return {}
+          return {}
+        },
       })
 
       const rejection = createRejection({ type: 'NotAuthorized' })
 
-      createRoute({ name: 'route', context: [rejection] }).addView(component, (__, context) => {
-        expectTypeOf<Parameters<typeof context.reject>[0]>().toEqualTypeOf<'NotAuthorized' | BuiltInRejectionType>()
+      createRoute({ name: 'route', context: [rejection] }).addView(component, {
+        props: (__, context) => {
+          expectTypeOf<Parameters<typeof context.reject>[0]>().toEqualTypeOf<'NotAuthorized' | BuiltInRejectionType>()
 
-        return {}
+          return {}
+        },
       })
     })
 
     test('push and update are typed to the route', () => {
-      createRoute({ name: 'route', path: '/[paramName]', context: [createRoute({ name: 'contextRoute' })] }).addView(component, (__, context) => {
-        context.push('route', { paramName: 'value' })
-        context.push('contextRoute')
-        context.push('/')
+      createRoute({ name: 'route', path: '/[paramName]', context: [createRoute({ name: 'contextRoute' })] }).addView(component, {
+        props: (__, context) => {
+          context.push('route', { paramName: 'value' })
+          context.push('contextRoute')
+          context.push('/')
 
-        // @ts-expect-error should not accept an invalid route name
-        context.push('foo')
+          // @ts-expect-error should not accept an invalid route name
+          context.push('foo')
 
-        context.update('paramName', 'value')
+          context.update('paramName', 'value')
 
-        // @ts-expect-error should not accept an invalid param name
-        context.update('invalidParamName', 'value')
+          // @ts-expect-error should not accept an invalid param name
+          context.update('invalidParamName', 'value')
 
-        return {}
+          return {}
+        },
       })
     })
   })
@@ -179,7 +264,7 @@ describe('addView', () => {
       expectTypeOf(route.redirectTo).toBeFunction()
       expectTypeOf(route.setTitle).toBeFunction()
 
-      route.addView('sidebar', component).onBeforeRouteEnter((to) => {
+      route.addView(component, { name: 'sidebar' }).onBeforeRouteEnter((to) => {
         expectTypeOf(to.params.paramName).toEqualTypeOf<string>()
       })
     })

--- a/src/services/addView.spec-d.ts
+++ b/src/services/addView.spec-d.ts
@@ -14,7 +14,9 @@ describe('addView', () => {
     })
 
     test('optional props with a getter', () => {
-      const route = createRoute({ name: 'route' }).addView(component, { props: () => ({ foo: 'bar' }) })
+      const route = createRoute({ name: 'route' }).addView(component, {
+        props: () => ({ foo: 'bar' }),
+      })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<() => { foo: string }>()
     })
@@ -28,21 +30,27 @@ describe('addView', () => {
 
     test('required props missing getter', () => {
       // @ts-expect-error should require a props getter
-      const route = createRoute({ name: 'route' }).addView(echo, { prefetch: false })
+      const route = createRoute({ name: 'route' }).addView(echo, {
+        prefetch: false,
+      })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<undefined>()
     })
 
     test('required props with a getter', () => {
-      const route = createRoute({ name: 'route' }).addView(echo, { props: () => ({ value: 'bar', extra: true }) })
+      const route = createRoute({ name: 'route' }).addView(echo, {
+        props: () => ({ value: 'bar', extra: true }),
+      })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<() => { value: string, extra: boolean }>()
     })
 
     test('required props with a getter with incorrect type', () => {
       const route = createRoute({ name: 'route' })
-        // @ts-expect-error should not accept incorrect type
-        .addView(echo, { props: () => ({ value: true }) })
+        .addView(echo, {
+          // @ts-expect-error should not accept incorrect type
+          props: () => ({ value: true }),
+        })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<undefined>()
     })
@@ -50,19 +58,27 @@ describe('addView', () => {
 
   describe('named view', () => {
     test('optional props without a getter is a props no-op', () => {
-      const route = createRoute({ name: 'route' }).addView(component, { name: 'sidebar' })
+      const route = createRoute({ name: 'route' }).addView(component, {
+        name: 'sidebar',
+      })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<undefined>()
     })
 
     test('optional props with a getter produces a record', () => {
-      const route = createRoute({ name: 'route' }).addView(component, { name: 'sidebar', props: () => ({ foo: 'bar' }) })
+      const route = createRoute({ name: 'route' }).addView(component, {
+        name: 'sidebar',
+        props: () => ({ foo: 'bar' }),
+      })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<{ sidebar: () => { foo: string } }>()
     })
 
     test('required props with a getter produces a record', () => {
-      const route = createRoute({ name: 'route' }).addView(echo, { name: 'sidebar', props: () => ({ value: 'bar', extra: true }) })
+      const route = createRoute({ name: 'route' }).addView(echo, {
+        name: 'sidebar',
+        props: () => ({ value: 'bar', extra: true }),
+      })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<{ sidebar: () => { value: string, extra: boolean } }>()
     })
@@ -70,41 +86,59 @@ describe('addView', () => {
 
   describe('prefetch', () => {
     test('prefetch alongside a getter preserves the props type', () => {
-      const route = createRoute({ name: 'route' }).addView(component, { props: () => ({ foo: 'bar' }), prefetch: 'eager' })
+      const route = createRoute({ name: 'route' }).addView(component, {
+        props: () => ({ foo: 'bar' }),
+        prefetch: 'eager',
+      })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<() => { foo: string }>()
     })
 
     test('prefetch without a getter is a props no-op', () => {
-      const route = createRoute({ name: 'route' }).addView(component, { prefetch: false })
+      const route = createRoute({ name: 'route' }).addView(component, {
+        prefetch: false,
+      })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<undefined>()
     })
 
     test('a named view with a getter and prefetch produces a record', () => {
       const route = createRoute({ name: 'route' })
-        .addView(component, { name: 'sidebar', props: () => ({ foo: 'bar' }), prefetch: 'eager' })
+        .addView(component, {
+          name: 'sidebar',
+          props: () => ({ foo: 'bar' }),
+          prefetch: 'eager',
+        })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<{ sidebar: () => { foo: string } }>()
     })
 
     test('a named view with prefetch and no getter is a props no-op', () => {
-      const route = createRoute({ name: 'route' }).addView(component, { name: 'sidebar', prefetch: 'eager' })
+      const route = createRoute({ name: 'route' }).addView(component, {
+        name: 'sidebar',
+        prefetch: 'eager',
+      })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<undefined>()
     })
 
     test('required props with a getter and prefetch', () => {
       const route = createRoute({ name: 'route' })
-        .addView(echo, { props: () => ({ value: 'bar', extra: true }), prefetch: 'intent' })
+        .addView(echo, {
+          props: () => ({ value: 'bar', extra: true }),
+          prefetch: 'intent',
+        })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<() => { value: string, extra: boolean }>()
     })
 
     test('a getter alongside prefetch is still checked against the component props', () => {
       createRoute({ name: 'route' })
-        // @ts-expect-error should not accept incorrect type
-        .addView(echo, { props: () => ({ value: true }), prefetch: false })
+        .addView(echo, {
+          // @ts-expect-error should not accept incorrect type
+          props: () => ({ value: true }),
+          prefetch: false,
+        })
     })
 
     test('a getter alongside prefetch still receives the resolved route with typed params', () => {
@@ -119,36 +153,59 @@ describe('addView', () => {
     })
 
     test('accepts a boolean, a strategy, or a config object', () => {
-      createRoute({ name: 'route' }).addView(component, { prefetch: true })
-      createRoute({ name: 'route' }).addView(component, { prefetch: 'lazy' })
-      createRoute({ name: 'route' }).addView(component, { prefetch: { components: 'eager', props: false } })
+      createRoute({ name: 'route' }).addView(component, {
+        prefetch: true,
+      })
+      createRoute({ name: 'route' }).addView(component, {
+        prefetch: 'lazy',
+      })
+      createRoute({ name: 'route' }).addView(component, {
+        prefetch: { components: 'eager', props: false },
+      })
 
-      // @ts-expect-error should not accept an unknown strategy
-      createRoute({ name: 'route' }).addView(component, { prefetch: 'whenever' })
+      createRoute({ name: 'route' }).addView(component, {
+        // @ts-expect-error should not accept an unknown strategy
+        prefetch: 'whenever',
+      })
 
-      // @ts-expect-error should not accept an unknown config option
-      createRoute({ name: 'route' }).addView(component, { prefetch: { styles: true } })
+      createRoute({ name: 'route' }).addView(component, {
+        // @ts-expect-error should not accept an unknown config option
+        prefetch: { styles: true },
+      })
     })
 
     test('unknown options are rejected', () => {
-      // @ts-expect-error should not accept an unknown option
-      createRoute({ name: 'route' }).addView(component, { prefetching: true })
+      createRoute({ name: 'route' }).addView(component, {
+        // @ts-expect-error should not accept an unknown option
+        prefetching: true,
+      })
     })
   })
 
   describe('multiple views', () => {
     test('default then named promotes to a record with the default under "default"', () => {
       const route = createRoute({ name: 'route' })
-        .addView(component, { props: () => ({ foo: 'bar' }) })
-        .addView(component, { name: 'sidebar', props: () => ({ baz: 1 }) })
+        .addView(component, {
+          props: () => ({ foo: 'bar' }),
+        })
+        .addView(component, {
+          name: 'sidebar',
+          props: () => ({ baz: 1 }),
+        })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<{ default: () => { foo: string }, sidebar: () => { baz: number } }>()
     })
 
     test('two named views produce a record', () => {
       const route = createRoute({ name: 'route' })
-        .addView(component, { name: 'one', props: () => ({ foo: 'bar' }) })
-        .addView(component, { name: 'two', props: () => ({ baz: 1 }) })
+        .addView(component, {
+          name: 'one',
+          props: () => ({ foo: 'bar' }),
+        })
+        .addView(component, {
+          name: 'two',
+          props: () => ({ baz: 1 }),
+        })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<{ one: () => { foo: string }, two: () => { baz: number } }>()
     })
@@ -157,7 +214,10 @@ describe('addView', () => {
   describe('backwards compatibility', () => {
     test('addView merges with the deprecated component + props options', () => {
       const route = createRoute({ name: 'route', component }, () => ({ foo: 'bar' }))
-        .addView(component, { name: 'sidebar', props: () => ({ baz: 1 }) })
+        .addView(component, {
+          name: 'sidebar',
+          props: () => ({ baz: 1 }),
+        })
 
       expectTypeOf<typeof route['views'][0]['props']>().toEqualTypeOf<{ default: () => { foo: string }, sidebar: () => { baz: number } }>()
     })
@@ -165,7 +225,9 @@ describe('addView', () => {
 
   describe('parent props', () => {
     test('bare parent props (added via addView) are passed to a child', () => {
-      const parent = createRoute({ name: 'parent' }).addView(component, { props: () => ({ foo: 123 }) })
+      const parent = createRoute({ name: 'parent' }).addView(component, {
+        props: () => ({ foo: 123 }),
+      })
 
       createRoute({ name: 'child', parent }, (__, { parent }) => {
         expectTypeOf(parent.props).toEqualTypeOf<{ foo: number }>()
@@ -177,8 +239,14 @@ describe('addView', () => {
 
     test('record parent props (added via addView) are passed to a child', () => {
       const parent = createRoute({ name: 'parent' })
-        .addView(component, { name: 'one', props: () => ({ foo: 123 }) })
-        .addView(component, { name: 'two', props: async () => ({ foo: 456 }) })
+        .addView(component, {
+          name: 'one',
+          props: () => ({ foo: 123 }),
+        })
+        .addView(component, {
+          name: 'two',
+          props: async () => ({ foo: 456 }),
+        })
 
       createRoute({ name: 'child', parent }, (__, { parent }) => {
         expectTypeOf(parent.props).toEqualTypeOf<{
@@ -264,7 +332,9 @@ describe('addView', () => {
       expectTypeOf(route.redirectTo).toBeFunction()
       expectTypeOf(route.setTitle).toBeFunction()
 
-      route.addView(component, { name: 'sidebar' }).onBeforeRouteEnter((to) => {
+      route.addView(component, {
+        name: 'sidebar',
+      }).onBeforeRouteEnter((to) => {
         expectTypeOf(to.params.paramName).toEqualTypeOf<string>()
       })
     })

--- a/src/services/addView.spec.ts
+++ b/src/services/addView.spec.ts
@@ -1,10 +1,11 @@
 import { describe, expect, test } from 'vitest'
 import { createRoute } from '@/services/createRoute'
+import { RouteViews } from '@/types/routeViews'
 import { component } from '@/utilities/testHelpers'
 
 const other = { template: '<div>other</div>' }
 
-function lastView(route: { views: { components: Record<string, unknown>, props: unknown }[] }): { components: Record<string, unknown>, props: unknown } {
+function lastView(route: { views: RouteViews[] }): RouteViews {
   return route.views[route.views.length - 1]
 }
 
@@ -16,7 +17,7 @@ describe('components', () => {
   })
 
   test('a named view is stored under its name', () => {
-    const route = createRoute({ name: 'route' }).addView('sidebar', component)
+    const route = createRoute({ name: 'route' }).addView(component, { name: 'sidebar' })
 
     expect(lastView(route).components).toStrictEqual({ sidebar: component })
   })
@@ -24,7 +25,7 @@ describe('components', () => {
   test('multiple views accumulate in the same views entry', () => {
     const route = createRoute({ name: 'route' })
       .addView(component)
-      .addView('sidebar', other)
+      .addView(other, { name: 'sidebar' })
 
     expect(lastView(route).components).toStrictEqual({ default: component, sidebar: other })
   })
@@ -33,7 +34,7 @@ describe('components', () => {
 describe('props', () => {
   test('a lone default view getter is stored as bare props', () => {
     const getter = (): { foo: string } => ({ foo: 'bar' })
-    const route = createRoute({ name: 'route' }).addView(component, getter)
+    const route = createRoute({ name: 'route' }).addView(component, { props: getter })
 
     expect(lastView(route).props).toBe(getter)
   })
@@ -49,10 +50,60 @@ describe('props', () => {
     const sidebarGetter = (): { baz: number } => ({ baz: 1 })
 
     const route = createRoute({ name: 'route' })
-      .addView(component, defaultGetter)
-      .addView('sidebar', other, sidebarGetter)
+      .addView(component, { props: defaultGetter })
+      .addView(other, { name: 'sidebar', props: sidebarGetter })
 
     expect(lastView(route).props).toStrictEqual({ default: defaultGetter, sidebar: sidebarGetter })
+  })
+})
+
+describe('prefetch', () => {
+  test('prefetch is stored under the view name', () => {
+    const route = createRoute({ name: 'route' }).addView(component, { prefetch: false })
+
+    expect(lastView(route).prefetch).toStrictEqual({ default: false })
+    expect(lastView(route).props).toBeUndefined()
+  })
+
+  test('prefetch is stored alongside a props getter', () => {
+    const getter = (): { foo: string } => ({ foo: 'bar' })
+    const route = createRoute({ name: 'route' }).addView(component, { props: getter, prefetch: 'eager' })
+
+    expect(lastView(route).props).toBe(getter)
+    expect(lastView(route).prefetch).toStrictEqual({ default: 'eager' })
+  })
+
+  test('prefetch is stored under a named view name', () => {
+    const route = createRoute({ name: 'route' }).addView(component, { name: 'sidebar', prefetch: 'eager' })
+
+    expect(lastView(route).prefetch).toStrictEqual({ sidebar: 'eager' })
+  })
+
+  test('prefetch is stored alongside a named view props getter', () => {
+    const getter = (): { foo: string } => ({ foo: 'bar' })
+    const route = createRoute({ name: 'route' }).addView(component, { name: 'sidebar', props: getter, prefetch: 'intent' })
+
+    expect(lastView(route).props).toStrictEqual({ sidebar: getter })
+    expect(lastView(route).prefetch).toStrictEqual({ sidebar: 'intent' })
+  })
+
+  test('each view keeps its own prefetch config', () => {
+    const route = createRoute({ name: 'route' })
+      .addView(component, { prefetch: { components: 'eager', props: false } })
+      .addView(other, { name: 'sidebar', prefetch: false })
+
+    expect(lastView(route).prefetch).toStrictEqual({
+      default: { components: 'eager', props: false },
+      sidebar: false,
+    })
+  })
+
+  test('views without a prefetch config are left absent', () => {
+    const route = createRoute({ name: 'route' })
+      .addView(component)
+      .addView(other, { name: 'sidebar', prefetch: 'intent' })
+
+    expect(lastView(route).prefetch).toStrictEqual({ sidebar: 'intent' })
   })
 })
 
@@ -62,7 +113,7 @@ describe('backwards compatibility', () => {
     const sidebarGetter = (): { baz: number } => ({ baz: 1 })
 
     const route = createRoute({ name: 'route', component }, defaultGetter)
-      .addView('sidebar', other, sidebarGetter)
+      .addView(other, { name: 'sidebar', props: sidebarGetter })
 
     expect(lastView(route).components).toStrictEqual({ default: component, sidebar: other })
     expect(lastView(route).props).toStrictEqual({ default: defaultGetter, sidebar: sidebarGetter })

--- a/src/services/addView.spec.ts
+++ b/src/services/addView.spec.ts
@@ -17,7 +17,9 @@ describe('components', () => {
   })
 
   test('a named view is stored under its name', () => {
-    const route = createRoute({ name: 'route' }).addView(component, { name: 'sidebar' })
+    const route = createRoute({ name: 'route' }).addView(component, {
+      name: 'sidebar',
+    })
 
     expect(lastView(route).components).toStrictEqual({ sidebar: component })
   })
@@ -25,7 +27,9 @@ describe('components', () => {
   test('multiple views accumulate in the same views entry', () => {
     const route = createRoute({ name: 'route' })
       .addView(component)
-      .addView(other, { name: 'sidebar' })
+      .addView(other, {
+        name: 'sidebar',
+      })
 
     expect(lastView(route).components).toStrictEqual({ default: component, sidebar: other })
   })
@@ -34,7 +38,9 @@ describe('components', () => {
 describe('props', () => {
   test('a lone default view getter is stored as bare props', () => {
     const getter = (): { foo: string } => ({ foo: 'bar' })
-    const route = createRoute({ name: 'route' }).addView(component, { props: getter })
+    const route = createRoute({ name: 'route' }).addView(component, {
+      props: getter,
+    })
 
     expect(lastView(route).props).toBe(getter)
   })
@@ -50,8 +56,13 @@ describe('props', () => {
     const sidebarGetter = (): { baz: number } => ({ baz: 1 })
 
     const route = createRoute({ name: 'route' })
-      .addView(component, { props: defaultGetter })
-      .addView(other, { name: 'sidebar', props: sidebarGetter })
+      .addView(component, {
+        props: defaultGetter,
+      })
+      .addView(other, {
+        name: 'sidebar',
+        props: sidebarGetter,
+      })
 
     expect(lastView(route).props).toStrictEqual({ default: defaultGetter, sidebar: sidebarGetter })
   })
@@ -59,7 +70,9 @@ describe('props', () => {
 
 describe('prefetch', () => {
   test('prefetch is stored under the view name', () => {
-    const route = createRoute({ name: 'route' }).addView(component, { prefetch: false })
+    const route = createRoute({ name: 'route' }).addView(component, {
+      prefetch: false,
+    })
 
     expect(lastView(route).prefetch).toStrictEqual({ default: false })
     expect(lastView(route).props).toBeUndefined()
@@ -67,21 +80,31 @@ describe('prefetch', () => {
 
   test('prefetch is stored alongside a props getter', () => {
     const getter = (): { foo: string } => ({ foo: 'bar' })
-    const route = createRoute({ name: 'route' }).addView(component, { props: getter, prefetch: 'eager' })
+    const route = createRoute({ name: 'route' }).addView(component, {
+      props: getter,
+      prefetch: 'eager',
+    })
 
     expect(lastView(route).props).toBe(getter)
     expect(lastView(route).prefetch).toStrictEqual({ default: 'eager' })
   })
 
   test('prefetch is stored under a named view name', () => {
-    const route = createRoute({ name: 'route' }).addView(component, { name: 'sidebar', prefetch: 'eager' })
+    const route = createRoute({ name: 'route' }).addView(component, {
+      name: 'sidebar',
+      prefetch: 'eager',
+    })
 
     expect(lastView(route).prefetch).toStrictEqual({ sidebar: 'eager' })
   })
 
   test('prefetch is stored alongside a named view props getter', () => {
     const getter = (): { foo: string } => ({ foo: 'bar' })
-    const route = createRoute({ name: 'route' }).addView(component, { name: 'sidebar', props: getter, prefetch: 'intent' })
+    const route = createRoute({ name: 'route' }).addView(component, {
+      name: 'sidebar',
+      props: getter,
+      prefetch: 'intent',
+    })
 
     expect(lastView(route).props).toStrictEqual({ sidebar: getter })
     expect(lastView(route).prefetch).toStrictEqual({ sidebar: 'intent' })
@@ -89,8 +112,13 @@ describe('prefetch', () => {
 
   test('each view keeps its own prefetch config', () => {
     const route = createRoute({ name: 'route' })
-      .addView(component, { prefetch: { components: 'eager', props: false } })
-      .addView(other, { name: 'sidebar', prefetch: false })
+      .addView(component, {
+        prefetch: { components: 'eager', props: false },
+      })
+      .addView(other, {
+        name: 'sidebar',
+        prefetch: false,
+      })
 
     expect(lastView(route).prefetch).toStrictEqual({
       default: { components: 'eager', props: false },
@@ -101,7 +129,10 @@ describe('prefetch', () => {
   test('views without a prefetch config are left absent', () => {
     const route = createRoute({ name: 'route' })
       .addView(component)
-      .addView(other, { name: 'sidebar', prefetch: 'intent' })
+      .addView(other, {
+        name: 'sidebar',
+        prefetch: 'intent',
+      })
 
     expect(lastView(route).prefetch).toStrictEqual({ sidebar: 'intent' })
   })
@@ -113,7 +144,10 @@ describe('backwards compatibility', () => {
     const sidebarGetter = (): { baz: number } => ({ baz: 1 })
 
     const route = createRoute({ name: 'route', component }, defaultGetter)
-      .addView(other, { name: 'sidebar', props: sidebarGetter })
+      .addView(other, {
+        name: 'sidebar',
+        props: sidebarGetter,
+      })
 
     expect(lastView(route).components).toStrictEqual({ default: component, sidebar: other })
     expect(lastView(route).props).toStrictEqual({ default: defaultGetter, sidebar: sidebarGetter })

--- a/src/services/addView.ts
+++ b/src/services/addView.ts
@@ -1,44 +1,43 @@
 import { Component } from 'vue'
 import { DEFAULT_VIEW_NAME } from '@/services/createRouteViews'
 import { PropsGetter } from '@/types/createRouteOptions'
+import { PrefetchConfig } from '@/types/prefetch'
 import { Route } from '@/types/route'
 import { RouteViews } from '@/types/routeViews'
 
-type DefaultViewArgs = [component: Component, props?: PropsGetter]
-type NamedViewArgs = [name: string, component: Component, props?: PropsGetter]
+/**
+ * The loose runtime shape of the `addView` options. Purposely wide: the getter and name types each
+ * `RouteAddView` describes are refined per route and component.
+ */
+type ViewOptions = {
+  name?: string,
+  props?: PropsGetter,
+  prefetch?: PrefetchConfig,
+}
 
 /**
- * The runtime arguments accepted by `addView`: a default view (component first) or a named view (name first).
+ * The runtime arguments accepted by `addView`.
  */
-type AddViewParameters = DefaultViewArgs | NamedViewArgs
+type AddViewParameters = [component: Component, options?: ViewOptions]
 
 type NamedView = {
   name: string,
   component: Component,
   props: PropsGetter | undefined,
+  prefetch: PrefetchConfig | undefined,
 }
 
 /**
- * Whether the `addView` arguments are for a named view (a name string as the first argument) rather than
- * the default view (a component as the first argument).
+ * Normalizes `addView` arguments into a `{ name, component, props, prefetch }` view, defaulting the
+ * name to 'default'.
  */
-function isNamedView(args: AddViewParameters): args is NamedViewArgs {
-  return typeof args[0] === 'string'
-}
-
-/**
- * Normalizes `addView` arguments into a `{ name, component, props }` view, defaulting the name to 'default'.
- */
-function toNamedView(args: AddViewParameters): NamedView {
-  if (isNamedView(args)) {
-    const [name, component, props] = args
-
-    return { name, component, props }
+function toNamedView(component: Component, options: ViewOptions | undefined): NamedView {
+  return {
+    name: options?.name ?? DEFAULT_VIEW_NAME,
+    component,
+    props: options?.props,
+    prefetch: options?.prefetch,
   }
-
-  const [component, props] = args
-
-  return { name: DEFAULT_VIEW_NAME, component, props }
 }
 
 /**
@@ -71,16 +70,30 @@ function toPropsRecord(props: ViewProps): Record<string, PropsGetter> {
 }
 
 /**
- * Returns a new {@link RouteViews} with a view (component + optional props getter) merged in. Components
- * are always stored as a record; props keep the bare getter for a lone default view and promote to a
- * record once a named view is added (pulling any existing bare default under 'default').
+ * Returns a new {@link RouteViews} with a view (component + optional props getter + optional per-view
+ * settings) merged in. Components and prefetch configs are always stored as records keyed by view name;
+ * props keep the bare getter for a lone default view and promote to a record once a named view is added
+ * (pulling any existing bare default under 'default').
  */
-function addToViews(views: RouteViews, name: string, component: Component, props: PropsGetter | undefined): RouteViews {
+function addToViews(views: RouteViews, { name, component, props, prefetch }: NamedView): RouteViews {
   return {
     id: views.id,
     components: { ...views.components, [name]: component },
     props: addProps(views.props as ViewProps, name, props),
+    prefetch: addPrefetch(views.prefetch, name, prefetch),
   }
+}
+
+/**
+ * Merges a view's prefetch config into the record keyed by view name. Views without their own config are
+ * left absent so they fall back to the route's config.
+ */
+function addPrefetch(current: RouteViews['prefetch'], name: string, prefetch: PrefetchConfig | undefined): RouteViews['prefetch'] {
+  if (prefetch === undefined) {
+    return current
+  }
+
+  return { ...current, [name]: prefetch }
 }
 
 function addProps(current: ViewProps, name: string, props: PropsGetter | undefined): ViewProps {
@@ -107,15 +120,15 @@ type AddView = (...args: AddViewParameters) => Route
  * mutation of the input route.
  */
 export function withAddView<TRoute extends Route>(route: TRoute): TRoute {
-  const addView: AddView = (...args) => {
-    const { name, component, props } = toNamedView(args)
+  const addView: AddView = (component, options) => {
+    const view = toNamedView(component, options)
     const currentViews = route.views.at(-1)
 
     if (!currentViews) {
       return withAddView(route)
     }
 
-    const nextViews = addToViews(currentViews, name, component, props)
+    const nextViews = addToViews(currentViews, view)
 
     return withAddView({
       ...route,

--- a/src/services/addView.ts
+++ b/src/services/addView.ts
@@ -20,18 +20,14 @@ type ViewOptions = {
  */
 type AddViewParameters = [component: Component, options?: ViewOptions]
 
-type NamedView = {
+type View = {
   name: string,
   component: Component,
   props: PropsGetter | undefined,
   prefetch: PrefetchConfig | undefined,
 }
 
-/**
- * Normalizes `addView` arguments into a `{ name, component, props, prefetch }` view, defaulting the
- * name to 'default'.
- */
-function toNamedView(component: Component, options: ViewOptions | undefined): NamedView {
+function toView(component: Component, options: ViewOptions | undefined): View {
   return {
     name: options?.name ?? DEFAULT_VIEW_NAME,
     component,
@@ -75,7 +71,7 @@ function toPropsRecord(props: ViewProps): Record<string, PropsGetter> {
  * props keep the bare getter for a lone default view and promote to a record once a named view is added
  * (pulling any existing bare default under 'default').
  */
-function addToViews(views: RouteViews, { name, component, props, prefetch }: NamedView): RouteViews {
+function addToViews(views: RouteViews, { name, component, props, prefetch }: View): RouteViews {
   return {
     id: views.id,
     components: { ...views.components, [name]: component },
@@ -121,7 +117,7 @@ type AddView = (...args: AddViewParameters) => Route
  */
 export function withAddView<TRoute extends Route>(route: TRoute): TRoute {
   const addView: AddView = (component, options) => {
-    const view = toNamedView(component, options)
+    const view = toView(component, options)
     const currentViews = route.views.at(-1)
 
     if (!currentViews) {

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -32,8 +32,13 @@ export function createPropStore(): PropStore {
 
     return route.matches
       .map((match, index) => ({ match, views: route.views[index] }))
-      .filter(({ match }) => getPrefetchOption({ ...prefetch, routePrefetch: match.prefetch }, 'props') === strategy)
-      .flatMap(({ views }) => getComponentProps(views))
+      .flatMap(({ match, views }) => getComponentProps(views).map((componentProps) => ({ match, views, componentProps })))
+      .filter(({ match, views, componentProps }) => getPrefetchOption({
+        ...prefetch,
+        routePrefetch: match.prefetch,
+        viewPrefetch: views.prefetch?.[componentProps.name],
+      }, 'props') === strategy)
+      .map(({ componentProps }) => componentProps)
       .reduce<Record<string, unknown>>((response, { id, name, props }) => {
         if (!props) {
           return response

--- a/src/types/addView.ts
+++ b/src/types/addView.ts
@@ -11,6 +11,7 @@ import { RouterPush } from '@/types/routerPush'
 import { RouterReject } from '@/types/routerReject'
 import { RouterReplace } from '@/types/routerReplace'
 import { RouteUpdate } from '@/types/routeUpdate'
+import { PrefetchConfig } from '@/types/prefetch'
 import { RouteViews } from '@/types/routeViews'
 import { Url } from '@/types/url'
 import { Identity, LastInArray, MaybePromise } from '@/types/utilities'
@@ -64,8 +65,8 @@ type MatchPropsReturnType<TProps> = TProps extends PropsGetter
     : undefined
 
 /**
- * When the getter argument is omitted the default type param resolves to the wide getter type, which
- * then "extends" itself and collapses to undefined. When a getter is provided it is narrower and preserved.
+ * When the getter is omitted the default type param resolves to the wide getter type, which then
+ * "extends" itself and collapses to undefined. When a getter is provided it is narrower and preserved.
  */
 type NewViewGetter<
   TRoute extends Route,
@@ -74,14 +75,59 @@ type NewViewGetter<
 > = AddViewPropsGetter<TRoute, TComponent> extends TGetter ? undefined : TGetter
 
 /**
- * The props argument for `addView`. Required when the component has required props, otherwise optional.
+ * The options for a view added via `addView`.
+ *
+ * @template TName - The view's name, inferred from the `name` option.
+ * @template TGetter - The view's props getter, inferred from the `props` option.
+ */
+export type AddViewOptions<
+  TName extends string | undefined = string,
+  TGetter = PropsGetter
+> = {
+  /**
+   * The name of the view, rendered by `<router-view name="..." />`. Defaults to the unnamed view.
+   */
+  name?: TName,
+  /**
+   * A props getter for the view. Receives the resolved route and a context object.
+   */
+  props?: TGetter,
+  /**
+   * Determines what assets are prefetched for this view when a router-link is rendered for this route.
+   * Overrides route level prefetch, and is itself overridden by link level prefetch.
+   */
+  prefetch?: PrefetchConfig,
+}
+
+/**
+ * {@link AddViewOptions} with `props` promoted to required. Only reached for components that have
+ * required props — everything else uses {@link AddViewOptions}, where `props` stays optional, so a view
+ * can always be given a name and a prefetch config without a getter.
+ *
+ * Spelled out rather than intersected with {@link AddViewOptions} so that the literal `name` still
+ * infers through the conditional args tuple.
+ */
+type AddViewOptionsWithRequiredProps<
+  TName extends string | undefined,
+  TGetter
+> = {
+  name?: TName,
+  props: TGetter,
+  prefetch?: PrefetchConfig,
+}
+
+/**
+ * The options argument for `addView`, required only when the component has required props. `TName` and
+ * `TGetter` are inferred from the object's properties rather than from the object as a whole: inferring
+ * the whole object as a `const` type param through this conditional tuple widens the literal name.
  */
 type AddViewArgs<
   TComponent extends Component,
+  TName extends string | undefined,
   TGetter
 > = ComponentPropsAreOptional<TComponent> extends true
-  ? [props?: TGetter]
-  : [props: TGetter]
+  ? [options?: AddViewOptions<TName, TGetter>]
+  : [options: AddViewOptionsWithRequiredProps<TName, TGetter>]
 
 /**
  * The current route's own view prop getters (the last entry of its `views` tuple).
@@ -158,36 +204,20 @@ type AddViewReturn<
  * including named views for named `<router-view />`s.
  */
 export type RouteAddView<TRoute extends Route = Route> = {
-  addView: {
-    /**
-     * Adds the default view for this route.
-     *
-     * @param component - The component to render in the default `<router-view />`.
-     * @param props - A props getter. Required when the component has required props.
-     */
-    <
-      TComponent extends Component,
-      const TGetter extends AddViewPropsGetter<TRoute, TComponent> = AddViewPropsGetter<TRoute, TComponent>
-    >(
-      component: TComponent,
-      ...props: AddViewArgs<TComponent, TGetter>
-    ): AddViewReturn<TRoute, AddViewProps<CurrentViewProps<TRoute>, undefined, NewViewGetter<TRoute, TComponent, TGetter>>>,
-
-    /**
-     * Adds a named view for this route, rendered by `<router-view name="..." />`.
-     *
-     * @param name - The name of the view.
-     * @param component - The component to render in the named `<router-view />`.
-     * @param props - A props getter. Required when the component has required props.
-     */
-    <
-      TName extends string,
-      TComponent extends Component,
-      const TGetter extends AddViewPropsGetter<TRoute, TComponent> = AddViewPropsGetter<TRoute, TComponent>
-    >(
-      name: TName,
-      component: TComponent,
-      ...props: AddViewArgs<TComponent, TGetter>
-    ): AddViewReturn<TRoute, AddViewProps<CurrentViewProps<TRoute>, TName, NewViewGetter<TRoute, TComponent, TGetter>>>,
-  },
+  /**
+   * Adds a view for this route.
+   *
+   * @param component - The component to render. Rendered by `<router-view name="..." />` when the
+   * options carry a name, and by the default `<router-view />` otherwise.
+   * @param options - The view's `name`, `props` getter, and `prefetch` config. Required when the
+   * component has required props, optional otherwise.
+   */
+  addView: <
+    TComponent extends Component,
+    const TName extends string | undefined = undefined,
+    const TGetter extends AddViewPropsGetter<TRoute, TComponent> = AddViewPropsGetter<TRoute, TComponent>
+  >(
+    component: TComponent,
+    ...options: AddViewArgs<TComponent, TName, TGetter>
+  ) => AddViewReturn<TRoute, AddViewProps<CurrentViewProps<TRoute>, TName, NewViewGetter<TRoute, TComponent, TGetter>>>,
 }

--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -104,13 +104,13 @@ export type CreateRouteOptions<
    * An optional component to render when this route is matched.
    *
    * @default RouterView
-   * @deprecated Use the chainable `addView` method on the route instead: `createRoute({ ... }).addView(component, props?)`.
+   * @deprecated Use the chainable `addView` method on the route instead: `createRoute({ ... }).addView(component, { props })`.
    */
   component?: Component,
   /**
    * An object of named components to render using named views
    *
-   * @deprecated Use the chainable `addView` method on the route instead: `createRoute({ ... }).addView(name, component, props?)`.
+   * @deprecated Use the chainable `addView` method on the route instead: `createRoute({ ... }).addView(component, { name, props })`.
    */
   components?: Record<string, Component>,
   /**

--- a/src/types/prefetch.ts
+++ b/src/types/prefetch.ts
@@ -26,5 +26,6 @@ export type PrefetchConfig = boolean | PrefetchStrategy | PrefetchConfigOptions
 export type PrefetchConfigs = {
   routerPrefetch?: PrefetchConfig,
   routePrefetch?: PrefetchConfig,
+  viewPrefetch?: PrefetchConfig,
   linkPrefetch?: PrefetchConfig,
 }

--- a/src/types/routeViews.ts
+++ b/src/types/routeViews.ts
@@ -1,4 +1,5 @@
 import { Component } from 'vue'
+import { PrefetchConfig } from '@/types/prefetch'
 
 /**
  * The components and prop getters for a single route, keyed by view name (the default view under
@@ -22,4 +23,9 @@ export type RouteViews<TProps = unknown> = {
    * Prop getters for the route's views.
    */
   props: TProps,
+  /**
+   * Prefetch configs keyed by view name, for views that opted into their own config. Overrides the
+   * route level prefetch for that view only. Absent keys fall back to the route's config.
+   */
+  prefetch?: Record<string, PrefetchConfig>,
 }

--- a/src/utilities/prefetch.spec.ts
+++ b/src/utilities/prefetch.spec.ts
@@ -22,6 +22,35 @@ describe('getPrefetchOptions', () => {
 
     expect(value).toBe(expected)
   })
+
+  test.each([
+    [undefined, false, true, true, false],
+    [undefined, 'eager', 'lazy', true, 'eager'],
+    [undefined, true, 'intent', false, 'intent'],
+    [undefined, { components: false }, true, true, false],
+    [undefined, undefined, 'lazy', true, 'lazy'],
+    ['intent', 'eager', false, false, 'intent'],
+    [true, false, undefined, undefined, DEFAULT_PREFETCH_STRATEGY],
+  ] as const)('when given [`%s`, `%s`, `%s`, `%s`] returns `%s`', (linkPrefetch, viewPrefetch, routePrefetch, routerPrefetch, expected) => {
+    const value = getPrefetchOption({
+      linkPrefetch,
+      viewPrefetch,
+      routePrefetch,
+      routerPrefetch,
+    }, 'components')
+
+    expect(value).toBe(expected)
+  })
+
+  test('a view config can split components and props', () => {
+    const configs = {
+      viewPrefetch: { components: 'eager', props: false },
+      routePrefetch: true,
+    } as const
+
+    expect(getPrefetchOption(configs, 'components')).toBe('eager')
+    expect(getPrefetchOption(configs, 'props')).toBe(false)
+  })
 })
 
 describe('getPrefetchConfigValue', () => {

--- a/src/utilities/prefetch.ts
+++ b/src/utilities/prefetch.ts
@@ -12,13 +12,15 @@ function isPrefetchStrategy(value: any): value is PrefetchStrategy {
   return ['eager', 'lazy', 'intent'].includes(value)
 }
 
-export function getPrefetchOption({ routerPrefetch, routePrefetch, linkPrefetch }: PrefetchConfigs, setting: keyof PrefetchConfigOptions): false | PrefetchStrategy {
+export function getPrefetchOption({ routerPrefetch, routePrefetch, viewPrefetch, linkPrefetch }: PrefetchConfigs, setting: keyof PrefetchConfigOptions): false | PrefetchStrategy {
   const link = getPrefetchConfigValue(linkPrefetch, setting)
+  const view = getPrefetchConfigValue(viewPrefetch, setting)
   const route = getPrefetchConfigValue(routePrefetch, setting)
   const router = getPrefetchConfigValue(routerPrefetch, setting)
 
   const value = [
     link,
+    view,
     route,
     router,
     DEFAULT_PREFETCH_CONFIG[setting],


### PR DESCRIPTION
# Description

Prefetching could only be configured per route, which is too coarse when a route has multiple views. A dashboard with a light sidebar and a heavy report had to prefetch both or neither.

Each view can now set its own prefetch config, and it overrides the route's config for that view only. View config sits between route and link in the precedence chain, so `link > view > route > router`.

Since this meant a fourth positional argument, `addView` now takes an options object instead:

```ts
// before
.addView('sidebar', Sidebar, (route) => ({ id: route.params.id }))

// after
.addView(Sidebar, {
  name: 'sidebar',
  props: (route) => ({ id: route.params.id }),
  prefetch: 'eager',
})
```

Docs are updated for the new signature and the per-view config.
