### PR TITLE
Fix a child receiving undefined where it awaits parent props

### DIFF
--- a/docs/core-concepts/component-props.md
+++ b/docs/core-concepts/component-props.md
@@ -65,6 +65,8 @@ const user = createRoute({
 
 The [callback context](/core-concepts/component-props#context) includes a `parent` property which contains the name and props of the parent route. This can be useful for passing down data to child components.
 
+`parent.props` is always a promise and must be awaited, even when the parent's getter is synchronous. The parent's props may not have been computed when your getter runs — if the parent's props are prefetched at a different strategy than yours, or not prefetched at all, awaiting them waits until they are.
+
 ```ts
 const blogPost = createRoute({
   name: 'blog',

--- a/src/components/routerLink.browser.spec.ts
+++ b/src/components/routerLink.browser.spec.ts
@@ -1048,6 +1048,332 @@ describe('prefetch props', () => {
     expect(wrapper.text()).toBe(value)
   })
 
+  test('a child waits for parent props that are not prefetched rather than receiving undefined', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const settled: unknown[] = []
+
+    const home = createRoute({
+      name: 'home',
+      path: '/',
+      component: () => h(RouterLink, { to: (resolve) => resolve('child') }),
+    })
+
+    const parent = createRoute({
+      name: 'parent',
+      path: '/parent',
+      component: { props: ['foo'], template: '<div><RouterView /></div>' },
+      prefetch: { props: false },
+    }, async () => ({ foo: 123 }))
+
+    const child = createRoute({
+      parent,
+      name: 'child',
+      path: '/child',
+      component: echo,
+      prefetch: { props: 'eager' },
+    }, async (__, { parent }) => {
+      settled.push(await parent.props)
+
+      return { value: 'child' }
+    })
+
+    const router = createRouter([home, child], {
+      initialUrl: '/',
+    })
+
+    await router.start()
+
+    const wrapper = mount({ template: '<RouterView />' }, {
+      global: {
+        plugins: [router],
+      },
+    })
+
+    await flushPromises()
+
+    expect(settled).toStrictEqual([])
+    expect(warn.mock.calls.some(([message]) => String(message).includes('Waiting on parent props'))).toBe(true)
+
+    wrapper.find('a').trigger('click')
+
+    await flushPromises()
+
+    expect(settled).toStrictEqual([{ foo: 123 }])
+
+    warn.mockRestore()
+  })
+
+  test('a child waits for parent props prefetched at a later strategy', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const settled: unknown[] = []
+
+    const home = createRoute({
+      name: 'home',
+      path: '/',
+      component: () => h(RouterLink, { to: (resolve) => resolve('child') }),
+    })
+
+    const parent = createRoute({
+      name: 'parent',
+      path: '/parent',
+      component: { props: ['foo'], template: '<div><RouterView /></div>' },
+      prefetch: { props: 'intent' },
+    }, async () => ({ foo: 123 }))
+
+    const child = createRoute({
+      parent,
+      name: 'child',
+      path: '/child',
+      component: echo,
+      prefetch: { props: 'eager' },
+    }, async (__, { parent }) => {
+      settled.push(await parent.props)
+
+      return { value: 'child' }
+    })
+
+    const router = createRouter([home, child], {
+      initialUrl: '/',
+    })
+
+    await router.start()
+
+    const wrapper = mount({ template: '<RouterView />' }, {
+      global: {
+        plugins: [router],
+      },
+    })
+
+    await flushPromises()
+
+    expect(settled).toStrictEqual([])
+
+    wrapper.find('a').trigger('click')
+
+    await flushPromises()
+
+    expect(settled).toStrictEqual([{ foo: 123 }])
+
+    warn.mockRestore()
+  })
+
+  test('a child prefetching by intent resolves parent props already prefetched eagerly', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const settled: unknown[] = []
+
+    const home = createRoute({
+      name: 'home',
+      path: '/',
+      component: () => h(RouterLink, { to: (resolve) => resolve('child') }),
+    })
+
+    const parent = createRoute({
+      name: 'parent',
+      path: '/parent',
+      component: { props: ['foo'], template: '<div><RouterView /></div>' },
+      prefetch: { props: 'eager' },
+    }, async () => ({ foo: 123 }))
+
+    const child = createRoute({
+      parent,
+      name: 'child',
+      path: '/child',
+      component: echo,
+      prefetch: { props: 'intent' },
+    }, async (__, { parent }) => {
+      settled.push(await parent.props)
+
+      return { value: 'child' }
+    })
+
+    const router = createRouter([home, child], {
+      initialUrl: '/',
+    })
+
+    await router.start()
+
+    const wrapper = mount({ template: '<RouterView />' }, {
+      global: {
+        plugins: [router],
+      },
+    })
+
+    await flushPromises()
+
+    wrapper.find('a').trigger('focusin')
+
+    await flushPromises()
+
+    expect(settled).toStrictEqual([{ foo: 123 }])
+    expect(warn.mock.calls.some(([message]) => String(message).includes('Waiting on parent props'))).toBe(false)
+
+    warn.mockRestore()
+  })
+
+  test('a child waiting on parent props settles when the parent getter returns undefined', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const settled: unknown[] = []
+
+    const home = createRoute({
+      name: 'home',
+      path: '/',
+      component: () => h(RouterLink, { to: (resolve) => resolve('child') }),
+    })
+
+    const parent = createRoute({
+      name: 'parent',
+      path: '/parent',
+      component: { template: '<div><RouterView /></div>' },
+      prefetch: { props: false },
+    }, () => undefined as never)
+
+    const child = createRoute({
+      parent,
+      name: 'child',
+      path: '/child',
+      component: echo,
+      prefetch: { props: 'eager' },
+    }, async (__, { parent }) => {
+      settled.push(await parent.props)
+
+      return { value: 'child' }
+    })
+
+    const router = createRouter([home, child], {
+      initialUrl: '/',
+    })
+
+    await router.start()
+
+    const wrapper = mount({ template: '<RouterView />' }, {
+      global: {
+        plugins: [router],
+      },
+    })
+
+    await flushPromises()
+
+    expect(settled).toStrictEqual([])
+
+    wrapper.find('a').trigger('click')
+
+    await flushPromises()
+
+    expect(settled).toStrictEqual([undefined])
+
+    warn.mockRestore()
+  })
+
+  test('a child does not wait when the parent props are prefetched at the same strategy', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const settled: unknown[] = []
+
+    const home = createRoute({
+      name: 'home',
+      path: '/',
+      component: () => h(RouterLink, { to: (resolve) => resolve('child') }),
+    })
+
+    const parent = createRoute({
+      name: 'parent',
+      path: '/parent',
+      component: { props: ['foo'], template: '<div><RouterView /></div>' },
+      prefetch: { props: 'eager' },
+    }, async () => ({ foo: 123 }))
+
+    const child = createRoute({
+      parent,
+      name: 'child',
+      path: '/child',
+      component: echo,
+      prefetch: { props: 'eager' },
+    }, async (__, { parent }) => {
+      settled.push(await parent.props)
+
+      return { value: 'child' }
+    })
+
+    const router = createRouter([home, child], {
+      initialUrl: '/',
+    })
+
+    await router.start()
+
+    mount({ template: '<RouterView />' }, {
+      global: {
+        plugins: [router],
+      },
+    })
+
+    await flushPromises()
+
+    expect(settled).toStrictEqual([{ foo: 123 }])
+    expect(warn.mock.calls.some(([message]) => String(message).includes('Waiting on parent props'))).toBe(false)
+
+    warn.mockRestore()
+  })
+
+  test('prefetched parent props are available to a child prefetching its own props', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    let childSawParentProps: unknown = 'NOT_READ'
+
+    const home = createRoute({
+      name: 'home',
+      path: '/',
+      component: () => h(RouterLink, { to: (resolve) => resolve('child') }),
+    })
+
+    const parent = createRoute({
+      name: 'parent',
+      path: '/parent',
+      component: { template: '<RouterView />' },
+      prefetch: { props: 'eager' },
+    }, async () => ({ foo: 123 }))
+
+    const child = createRoute({
+      parent,
+      name: 'child',
+      path: '/child',
+      component: echo,
+      prefetch: { props: 'eager' },
+    }, async (__, { parent }) => {
+      childSawParentProps = await parent.props
+
+      return { value: 'child' }
+    })
+
+    const router = createRouter([home, child], {
+      initialUrl: '/',
+    })
+
+    await router.start()
+
+    const wrapper = mount({ template: '<RouterView />' }, {
+      global: {
+        plugins: [router],
+      },
+    })
+
+    await flushPromises()
+
+    expect(childSawParentProps).toStrictEqual({ foo: 123 })
+    expect(warn).not.toHaveBeenCalled()
+
+    wrapper.find('a').trigger('click')
+
+    await flushPromises()
+
+    expect(wrapper.text()).toBe('child')
+
+    warn.mockRestore()
+  })
+
   test('parent routes that should not prefetch props are not prefetched', async () => {
     const parentProps = vi.fn()
     const childProps = vi.fn()

--- a/src/compositions/usePrefetching.ts
+++ b/src/compositions/usePrefetching.ts
@@ -32,13 +32,15 @@ export function createUsePrefetching<TRouter extends Router>(routerKey: Injectio
     const { isElementVisible } = useVisibilityObserver(element)
 
     const commit: UsePrefetching['commit'] = () => {
-      const props = Array.from(prefetchedProps.values()).reduce<Record<string, MaybePromise<PropsResult>>>((accumulator, value) => {
+      setPrefetchProps(getAccumulatedProps())
+    }
+
+    function getAccumulatedProps(): Record<string, MaybePromise<PropsResult>> {
+      return Array.from(prefetchedProps.values()).reduce<Record<string, MaybePromise<PropsResult>>>((accumulator, value) => {
         Object.assign(accumulator, value)
 
         return accumulator
       }, {})
-
-      setPrefetchProps(props)
     }
 
     watch(() => toValue(config), ({ route, ...configs }) => {
@@ -78,7 +80,7 @@ export function createUsePrefetching<TRouter extends Router>(routerKey: Injectio
       prefetchComponentsForRoute(strategy, route, configs)
 
       if (!prefetchedProps.has(strategy)) {
-        prefetchedProps.set(strategy, getPrefetchProps(strategy, route, configs))
+        prefetchedProps.set(strategy, getPrefetchProps(strategy, route, configs, getAccumulatedProps()))
       }
     }
 

--- a/src/services/addView.spec-d.ts
+++ b/src/services/addView.spec-d.ts
@@ -230,7 +230,7 @@ describe('addView', () => {
       })
 
       createRoute({ name: 'child', parent }, (__, { parent }) => {
-        expectTypeOf(parent.props).toEqualTypeOf<{ foo: number }>()
+        expectTypeOf(parent.props).toEqualTypeOf<Promise<{ foo: number }>>()
         expectTypeOf(parent.name).toEqualTypeOf<'parent'>()
 
         return {}
@@ -250,7 +250,7 @@ describe('addView', () => {
 
       createRoute({ name: 'child', parent }, (__, { parent }) => {
         expectTypeOf(parent.props).toEqualTypeOf<{
-          one: { foo: number },
+          one: Promise<{ foo: number }>,
           two: Promise<{ foo: number }>,
         }>()
 

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -1,4 +1,4 @@
-import { reactive } from 'vue'
+import { effectScope, reactive, watch, WatchHandle } from 'vue'
 import { isWithComponentProps, isWithComponentPropsRecord, PropsGetter } from '@/types/createRouteOptions'
 import type { PrefetchConfigs, PrefetchStrategy } from '@/types/prefetch'
 import { getPrefetchOption } from '@/utilities/prefetch'
@@ -6,7 +6,6 @@ import { ResolvedRoute } from '@/types/resolved'
 import { RouteViews } from '@/types/routeViews'
 import { ContextPushError } from '@/errors/contextPushError'
 import { ContextRejectionError } from '@/errors/contextRejectionError'
-import { isPromise } from '@/utilities/promises'
 import { getPropsValue, PropsResult } from '@/utilities/props'
 import { PropsCallbackParent } from '@/types/props'
 import { MaybePromise } from '@/types/utilities'
@@ -21,7 +20,7 @@ type SetPropsResponse = CallbackContextSuccess | CallbackContextPush | CallbackC
 type StoredProps = MaybePromise<PropsResult>
 
 export type PropStore = HasVueAppStore & {
-  getPrefetchProps: (strategy: PrefetchStrategy, route: ResolvedRoute, configs: PrefetchConfigs) => Record<string, StoredProps>,
+  getPrefetchProps: (strategy: PrefetchStrategy, route: ResolvedRoute, configs: PrefetchConfigs, prefetched?: Record<string, StoredProps>) => Record<string, StoredProps>,
   setPrefetchProps: (props: Record<string, StoredProps>) => void,
   setProps: (route: ResolvedRoute) => Promise<SetPropsResponse>,
   getProps: (id: string, name: string, route: ResolvedRoute) => StoredProps,
@@ -35,8 +34,17 @@ const NO_PROPS: PropsResult = { kind: 'value', value: undefined }
 export function createPropStore(): PropStore {
   const { setVueApp, runWithContext } = createVueAppStore()
   const store: Map<string, StoredProps> = reactive(new Map())
+  const waiters = new Map<string, Set<WatchHandle>>()
 
-  const getPrefetchProps: PropStore['getPrefetchProps'] = (strategy, route, prefetch) => {
+  /**
+   * Detached because waiters outlive the component whose prefetch created them.
+   */
+  const waiterScope = effectScope(true)
+
+  /**
+   * Seeded with props already prefetched at earlier strategies, which are not in the store until commit.
+   */
+  const getPrefetchProps: PropStore['getPrefetchProps'] = (strategy, route, prefetch, prefetched = {}) => {
     const { push, replace, reject, update } = createRouterCallbackContext({ to: route })
 
     return route.matches
@@ -59,13 +67,13 @@ export function createPropStore(): PropStore {
           replace,
           reject,
           update,
-          parent: getParentContext(route, depth, true),
+          parent: getParentContext(route, depth, true, response),
         })))
 
         response[key] = value
 
         return response
-      }, {})
+      }, { ...prefetched })
   }
 
   const setPrefetchProps: PropStore['setPrefetchProps'] = (props) => {
@@ -139,7 +147,7 @@ export function createPropStore(): PropStore {
    * The parent context for the view at the given depth. Must be resolved per depth rather than from the
    * end of the tuples: every view in a nested route gets its own parent, not the resolved route's parent.
    */
-  function getParentContext(route: ResolvedRoute, depth: number, prefetch: boolean = false): PropsCallbackParent {
+  function getParentContext(route: ResolvedRoute, depth: number, prefetch: boolean = false, pending?: Record<string, StoredProps>): PropsCallbackParent {
     if (depth === 0) {
       return
     }
@@ -153,7 +161,7 @@ export function createPropStore(): PropStore {
       return {
         name,
         get props() {
-          return getParentProps(parentViews.id, 'default', route, prefetch)
+          return getParentProps(parentViews.id, 'default', route, prefetch, pending)
         },
       }
     }
@@ -163,11 +171,12 @@ export function createPropStore(): PropStore {
         name,
         props: new Proxy({}, {
           get(target, propName) {
-            if (typeof propName !== 'string') {
+            // a name with no getter can never be stored, so waiting on it would never settle
+            if (typeof propName !== 'string' || !Object.prototype.hasOwnProperty.call(parentViews.props, propName)) {
               return Reflect.get(target, propName)
             }
 
-            return getParentProps(parentViews.id, propName, route, prefetch)
+            return getParentProps(parentViews.id, propName, route, prefetch, pending)
           },
         }),
       }
@@ -179,41 +188,100 @@ export function createPropStore(): PropStore {
     }
   }
 
-  function getParentProps(id: string, name: string, route: ResolvedRoute, prefetch: boolean = false): unknown {
+  /**
+   * Reads a parent view's props, checking the batch being prefetched before the store, and waiting for the
+   * parent's own lifecycle to compute them when neither has them yet.
+   */
+  function getParentProps(id: string, name: string, route: ResolvedRoute, prefetch: boolean = false, pending?: Record<string, StoredProps>): Promise<unknown> {
     const key = getPropKey(id, name, route)
-    const stored = store.get(key)
+    const batched = pending?.[key]
 
-    if (prefetch && stored === undefined) {
-      const routeName = route.name || 'unknown'
-
-      console.warn(`
-        Unable to access parent props "${name}" while prefetching props for route "${routeName}".
-        This may occur if the parent route's props were not also prefetched.
-      `)
+    if (batched !== undefined) {
+      return toParentProps(batched)
     }
 
-    return unwrapPropsError(stored ?? NO_PROPS)
+    const stored = store.get(key)
+
+    if (stored !== undefined) {
+      return toParentProps(stored)
+    }
+
+    if (prefetch) {
+      warnWaitingForParentProps(name, route)
+    }
+
+    return toParentProps(waitForProps(key))
   }
 
   /**
-   * Rethrows a failed getter's error, which is otherwise recorded rather than thrown.
+   * Resolves once the given props are stored. Never resolves if navigation discards the waiter first.
    */
-  function unwrapPropsError(result: StoredProps): unknown {
-    if (isPromise(result)) {
-      return result.then((resolved) => {
-        if (resolved.kind === 'error') {
-          throw resolved.error
-        }
+  function waitForProps(key: string): Promise<PropsResult> {
+    return new Promise((resolve) => {
+      const stops = waiters.get(key) ?? new Set<WatchHandle>()
 
-        return resolved.value
+      waiters.set(key, stops)
+
+      waiterScope.run(() => {
+        const stop = watch(() => store.get(key), (result) => {
+          if (result === undefined) {
+            return
+          }
+
+          discardWaiter(key, stop)
+          resolve(result)
+        })
+
+        stops.add(stop)
       })
+    })
+  }
+
+  function discardWaiter(key: string, stop: WatchHandle): void {
+    stop()
+
+    const stops = waiters.get(key)
+
+    stops?.delete(stop)
+
+    if (stops?.size === 0) {
+      waiters.delete(key)
+    }
+  }
+
+  function discardUnusedWaiters(keysToKeep: string[]): void {
+    for (const [key, stops] of waiters) {
+      if (keysToKeep.includes(key)) {
+        continue
+      }
+
+      stops.forEach((stop) => stop())
+      waiters.delete(key)
+    }
+  }
+
+  function warnWaitingForParentProps(name: string, route: ResolvedRoute): void {
+    const routeName = route.name || 'unknown'
+
+    console.warn(`
+      Waiting on parent props "${name}" while prefetching props for route "${routeName}".
+      The parent's props are not being prefetched at this point, so these props cannot resolve until the
+      parent's props are computed — either by the parent's own prefetch strategy or by navigating.
+      Prefetch the parent's props with the same strategy to avoid stalling here.
+    `)
+  }
+
+  /**
+   * Always a promise, since the props may not have been computed yet. Rethrows a failed getter's error.
+   */
+  async function toParentProps(result: MaybePromise<PropsResult>): Promise<unknown> {
+    const resolved = await result
+
+    if (resolved.kind === 'error') {
+      throw resolved.error
     }
 
-    if (result.kind === 'error') {
-      throw result.error
-    }
-
-    return result.value
+    return resolved.value
   }
 
   function getPropKey(id: string, name: string, route: ResolvedRoute): string {
@@ -247,6 +315,8 @@ export function createPropStore(): PropStore {
 
       store.delete(key)
     }
+
+    discardUnusedWaiters(keysToKeep)
   }
 
   return {

--- a/src/services/createRoute.spec-d.ts
+++ b/src/services/createRoute.spec-d.ts
@@ -405,7 +405,7 @@ describe('props', () => {
       name: 'child',
       parent: parent,
     }, (__, { parent }) => {
-      expectTypeOf(parent.props).toEqualTypeOf<{ foo: number }>()
+      expectTypeOf(parent.props).toEqualTypeOf<Promise<{ foo: number }>>()
       expectTypeOf(parent.name).toEqualTypeOf<'parent'>()
 
       return {}
@@ -445,7 +445,7 @@ describe('props', () => {
       parent: parent,
     }, (__, { parent }) => {
       expectTypeOf(parent.props).toEqualTypeOf<{
-        one: { foo: number },
+        one: Promise<{ foo: number }>,
         two: Promise<{ foo: number }>,
       }>()
       expectTypeOf(parent.name).toEqualTypeOf<'parent'>()

--- a/src/services/createRoute.spec.ts
+++ b/src/services/createRoute.spec.ts
@@ -232,8 +232,8 @@ describe('props', () => {
       name: 'parent',
       parent: grandparent,
       path: '/parent',
-    }, (__, { parent }) => {
-      seen.push({ self: 'parent', parentName: parent.name, parentProps: parent.props })
+    }, async (__, { parent }) => {
+      seen.push({ self: 'parent', parentName: parent.name, parentProps: await parent.props })
 
       return { level: 'parent' }
     })
@@ -242,8 +242,10 @@ describe('props', () => {
       name: 'child',
       parent,
       path: '/child',
-    }, (__, { parent }) => {
-      seen.push({ self: 'child', parentName: parent.name, parentProps: parent.props })
+    }, async (__, { parent }) => {
+      // the parent's type collapses to undefined when its getter consumes the callback context
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      seen.push({ self: 'child', parentName: parent.name, parentProps: await parent.props })
 
       return { level: 'child' }
     })
@@ -253,6 +255,7 @@ describe('props', () => {
     })
 
     await router.start()
+    await flushPromises()
 
     expect(seen).toStrictEqual([
       { self: 'parent', parentName: 'grandparent', parentProps: { level: 'grandparent' } },
@@ -271,8 +274,10 @@ describe('props', () => {
       name: 'child',
       parent: parent,
       path: '/child',
-    }, (__, { parent }) => {
-      return spy({ value: parent.props.foo })
+    }, async (__, { parent }) => {
+      const { foo: value } = await parent.props
+
+      return spy({ value })
     })
 
     const router = createRouter([parent, child], {
@@ -280,6 +285,7 @@ describe('props', () => {
     })
 
     await router.start()
+    await flushPromises()
 
     expect(spy).toHaveBeenCalledWith({ value: 123 })
   })
@@ -331,9 +337,9 @@ describe('props', () => {
       name: 'child',
       parent: parent,
       path: '/child',
-    }, (__, { parent }) => {
+    }, async (__, { parent }) => {
       try {
-        const value = parent.props
+        const value = await parent.props
 
         caught({ didNotThrow: value })
       } catch (thrown) {
@@ -400,11 +406,11 @@ describe('props', () => {
       name: 'child',
       parent: parent,
       path: '/child',
-    }, (__, { parent }) => {
-      return spy({
-        value1: parent.props.one.foo,
-        value2: parent.props.two.bar,
-      })
+    }, async (__, { parent }) => {
+      const { foo: value1 } = await parent.props.one
+      const { bar: value2 } = await parent.props.two
+
+      return spy({ value1, value2 })
     })
 
     const router = createRouter([parent, child], {
@@ -414,6 +420,40 @@ describe('props', () => {
     await router.start()
 
     expect(spy).toHaveBeenCalledWith({ value1: 123, value2: 456 })
+  })
+
+  test('parent props for view names without a getter are undefined rather than never settling', async () => {
+    const spy = vi.fn()
+
+    const parent = createRoute({
+      name: 'parent',
+      components: {
+        one: component,
+        two: component,
+        three: component,
+      },
+    }, {
+      one: () => ({ foo: 123 }),
+      two: () => ({ bar: 456 }),
+    })
+
+    const child = createRoute({
+      name: 'child',
+      parent: parent,
+      path: '/child',
+    }, (__, { parent }) => {
+      const props = parent.props as Record<string, unknown>
+
+      return spy({ three: props.three, missing: props.missing })
+    })
+
+    const router = createRouter([parent, child], {
+      initialUrl: '/child',
+    })
+
+    await router.start()
+
+    expect(spy).toHaveBeenCalledWith({ three: undefined, missing: undefined })
   })
 
   test('async parent props with multiple views are passed to child props', async () => {

--- a/src/types/addView.ts
+++ b/src/types/addView.ts
@@ -58,10 +58,13 @@ type ParentMatchName<
   ? TParent['name']
   : string
 
+/**
+ * Always a promise, since the parent's props may not have been computed when the child's getter runs.
+ */
 type MatchPropsReturnType<TProps> = TProps extends PropsGetter
-  ? ReturnType<TProps>
+  ? Promise<Awaited<ReturnType<TProps>>>
   : TProps extends Record<string, PropsGetter>
-    ? { [K in keyof TProps]: ReturnType<TProps[K]> }
+    ? { [K in keyof TProps]: Promise<Awaited<ReturnType<TProps[K]>>> }
     : undefined
 
 /**

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -36,9 +36,9 @@ type GetParentPropsReturnType<
 > = TParent extends Route
   ? LastInArray<TParent['views']> extends RouteViews<infer TProps>
     ? TProps extends PropsGetter
-      ? ReturnType<TProps>
+      ? Promise<Awaited<ReturnType<TProps>>>
       : TProps extends Record<string, PropsGetter>
-        ? { [K in keyof TProps]: ReturnType<TProps[K]> }
+        ? { [K in keyof TProps]: Promise<Awaited<ReturnType<TProps[K]>>> }
         : undefined
     : undefined
   : undefined


### PR DESCRIPTION
# Description

Stacked on #802.

A child awaiting its parent's props received `undefined` whenever those props hadn't been computed yet — either because they aren't prefetched, or because they're prefetched at a different strategy than the child's. The types promise the parent's props, so destructuring silently produced undefined fields.

```ts
const parent = createRoute({
  name: 'parent',
  path: '/parent',
}).addView(ParentLayout, {
  props: async () => ({ foo: 123 }),
  prefetch: { props: 'intent' },
})

const child = createRoute({
  name: 'child',
  parent,
  path: '/child',
}).addView(ChildPage, {
  props: async (route, { parent }) => {
    const value = await parent.props
    // before: undefined, because the parent prefetches at a different strategy
    // after:  waits, then { foo: 123 }

    return { value }
  },
  prefetch: { props: 'eager' },
})
```

The child now waits for the parent's props to be computed by the parent's own lifecycle. Nothing runs earlier than configured — running the parent's getter early would override a parent explicitly told not to prefetch — and navigation writes every view's props before it awaits anything, so a waiting child always resolves by then.

Props already prefetched at an earlier strategy are read from that batch rather than waited for, so a child prefetching later than its parent no longer stalls until navigation. A view name with no getter reads as `undefined` instead of waiting for props that can never arrive.

## Breaking change

`parent.props` is always a promise now and must be awaited. The type used to mirror the parent's getter, so a synchronous getter typed it as a plain value, which can't be true once the props might still be pending.

```ts
// before
const { foo } = parent.props

// after
const { foo } = await parent.props
```
