### PR TITLE
Fix a parent's props type being lost in either syntax when its getter declares arguments

### DIFF
--- a/src/services/addView.spec-d.ts
+++ b/src/services/addView.spec-d.ts
@@ -257,6 +257,45 @@ describe('addView', () => {
         return {}
       })
     })
+
+    test('bare parent props are passed to a child when the parent getter declares its arguments', () => {
+      const parent = createRoute({ name: 'parent', path: '/parent/[id]' })
+        .addView(component, {
+          props: (route, { push }) => ({ foo: route.params.id, canPush: typeof push === 'function' }),
+        })
+
+      createRoute({ name: 'child', parent }).addView(component, {
+        props: (__, { parent }) => {
+          expectTypeOf(parent.props).toEqualTypeOf<Promise<{ foo: string, canPush: boolean }>>()
+          expectTypeOf(parent.name).toEqualTypeOf<'parent'>()
+
+          return {}
+        },
+      })
+    })
+
+    test('record parent props are passed to a child when the parent getters declare their arguments', () => {
+      const parent = createRoute({ name: 'parent', path: '/parent/[id]' })
+        .addView(component, {
+          name: 'one',
+          props: (route) => ({ foo: route.params.id }),
+        })
+        .addView(component, {
+          name: 'two',
+          props: async (__, { push }) => ({ canPush: typeof push === 'function' }),
+        })
+
+      createRoute({ name: 'child', parent }).addView(component, {
+        props: (__, { parent }) => {
+          expectTypeOf(parent.props).toEqualTypeOf<{
+            one: Promise<{ foo: string }>,
+            two: Promise<{ canPush: boolean }>,
+          }>()
+
+          return {}
+        },
+      })
+    })
   })
 
   describe('props getter context', () => {

--- a/src/services/createRoute.spec-d.ts
+++ b/src/services/createRoute.spec-d.ts
@@ -412,6 +412,22 @@ describe('props', () => {
     })
   })
 
+  test('parent props are passed to child props when the parent getter declares its arguments', () => {
+    const parent = createRoute({
+      name: 'parent',
+      path: '/parent/[id]',
+    }, (route, { push }) => ({ foo: route.params.id, canPush: typeof push === 'function' }))
+
+    createRoute({
+      name: 'child',
+      parent: parent,
+    }, (__, { parent }) => {
+      expectTypeOf(parent.props).toEqualTypeOf<Promise<{ foo: string, canPush: boolean }>>()
+
+      return {}
+    })
+  })
+
   test('async parent props are passed to child props', () => {
     const parent = createRoute({
       name: 'parent',

--- a/src/services/createRoute.spec.ts
+++ b/src/services/createRoute.spec.ts
@@ -243,8 +243,6 @@ describe('props', () => {
       parent,
       path: '/child',
     }, async (__, { parent }) => {
-      // the parent's type collapses to undefined when its getter consumes the callback context
-      // eslint-disable-next-line @typescript-eslint/await-thenable
       seen.push({ self: 'child', parentName: parent.name, parentProps: await parent.props })
 
       return { level: 'child' }

--- a/src/types/addView.ts
+++ b/src/types/addView.ts
@@ -14,7 +14,7 @@ import { RouteUpdate } from '@/types/routeUpdate'
 import { PrefetchConfig } from '@/types/prefetch'
 import { RouteViews } from '@/types/routeViews'
 import { Url } from '@/types/url'
-import { Identity, LastInArray, MaybePromise } from '@/types/utilities'
+import { AnyFunction, Identity, LastInArray, MaybePromise } from '@/types/utilities'
 
 /**
  * The props getter for a view added via `addView`. Receives the same two arguments as the
@@ -61,9 +61,9 @@ type ParentMatchName<
 /**
  * Always a promise, since the parent's props may not have been computed when the child's getter runs.
  */
-type MatchPropsReturnType<TProps> = TProps extends PropsGetter
+type MatchPropsReturnType<TProps> = TProps extends AnyFunction
   ? Promise<Awaited<ReturnType<TProps>>>
-  : TProps extends Record<string, PropsGetter>
+  : TProps extends Record<string, AnyFunction>
     ? { [K in keyof TProps]: Promise<Awaited<ReturnType<TProps[K]>>> }
     : undefined
 
@@ -152,12 +152,12 @@ export type AddViewProps<
   : TName extends undefined
     ? TCurrent extends undefined
       ? TNewGetter
-      : TCurrent extends (...args: any[]) => any
+      : TCurrent extends AnyFunction
         ? TNewGetter
         : Identity<TCurrent & { default: TNewGetter }>
     : TCurrent extends undefined
       ? Identity<Record<TName & string, TNewGetter>>
-      : TCurrent extends (...args: any[]) => any
+      : TCurrent extends AnyFunction
         ? Identity<{ default: TCurrent } & Record<TName & string, TNewGetter>>
         : Identity<TCurrent & Record<TName & string, TNewGetter>>
 

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -1,4 +1,4 @@
-import { CreateRouteOptions, PropsGetter } from '@/types/createRouteOptions'
+import { CreateRouteOptions } from '@/types/createRouteOptions'
 import { Route } from '@/types/route'
 import { RouterReject } from './routerReject'
 import { RouterPush } from './routerPush'
@@ -7,7 +7,7 @@ import { ExtractRouteContextRejections, ExtractRouteContextRoutes } from './rout
 import { ResolvedRoute } from './resolved'
 import { RouteUpdate } from './routeUpdate'
 import { RouteViews } from '@/types/routeViews'
-import { LastInArray } from '@/types/utilities'
+import { AnyFunction, LastInArray } from '@/types/utilities'
 
 /**
  * Context provided to props callback functions
@@ -35,9 +35,9 @@ type GetParentPropsReturnType<
   TParent extends Route | undefined = Route | undefined
 > = TParent extends Route
   ? LastInArray<TParent['views']> extends RouteViews<infer TProps>
-    ? TProps extends PropsGetter
+    ? TProps extends AnyFunction
       ? Promise<Awaited<ReturnType<TProps>>>
-      : TProps extends Record<string, PropsGetter>
+      : TProps extends Record<string, AnyFunction>
         ? { [K in keyof TProps]: Promise<Awaited<ReturnType<TProps[K]>>> }
         : undefined
     : undefined

--- a/src/types/utilities.ts
+++ b/src/types/utilities.ts
@@ -12,6 +12,8 @@ export type LastInArray<T, TFallback = never> = T extends [...any[], infer Last]
 
 export type MaybePromise<T> = T | Promise<T>
 
+export type AnyFunction = (...args: any[]) => any
+
 type OnlyRequiredProperties<T> = {
   [K in keyof T as Extract<T[K], undefined> extends never ? K : never]: T[K]
 }


### PR DESCRIPTION
# Description

Bug 4 of 4. Stacked on #795.

A child's `parent.props` typed as `undefined` whenever the parent's props getter declared any argument — which is most of them. The route itself kept its props type; only the child's view of it was lost. Both ways of writing a getter are affected, `addView` and the `createRoute` props argument.

```ts
const parent = createRoute({
  name: 'parent',
  path: '/parent/[id]',
}).addView(ParentLayout, {
  props: (route) => ({ id: route.params.id }),
})

const child = createRoute({
  name: 'child',
  parent,
  path: '/child',
}).addView(ChildPage, {
  props: async (route, { parent }) => {
    const { id } = await parent.props
    // before: parent.props is typed undefined, so this does not compile
    // after:  Promise<{ id: string }>

    return { id }
  },
})
```

The same happens when the parent declares its getter through the props argument:

```ts
const parent = createRoute({
  name: 'parent',
  path: '/parent/[id]',
}, (route) => ({ id: route.params.id }))
```

Both types that reconstruct a parent's props for a child asked whether the getter `extends PropsGetter`. That signature's `route` argument is the wide `ResolvedRoute<Route>`, and a getter written `(route) => ...` has its argument narrowed to one specific route. Parameters are contravariant, so the check fails and falls through to `undefined`. Getters taking no arguments passed only because a zero argument function is assignable to any signature — which is why this went unnoticed, since the tests used `() => ({ foo: 123 })`.

These checks meant "is this a function", so they now ask that. `AddViewProps` already did it this way, so the same `AnyFunction` is shared between them.

Also removes the `eslint-disable` that #795 needed for exactly this reason.
