### PR TITLE
Fix a child receiving an Error where it awaits parent props

### DIFF
--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -6,6 +6,7 @@ import { ResolvedRoute } from '@/types/resolved'
 import { RouteViews } from '@/types/routeViews'
 import { ContextPushError } from '@/errors/contextPushError'
 import { ContextRejectionError } from '@/errors/contextRejectionError'
+import { isPromise } from '@/utilities/promises'
 import { getPropsValue } from '@/utilities/props'
 import { PropsCallbackParent } from '@/types/props'
 import { createVueAppStore, HasVueAppStore } from './createVueAppStore'
@@ -180,6 +181,29 @@ export function createPropStore(): PropStore {
         Unable to access parent props "${name}" while prefetching props for route "${routeName}".
         This may occur if the parent route's props were not also prefetched.
       `)
+    }
+
+    return unwrapPropsError(value)
+  }
+
+  /**
+   * A failed props getter is stored as its error rather than thrown, so that navigation can inspect the
+   * settled value. Consumers of a parent's props expect the props themselves, so the error is rethrown
+   * here instead of being handed back as though it were a valid value.
+   */
+  function unwrapPropsError(value: unknown): unknown {
+    if (value instanceof Error) {
+      throw value
+    }
+
+    if (isPromise(value)) {
+      return value.then((resolved) => {
+        if (resolved instanceof Error) {
+          throw resolved
+        }
+
+        return resolved
+      })
     }
 
     return value

--- a/src/services/createRoute.spec.ts
+++ b/src/services/createRoute.spec.ts
@@ -1,3 +1,4 @@
+import { flushPromises } from '@vue/test-utils'
 import { describe, expect, test, vi } from 'vitest'
 import { createRoute } from '@/services/createRoute'
 import { component } from '@/utilities/testHelpers'
@@ -283,6 +284,74 @@ describe('props', () => {
     expect(spy).toHaveBeenCalledWith({ value: 123 })
   })
 
+  test('awaiting parent props that rejected throws the error', async () => {
+    const error = new Error('parent props failed')
+    const caught = vi.fn()
+
+    const parent = createRoute({
+      name: 'parent',
+    }, async () => {
+      throw error
+    })
+
+    const child = createRoute({
+      name: 'child',
+      parent: parent,
+      path: '/child',
+    }, async (__, { parent }) => {
+      try {
+        await parent.props
+      } catch (thrown) {
+        caught(thrown)
+      }
+
+      return {}
+    })
+
+    const router = createRouter([parent, child], {
+      initialUrl: '/child',
+    })
+
+    await router.start()
+
+    expect(caught).toHaveBeenCalledWith(error)
+  })
+
+  test('reading parent props that threw synchronously throws the error', async () => {
+    const error = new Error('parent props failed')
+    const caught = vi.fn()
+
+    const parent = createRoute({
+      name: 'parent',
+    }, () => {
+      throw error
+    })
+
+    const child = createRoute({
+      name: 'child',
+      parent: parent,
+      path: '/child',
+    }, (__, { parent }) => {
+      try {
+        const value = parent.props
+
+        caught({ didNotThrow: value })
+      } catch (thrown) {
+        caught(thrown)
+      }
+
+      return {}
+    })
+
+    const router = createRouter([parent, child], {
+      initialUrl: '/child',
+    })
+
+    await router.start()
+
+    expect(caught).toHaveBeenCalledWith(error)
+  })
+
   test('async parent props are passed to child props', async () => {
     const spy = vi.fn()
 
@@ -385,6 +454,7 @@ describe('props', () => {
     })
 
     await router.start()
+    await flushPromises()
 
     expect(spy).toHaveBeenCalledWith({ value1: 123, value2: 456 })
   })


### PR DESCRIPTION
# Description

Bug 2 of 3. Stacked on #793.

When a props getter fails its error is stored as the value rather than thrown, so navigation can inspect a settled value without unhandled rejections. Parent props were handed back the same way, so `await parent.props` resolved *with* an `Error` instead of throwing.

```ts
const parent = createRoute({
  name: 'parent',
  path: '/parent',
}).addView(ParentLayout, {
  props: async () => {
    throw new Error('parent props failed')
  },
})

const child = createRoute({
  name: 'child',
  parent,
  path: '/child',
}).addView(ChildPage, {
  props: async (route, { parent }) => {
    const { post } = await parent.props
    // before: does not throw. post is undefined and the getter carries on
    //         with corrupt data, while navigation completes
    // after:  throws Error('parent props failed')

    return { post }
  },
})
```

Reading a parent's props now rethrows, so the child's own getter fails and the error reaches the existing error hooks attributed to the route that actually depended on it. Comes before #795 because the waiting path there composes this unwrapping.

One existing test needed an extra `flushPromises`. Inspecting a promise's resolved value costs a microtask, and that test awaited two parent props, so `router.start()` alone no longer covered it — props are deliberately not awaited during navigation, so it was already relying on the chain being short.
