### PR TITLE
Fix parent props waiter edge cases found in review

### DIFF
--- a/docs/core-concepts/component-props.md
+++ b/docs/core-concepts/component-props.md
@@ -56,6 +56,8 @@ const user = createRoute({
 
 The [callback context](/core-concepts/component-props#context) includes a `parent` property which contains the name and props of the parent route. This can be useful for passing down data to child components.
 
+`parent.props` is always a promise and must be awaited, even when the parent's getter is synchronous. The parent's props may not have been computed when your getter runs — if the parent's props are prefetched at a different strategy than yours, or not prefetched at all, awaiting them waits until they are.
+
 ```ts
 const blogPost = createRoute({
   name: 'blog',

--- a/src/components/routerLink.browser.spec.ts
+++ b/src/components/routerLink.browser.spec.ts
@@ -886,6 +886,223 @@ describe('prefetch props', () => {
     expect(wrapper.text()).toBe(value)
   })
 
+  test('a child waits for parent props that are not prefetched rather than receiving undefined', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const settled: unknown[] = []
+
+    const home = createRoute({
+      name: 'home',
+      path: '/',
+      component: () => h(RouterLink, { to: (resolve) => resolve('child') }),
+    })
+
+    const parent = createRoute({
+      name: 'parent',
+      path: '/parent',
+      component: { props: ['foo'], template: '<div><RouterView /></div>' },
+      prefetch: { props: false },
+    }, async () => ({ foo: 123 }))
+
+    const child = createRoute({
+      parent,
+      name: 'child',
+      path: '/child',
+      component: echo,
+      prefetch: { props: 'eager' },
+    }, async (__, { parent }) => {
+      settled.push(await parent.props)
+
+      return { value: 'child' }
+    })
+
+    const router = createRouter([home, child], {
+      initialUrl: '/',
+    })
+
+    await router.start()
+
+    const wrapper = mount({ template: '<RouterView />' }, {
+      global: {
+        plugins: [router],
+      },
+    })
+
+    await flushPromises()
+
+    expect(settled).toStrictEqual([])
+    expect(warn.mock.calls.some(([message]) => String(message).includes('Waiting on parent props'))).toBe(true)
+
+    wrapper.find('a').trigger('click')
+
+    await flushPromises()
+
+    expect(settled).toStrictEqual([{ foo: 123 }])
+
+    warn.mockRestore()
+  })
+
+  test('a child waits for parent props prefetched at a later strategy', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const settled: unknown[] = []
+
+    const home = createRoute({
+      name: 'home',
+      path: '/',
+      component: () => h(RouterLink, { to: (resolve) => resolve('child') }),
+    })
+
+    const parent = createRoute({
+      name: 'parent',
+      path: '/parent',
+      component: { props: ['foo'], template: '<div><RouterView /></div>' },
+      prefetch: { props: 'intent' },
+    }, async () => ({ foo: 123 }))
+
+    const child = createRoute({
+      parent,
+      name: 'child',
+      path: '/child',
+      component: echo,
+      prefetch: { props: 'eager' },
+    }, async (__, { parent }) => {
+      settled.push(await parent.props)
+
+      return { value: 'child' }
+    })
+
+    const router = createRouter([home, child], {
+      initialUrl: '/',
+    })
+
+    await router.start()
+
+    const wrapper = mount({ template: '<RouterView />' }, {
+      global: {
+        plugins: [router],
+      },
+    })
+
+    await flushPromises()
+
+    expect(settled).toStrictEqual([])
+
+    wrapper.find('a').trigger('click')
+
+    await flushPromises()
+
+    expect(settled).toStrictEqual([{ foo: 123 }])
+
+    warn.mockRestore()
+  })
+
+  test('a child does not wait when the parent props are prefetched at the same strategy', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const settled: unknown[] = []
+
+    const home = createRoute({
+      name: 'home',
+      path: '/',
+      component: () => h(RouterLink, { to: (resolve) => resolve('child') }),
+    })
+
+    const parent = createRoute({
+      name: 'parent',
+      path: '/parent',
+      component: { props: ['foo'], template: '<div><RouterView /></div>' },
+      prefetch: { props: 'eager' },
+    }, async () => ({ foo: 123 }))
+
+    const child = createRoute({
+      parent,
+      name: 'child',
+      path: '/child',
+      component: echo,
+      prefetch: { props: 'eager' },
+    }, async (__, { parent }) => {
+      settled.push(await parent.props)
+
+      return { value: 'child' }
+    })
+
+    const router = createRouter([home, child], {
+      initialUrl: '/',
+    })
+
+    await router.start()
+
+    mount({ template: '<RouterView />' }, {
+      global: {
+        plugins: [router],
+      },
+    })
+
+    await flushPromises()
+
+    expect(settled).toStrictEqual([{ foo: 123 }])
+    expect(warn.mock.calls.some(([message]) => String(message).includes('Waiting on parent props'))).toBe(false)
+
+    warn.mockRestore()
+  })
+
+  test('prefetched parent props are available to a child prefetching its own props', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    let childSawParentProps: unknown = 'NOT_READ'
+
+    const home = createRoute({
+      name: 'home',
+      path: '/',
+      component: () => h(RouterLink, { to: (resolve) => resolve('child') }),
+    })
+
+    const parent = createRoute({
+      name: 'parent',
+      path: '/parent',
+      component: { template: '<RouterView />' },
+      prefetch: { props: 'eager' },
+    }, async () => ({ foo: 123 }))
+
+    const child = createRoute({
+      parent,
+      name: 'child',
+      path: '/child',
+      component: echo,
+      prefetch: { props: 'eager' },
+    }, async (__, { parent }) => {
+      childSawParentProps = await parent.props
+
+      return { value: 'child' }
+    })
+
+    const router = createRouter([home, child], {
+      initialUrl: '/',
+    })
+
+    await router.start()
+
+    const wrapper = mount({ template: '<RouterView />' }, {
+      global: {
+        plugins: [router],
+      },
+    })
+
+    await flushPromises()
+
+    expect(childSawParentProps).toStrictEqual({ foo: 123 })
+    expect(warn).not.toHaveBeenCalled()
+
+    wrapper.find('a').trigger('click')
+
+    await flushPromises()
+
+    expect(wrapper.text()).toBe('child')
+
+    warn.mockRestore()
+  })
+
   test('parent routes that should not prefetch props are not prefetched', async () => {
     const parentProps = vi.fn()
     const childProps = vi.fn()

--- a/src/components/routerLink.browser.spec.ts
+++ b/src/components/routerLink.browser.spec.ts
@@ -2,6 +2,7 @@ import { flushPromises, mount } from '@vue/test-utils'
 import { describe, expect, test, vi } from 'vitest'
 import { defineAsyncComponent, h, nextTick, ref } from 'vue'
 import echo from '@/components/echo'
+import { ParentPropsAbandonedError } from '@/errors/parentPropsAbandonedError'
 import { createRoute } from '@/services/createRoute'
 import { createRouter } from '@/services/createRouter'
 import { PrefetchConfig } from '@/types/prefetch'
@@ -1099,6 +1100,188 @@ describe('prefetch props', () => {
     await flushPromises()
 
     expect(wrapper.text()).toBe('child')
+
+    warn.mockRestore()
+  })
+
+  test('a child prefetching by intent resolves parent props already prefetched eagerly', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const settled: unknown[] = []
+
+    const home = createRoute({
+      name: 'home',
+      path: '/',
+      component: () => h(RouterLink, { to: (resolve) => resolve('child') }),
+    })
+
+    const parent = createRoute({
+      name: 'parent',
+      path: '/parent',
+      component: { props: ['foo'], template: '<div><RouterView /></div>' },
+      prefetch: { props: 'eager' },
+    }, async () => ({ foo: 123 }))
+
+    const child = createRoute({
+      parent,
+      name: 'child',
+      path: '/child',
+      component: echo,
+      prefetch: { props: 'intent' },
+    }, async (__, { parent }) => {
+      settled.push(await parent.props)
+
+      return { value: 'child' }
+    })
+
+    const router = createRouter([home, child], {
+      initialUrl: '/',
+    })
+
+    await router.start()
+
+    const wrapper = mount({ template: '<RouterView />' }, {
+      global: {
+        plugins: [router],
+      },
+    })
+
+    // mounting the link runs the eager prefetch, which computes the parent's props
+    await flushPromises()
+
+    wrapper.find('a').trigger('focusin')
+
+    await flushPromises()
+
+    // no navigation has happened — the intent prefetch should resolve the parent's
+    // props from the eager batch instead of stalling until the store is committed
+    expect(settled).toStrictEqual([{ foo: 123 }])
+    expect(warn.mock.calls.some(([message]) => String(message).includes('Waiting on parent props'))).toBe(false)
+
+    warn.mockRestore()
+  })
+
+  test('a child waiting on parent props that compute to undefined still resolves', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const settled: unknown[] = []
+
+    const home = createRoute({
+      name: 'home',
+      path: '/',
+      component: () => h(RouterLink, { to: (resolve) => resolve('child') }),
+    })
+
+    const parent = createRoute({
+      name: 'parent',
+      path: '/parent',
+      component: { template: '<RouterView />' },
+      prefetch: { props: false },
+    }, () => undefined as any)
+
+    const child = createRoute({
+      parent,
+      name: 'child',
+      path: '/child',
+      component: echo,
+      prefetch: { props: 'eager' },
+    }, async (__, { parent }) => {
+      settled.push(await parent.props)
+
+      return { value: 'child' }
+    })
+
+    const router = createRouter([home, child], {
+      initialUrl: '/',
+    })
+
+    await router.start()
+
+    const wrapper = mount({ template: '<RouterView />' }, {
+      global: {
+        plugins: [router],
+      },
+    })
+
+    await flushPromises()
+
+    expect(settled).toStrictEqual([])
+
+    wrapper.find('a').trigger('click')
+
+    await flushPromises()
+
+    // the parent's props computed to undefined — the child must still resolve
+    // and navigation must complete rather than waiting forever
+    expect(settled).toStrictEqual([undefined])
+    expect(wrapper.text()).toBe('child')
+
+    warn.mockRestore()
+  })
+
+  test('a child waiting on parent props is rejected when navigation abandons them', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const caught: unknown[] = []
+
+    const home = createRoute({
+      name: 'home',
+      path: '/',
+      component: () => h(RouterLink, { to: (resolve) => resolve('child') }),
+    })
+
+    const other = createRoute({
+      name: 'other',
+      path: '/other',
+      component: echo,
+    }, () => ({ value: 'other' }))
+
+    const parent = createRoute({
+      name: 'parent',
+      path: '/parent',
+      component: { props: ['foo'], template: '<div><RouterView /></div>' },
+      prefetch: { props: false },
+    }, async () => ({ foo: 123 }))
+
+    const child = createRoute({
+      parent,
+      name: 'child',
+      path: '/child',
+      component: echo,
+      prefetch: { props: 'eager' },
+    }, async (__, { parent }) => {
+      try {
+        await parent.props
+      } catch (error) {
+        caught.push(error)
+      }
+
+      return { value: 'child' }
+    })
+
+    const router = createRouter([home, child, other], {
+      initialUrl: '/',
+    })
+
+    await router.start()
+
+    mount({ template: '<RouterView />' }, {
+      global: {
+        plugins: [router],
+      },
+    })
+
+    // the eager prefetch leaves the child's getter waiting on the parent's props
+    await flushPromises()
+
+    expect(caught).toStrictEqual([])
+
+    // navigating somewhere other than the child discards the waiter
+    await router.push('other')
+    await flushPromises()
+
+    expect(caught).toHaveLength(1)
+    expect(caught[0]).toBeInstanceOf(ParentPropsAbandonedError)
 
     warn.mockRestore()
   })

--- a/src/compositions/usePrefetching.ts
+++ b/src/compositions/usePrefetching.ts
@@ -30,13 +30,15 @@ export function createUsePrefetching<TRouter extends Router>(routerKey: Injectio
     const { isElementVisible } = useVisibilityObserver(element)
 
     const commit: UsePrefetching['commit'] = () => {
-      const props = Array.from(prefetchedProps.values()).reduce((accumulator, value) => {
+      setPrefetchProps(getAccumulatedProps())
+    }
+
+    function getAccumulatedProps(): Record<string, unknown> {
+      return Array.from(prefetchedProps.values()).reduce((accumulator, value) => {
         Object.assign(accumulator, value)
 
         return accumulator
       }, {})
-
-      setPrefetchProps(props)
     }
 
     watch(() => toValue(config), ({ route, ...configs }) => {
@@ -76,7 +78,7 @@ export function createUsePrefetching<TRouter extends Router>(routerKey: Injectio
       prefetchComponentsForRoute(strategy, route, configs)
 
       if (!prefetchedProps.has(strategy)) {
-        prefetchedProps.set(strategy, getPrefetchProps(strategy, route, configs))
+        prefetchedProps.set(strategy, getPrefetchProps(strategy, route, configs, getAccumulatedProps()))
       }
     }
 

--- a/src/errors/parentPropsAbandonedError.ts
+++ b/src/errors/parentPropsAbandonedError.ts
@@ -1,0 +1,5 @@
+export class ParentPropsAbandonedError extends Error {
+  public constructor() {
+    super('Parent props were discarded before they were computed because navigation moved elsewhere.')
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -74,6 +74,7 @@ export * from './types/useLink'
 // Errors
 export { DuplicateParamsError } from './errors/duplicateParamsError'
 export { MetaPropertyConflict } from './errors/metaPropertyConflict'
+export { ParentPropsAbandonedError } from './errors/parentPropsAbandonedError'
 export { RouterNotInstalledError } from './errors/routerNotInstalledError'
 export { UseRouteInvalidError } from './errors/useRouteInvalidError'
 

--- a/src/services/addView.spec-d.ts
+++ b/src/services/addView.spec-d.ts
@@ -93,7 +93,7 @@ describe('addView', () => {
       const parent = createRoute({ name: 'parent' }).addView(component, () => ({ foo: 123 }))
 
       createRoute({ name: 'child', parent }, (__, { parent }) => {
-        expectTypeOf(parent.props).toEqualTypeOf<{ foo: number }>()
+        expectTypeOf(parent.props).toEqualTypeOf<Promise<{ foo: number }>>()
         expectTypeOf(parent.name).toEqualTypeOf<'parent'>()
 
         return {}
@@ -107,7 +107,7 @@ describe('addView', () => {
 
       createRoute({ name: 'child', parent }, (__, { parent }) => {
         expectTypeOf(parent.props).toEqualTypeOf<{
-          one: { foo: number },
+          one: Promise<{ foo: number }>,
           two: Promise<{ foo: number }>,
         }>()
 

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -1,4 +1,4 @@
-import { reactive } from 'vue'
+import { effectScope, reactive, watch, WatchHandle } from 'vue'
 import { isWithComponentProps, isWithComponentPropsRecord, PropsGetter } from '@/types/createRouteOptions'
 import type { PrefetchConfigs, PrefetchStrategy } from '@/types/prefetch'
 import { getPrefetchOption } from '@/utilities/prefetch'
@@ -6,7 +6,6 @@ import { ResolvedRoute } from '@/types/resolved'
 import { RouteViews } from '@/types/routeViews'
 import { ContextPushError } from '@/errors/contextPushError'
 import { ContextRejectionError } from '@/errors/contextRejectionError'
-import { isPromise } from '@/utilities/promises'
 import { getPropsValue } from '@/utilities/props'
 import { PropsCallbackParent } from '@/types/props'
 import { createVueAppStore, HasVueAppStore } from './createVueAppStore'
@@ -27,6 +26,14 @@ export type PropStore = HasVueAppStore & {
 export function createPropStore(): PropStore {
   const { setVueApp, runWithContext } = createVueAppStore()
   const store: Map<string, unknown> = reactive(new Map())
+  const waiters = new Map<string, Set<WatchHandle>>()
+
+  /**
+   * Waiters are created while a props getter runs, which can be inside the effect scope of whichever
+   * component triggered a prefetch. That component often unmounts as part of the navigation the waiter is
+   * waiting for, so they are owned by a detached scope instead of being disposed along with it.
+   */
+  const waiterScope = effectScope(true)
 
   const getPrefetchProps: PropStore['getPrefetchProps'] = (strategy, route, prefetch) => {
     const { push, replace, reject, update } = createRouterCallbackContext({ to: route })
@@ -46,7 +53,7 @@ export function createPropStore(): PropStore {
           replace,
           reject,
           update,
-          parent: getParentContext(route, depth, true),
+          parent: getParentContext(route, depth, true, response),
         })))
 
         response[key] = value
@@ -126,7 +133,7 @@ export function createPropStore(): PropStore {
    * The parent context for the view at the given depth. Must be resolved per depth rather than from the
    * end of the tuples: every view in a nested route gets its own parent, not the resolved route's parent.
    */
-  function getParentContext(route: ResolvedRoute, depth: number, prefetch: boolean = false): PropsCallbackParent {
+  function getParentContext(route: ResolvedRoute, depth: number, prefetch: boolean = false, pending?: Record<string, unknown>): PropsCallbackParent {
     if (depth === 0) {
       return
     }
@@ -140,7 +147,7 @@ export function createPropStore(): PropStore {
       return {
         name,
         get props() {
-          return getParentProps(parentViews.id, 'default', route, prefetch)
+          return getParentProps(parentViews.id, 'default', route, prefetch, pending)
         },
       }
     }
@@ -154,7 +161,7 @@ export function createPropStore(): PropStore {
               return Reflect.get(target, propName)
             }
 
-            return getParentProps(parentViews.id, propName, route, prefetch)
+            return getParentProps(parentViews.id, propName, route, prefetch, pending)
           },
         }),
       }
@@ -166,42 +173,108 @@ export function createPropStore(): PropStore {
     }
   }
 
-  function getParentProps(id: string, name: string, route: ResolvedRoute, prefetch: boolean = false): unknown {
-    const value = getProps(id, name, route)
+  /**
+   * Reads a parent view's props. While prefetching, values are only written to the store once navigation
+   * commits, so the batch being built is checked first — a parent's props are computed earlier in the same
+   * batch (matches are walked outermost first) and would otherwise be invisible to its children.
+   *
+   * When the parent's props have not been computed yet, the parent's own lifecycle is left to compute them
+   * and the returned promise resolves once it has, rather than handing back undefined as though the parent
+   * had no props.
+   */
+  function getParentProps(id: string, name: string, route: ResolvedRoute, prefetch: boolean = false, pending?: Record<string, unknown>): Promise<unknown> {
+    const key = getPropKey(id, name, route)
 
-    if (prefetch && !value) {
-      const routeName = route.name || 'unknown'
-
-      console.warn(`
-        Unable to access parent props "${name}" while prefetching props for route "${routeName}".
-        This may occur if the parent route's props were not also prefetched.
-      `)
+    if (pending && key in pending) {
+      return toParentProps(pending[key])
     }
 
-    return unwrapPropsError(value)
+    if (store.has(key)) {
+      return toParentProps(store.get(key))
+    }
+
+    if (prefetch) {
+      warnWaitingForParentProps(name, route)
+    }
+
+    return toParentProps(waitForProps(key))
   }
 
   /**
-   * A failed props getter is stored as its error rather than thrown, so that navigation can inspect the
-   * settled value. Consumers of a parent's props expect the props themselves, so the error is rethrown
-   * here instead of being handed back as though it were a valid value.
+   * Resolves once the given props have been computed and stored. Never resolves if navigation moves
+   * somewhere else first, at which point the waiter is discarded along with the props it was waiting for.
    */
-  function unwrapPropsError(value: unknown): unknown {
-    if (value instanceof Error) {
-      throw value
-    }
+  function waitForProps(key: string): Promise<unknown> {
+    return new Promise((resolve) => {
+      const stops = waiters.get(key) ?? new Set<WatchHandle>()
 
-    if (isPromise(value)) {
-      return value.then((resolved) => {
-        if (resolved instanceof Error) {
-          throw resolved
-        }
+      waiters.set(key, stops)
 
-        return resolved
+      waiterScope.run(() => {
+        const stop = watch(() => store.get(key), (value) => {
+          if (value === undefined) {
+            return
+          }
+
+          discardWaiter(key, stop)
+          resolve(value)
+        })
+
+        stops.add(stop)
       })
+    })
+  }
+
+  function discardWaiter(key: string, stop: WatchHandle): void {
+    stop()
+
+    const stops = waiters.get(key)
+
+    stops?.delete(stop)
+
+    if (stops?.size === 0) {
+      waiters.delete(key)
+    }
+  }
+
+  function discardUnusedWaiters(keysToKeep: string[]): void {
+    for (const [key, stops] of waiters) {
+      if (keysToKeep.includes(key)) {
+        continue
+      }
+
+      stops.forEach((stop) => stop())
+      waiters.delete(key)
+    }
+  }
+
+  function warnWaitingForParentProps(name: string, route: ResolvedRoute): void {
+    const routeName = route.name || 'unknown'
+
+    console.warn(`
+      Waiting on parent props "${name}" while prefetching props for route "${routeName}".
+      The parent's props are not being prefetched at this point, so these props cannot resolve until the
+      parent's props are computed — either by the parent's own prefetch strategy or by navigating.
+      Prefetch the parent's props with the same strategy to avoid stalling here.
+    `)
+  }
+
+  /**
+   * A parent's props are always handed to a child as a promise, whether or not they have been computed
+   * yet, so that the type does not have to claim a value is already available.
+   *
+   * A failed props getter is stored as its error rather than thrown, so that navigation can inspect the
+   * settled value. Consumers expect the props themselves, so the error is rethrown here rather than being
+   * handed back as though it were a valid value.
+   */
+  async function toParentProps(value: unknown): Promise<unknown> {
+    const resolved = await value
+
+    if (resolved instanceof Error) {
+      throw resolved
     }
 
-    return value
+    return resolved
   }
 
   function getPropKey(id: string, name: string, route: ResolvedRoute): string {
@@ -235,6 +308,8 @@ export function createPropStore(): PropStore {
 
       store.delete(key)
     }
+
+    discardUnusedWaiters(keysToKeep)
   }
 
   return {

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -6,6 +6,7 @@ import { ResolvedRoute } from '@/types/resolved'
 import { RouteViews } from '@/types/routeViews'
 import { ContextPushError } from '@/errors/contextPushError'
 import { ContextRejectionError } from '@/errors/contextRejectionError'
+import { ParentPropsAbandonedError } from '@/errors/parentPropsAbandonedError'
 import { getPropsValue } from '@/utilities/props'
 import { PropsCallbackParent } from '@/types/props'
 import { createVueAppStore, HasVueAppStore } from './createVueAppStore'
@@ -14,10 +15,12 @@ import { createRouterCallbackContext } from './createRouterCallbackContext'
 
 type ComponentProps = { id: string, name: string, depth: number, props?: PropsGetter }
 
+type Waiter = { stop: WatchHandle, abandon: () => void }
+
 type SetPropsResponse = CallbackContextSuccess | CallbackContextPush | CallbackContextReject
 
 export type PropStore = HasVueAppStore & {
-  getPrefetchProps: (strategy: PrefetchStrategy, route: ResolvedRoute, configs: PrefetchConfigs) => Record<string, unknown>,
+  getPrefetchProps: (strategy: PrefetchStrategy, route: ResolvedRoute, configs: PrefetchConfigs, prefetched?: Record<string, unknown>) => Record<string, unknown>,
   setPrefetchProps: (props: Record<string, unknown>) => void,
   setProps: (route: ResolvedRoute) => Promise<SetPropsResponse>,
   getProps: (id: string, name: string, route: ResolvedRoute) => unknown,
@@ -26,7 +29,7 @@ export type PropStore = HasVueAppStore & {
 export function createPropStore(): PropStore {
   const { setVueApp, runWithContext } = createVueAppStore()
   const store: Map<string, unknown> = reactive(new Map())
-  const waiters = new Map<string, Set<WatchHandle>>()
+  const waiters = new Map<string, Set<Waiter>>()
 
   /**
    * Waiters are created while a props getter runs, which can be inside the effect scope of whichever
@@ -35,7 +38,12 @@ export function createPropStore(): PropStore {
    */
   const waiterScope = effectScope(true)
 
-  const getPrefetchProps: PropStore['getPrefetchProps'] = (strategy, route, prefetch) => {
+  /**
+   * The response is seeded with props already prefetched at earlier strategies so that a child
+   * prefetching later than its parent resolves the parent's pending props instead of waiting for
+   * navigation to commit them to the store.
+   */
+  const getPrefetchProps: PropStore['getPrefetchProps'] = (strategy, route, prefetch, prefetched = {}) => {
     const { push, replace, reject, update } = createRouterCallbackContext({ to: route })
 
     return route.matches
@@ -59,7 +67,7 @@ export function createPropStore(): PropStore {
         response[key] = value
 
         return response
-      }, {})
+      }, { ...prefetched })
   }
 
   const setPrefetchProps: PropStore['setPrefetchProps'] = (props) => {
@@ -157,7 +165,9 @@ export function createPropStore(): PropStore {
         name,
         props: new Proxy({}, {
           get(target, propName) {
-            if (typeof propName !== 'string') {
+            // names without a getter in the parent's props record can never be stored, so waiting on
+            // them would never settle — they fall through to the target's own (undefined) properties
+            if (typeof propName !== 'string' || !Object.prototype.hasOwnProperty.call(parentViews.props, propName)) {
               return Reflect.get(target, propName)
             }
 
@@ -201,36 +211,41 @@ export function createPropStore(): PropStore {
   }
 
   /**
-   * Resolves once the given props have been computed and stored. Never resolves if navigation moves
-   * somewhere else first, at which point the waiter is discarded along with the props it was waiting for.
+   * Resolves once the given props have been computed and stored. Watches for the key's existence rather
+   * than its value so that props which are legitimately `undefined` still resolve. Rejects with
+   * ParentPropsAbandonedError if navigation moves somewhere else first, at which point the waiter is
+   * discarded along with the props it was waiting for.
    */
   function waitForProps(key: string): Promise<unknown> {
-    return new Promise((resolve) => {
-      const stops = waiters.get(key) ?? new Set<WatchHandle>()
+    return new Promise((resolve, reject) => {
+      const stops = waiters.get(key) ?? new Set<Waiter>()
 
       waiters.set(key, stops)
 
       waiterScope.run(() => {
-        const stop = watch(() => store.get(key), (value) => {
-          if (value === undefined) {
-            return
-          }
+        const waiter: Waiter = {
+          stop: watch(() => store.has(key), (has) => {
+            if (!has) {
+              return
+            }
 
-          discardWaiter(key, stop)
-          resolve(value)
-        })
+            discardWaiter(key, waiter)
+            resolve(store.get(key))
+          }),
+          abandon: () => reject(new ParentPropsAbandonedError()),
+        }
 
-        stops.add(stop)
+        stops.add(waiter)
       })
     })
   }
 
-  function discardWaiter(key: string, stop: WatchHandle): void {
-    stop()
+  function discardWaiter(key: string, waiter: Waiter): void {
+    waiter.stop()
 
     const stops = waiters.get(key)
 
-    stops?.delete(stop)
+    stops?.delete(waiter)
 
     if (stops?.size === 0) {
       waiters.delete(key)
@@ -243,7 +258,11 @@ export function createPropStore(): PropStore {
         continue
       }
 
-      stops.forEach((stop) => stop())
+      stops.forEach((waiter) => {
+        waiter.stop()
+        waiter.abandon()
+      })
+
       waiters.delete(key)
     }
   }

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -12,7 +12,7 @@ import { createVueAppStore, HasVueAppStore } from './createVueAppStore'
 import { CallbackContextPush, CallbackContextReject, CallbackContextSuccess } from '@/types/callbackContext'
 import { createRouterCallbackContext } from './createRouterCallbackContext'
 
-type ComponentProps = { id: string, name: string, props?: PropsGetter }
+type ComponentProps = { id: string, name: string, depth: number, props?: PropsGetter }
 
 type SetPropsResponse = CallbackContextSuccess | CallbackContextPush | CallbackContextReject
 
@@ -31,10 +31,10 @@ export function createPropStore(): PropStore {
     const { push, replace, reject, update } = createRouterCallbackContext({ to: route })
 
     return route.matches
-      .map((match, index) => ({ match, views: route.views[index] }))
+      .map((match, index) => ({ match, views: route.views[index], depth: index }))
       .filter(({ match }) => getPrefetchOption({ ...prefetch, routePrefetch: match.prefetch }, 'props') === strategy)
-      .flatMap(({ views }) => getComponentProps(views))
-      .reduce<Record<string, unknown>>((response, { id, name, props }) => {
+      .flatMap(({ views, depth }) => getComponentProps(views, depth))
+      .reduce<Record<string, unknown>>((response, { id, name, depth, props }) => {
         if (!props) {
           return response
         }
@@ -45,7 +45,7 @@ export function createPropStore(): PropStore {
           replace,
           reject,
           update,
-          parent: getParentContext(route, true),
+          parent: getParentContext(route, depth, true),
         })))
 
         response[key] = value
@@ -62,11 +62,11 @@ export function createPropStore(): PropStore {
 
   const setProps: PropStore['setProps'] = async (route) => {
     const { push, replace, reject, update } = createRouterCallbackContext({ to: route })
-    const componentProps = route.views.flatMap(getComponentProps)
+    const componentProps = route.views.flatMap((views, depth) => getComponentProps(views, depth))
     const keys: string[] = []
     const promises: Promise<unknown>[] = []
 
-    for (const { id, name, props } of componentProps) {
+    for (const { id, name, depth, props } of componentProps) {
       if (!props) {
         continue
       }
@@ -81,7 +81,7 @@ export function createPropStore(): PropStore {
           replace,
           reject,
           update,
-          parent: getParentContext(route),
+          parent: getParentContext(route, depth),
         })))
 
         store.set(key, value)
@@ -121,13 +121,17 @@ export function createPropStore(): PropStore {
     return store.get(key)
   }
 
-  function getParentContext(route: ResolvedRoute, prefetch: boolean = false): PropsCallbackParent {
-    const parentMatch = route.matches.at(-2)
-    const parentViews = route.views.at(-2)
-
-    if (!parentMatch || !parentViews) {
+  /**
+   * The parent context for the view at the given depth. Must be resolved per depth rather than from the
+   * end of the tuples: every view in a nested route gets its own parent, not the resolved route's parent.
+   */
+  function getParentContext(route: ResolvedRoute, depth: number, prefetch: boolean = false): PropsCallbackParent {
+    if (depth === 0) {
       return
     }
+
+    const parentMatch = route.matches[depth - 1]
+    const parentViews = route.views[depth - 1]
 
     const name = parentMatch.name ?? ''
 
@@ -180,19 +184,20 @@ export function createPropStore(): PropStore {
     return [id, name, route.id, JSON.stringify(route.params)].join('-')
   }
 
-  function getComponentProps(views: RouteViews): ComponentProps[] {
+  function getComponentProps(views: RouteViews, depth: number): ComponentProps[] {
     if (isWithComponentProps(views)) {
       return [
         {
           id: views.id,
           name: 'default',
+          depth,
           props: views.props,
         },
       ]
     }
 
     if (isWithComponentPropsRecord(views)) {
-      return Object.entries(views.props).map(([name, props]) => ({ id: views.id, name, props }))
+      return Object.entries(views.props).map(([name, props]) => ({ id: views.id, name, depth, props }))
     }
 
     return []

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -6,6 +6,7 @@ import { ResolvedRoute } from '@/types/resolved'
 import { RouteViews } from '@/types/routeViews'
 import { ContextPushError } from '@/errors/contextPushError'
 import { ContextRejectionError } from '@/errors/contextRejectionError'
+import { isPromise } from '@/utilities/promises'
 import { getPropsValue } from '@/utilities/props'
 import { PropsCallbackParent } from '@/types/props'
 import { createVueAppStore, HasVueAppStore } from './createVueAppStore'
@@ -175,6 +176,29 @@ export function createPropStore(): PropStore {
         Unable to access parent props "${name}" while prefetching props for route "${routeName}".
         This may occur if the parent route's props were not also prefetched.
       `)
+    }
+
+    return unwrapPropsError(value)
+  }
+
+  /**
+   * A failed props getter is stored as its error rather than thrown, so that navigation can inspect the
+   * settled value. Consumers of a parent's props expect the props themselves, so the error is rethrown
+   * here instead of being handed back as though it were a valid value.
+   */
+  function unwrapPropsError(value: unknown): unknown {
+    if (value instanceof Error) {
+      throw value
+    }
+
+    if (isPromise(value)) {
+      return value.then((resolved) => {
+        if (resolved instanceof Error) {
+          throw resolved
+        }
+
+        return resolved
+      })
     }
 
     return value

--- a/src/services/createRoute.spec-d.ts
+++ b/src/services/createRoute.spec-d.ts
@@ -405,7 +405,7 @@ describe('props', () => {
       name: 'child',
       parent: parent,
     }, (__, { parent }) => {
-      expectTypeOf(parent.props).toEqualTypeOf<{ foo: number }>()
+      expectTypeOf(parent.props).toEqualTypeOf<Promise<{ foo: number }>>()
       expectTypeOf(parent.name).toEqualTypeOf<'parent'>()
 
       return {}
@@ -445,7 +445,7 @@ describe('props', () => {
       parent: parent,
     }, (__, { parent }) => {
       expectTypeOf(parent.props).toEqualTypeOf<{
-        one: { foo: number },
+        one: Promise<{ foo: number }>,
         two: Promise<{ foo: number }>,
       }>()
       expectTypeOf(parent.name).toEqualTypeOf<'parent'>()

--- a/src/services/createRoute.spec.ts
+++ b/src/services/createRoute.spec.ts
@@ -1,3 +1,4 @@
+import { flushPromises } from '@vue/test-utils'
 import { describe, expect, test, vi } from 'vitest'
 import { createRoute } from '@/services/createRoute'
 import { component } from '@/utilities/testHelpers'
@@ -283,6 +284,74 @@ describe('props', () => {
     expect(spy).toHaveBeenCalledWith({ value: 123 })
   })
 
+  test('awaiting parent props that rejected throws the error', async () => {
+    const error = new Error('parent props failed')
+    const caught = vi.fn()
+
+    const parent = createRoute({
+      name: 'parent',
+    }, async () => {
+      throw error
+    })
+
+    const child = createRoute({
+      name: 'child',
+      parent: parent,
+      path: '/child',
+    }, async (__, { parent }) => {
+      try {
+        await parent.props
+      } catch (thrown) {
+        caught(thrown)
+      }
+
+      return {}
+    })
+
+    const router = createRouter([parent, child], {
+      initialUrl: '/child',
+    })
+
+    await router.start()
+
+    expect(caught).toHaveBeenCalledWith(error)
+  })
+
+  test('reading parent props that threw synchronously throws the error', async () => {
+    const error = new Error('parent props failed')
+    const caught = vi.fn()
+
+    const parent = createRoute({
+      name: 'parent',
+    }, () => {
+      throw error
+    })
+
+    const child = createRoute({
+      name: 'child',
+      parent: parent,
+      path: '/child',
+    }, (__, { parent }) => {
+      try {
+        const value = parent.props
+
+        caught({ didNotThrow: value })
+      } catch (thrown) {
+        caught(thrown)
+      }
+
+      return {}
+    })
+
+    const router = createRouter([parent, child], {
+      initialUrl: '/child',
+    })
+
+    await router.start()
+
+    expect(caught).toHaveBeenCalledWith(error)
+  })
+
   test('async parent props are passed to child props', async () => {
     const spy = vi.fn()
 
@@ -385,6 +454,7 @@ describe('props', () => {
     })
 
     await router.start()
+    await flushPromises()
 
     expect(spy).toHaveBeenCalledWith({ value1: 123, value2: 456 })
   })

--- a/src/services/createRoute.spec.ts
+++ b/src/services/createRoute.spec.ts
@@ -424,6 +424,42 @@ describe('props', () => {
     expect(spy).toHaveBeenCalledWith({ value1: 123, value2: 456 })
   })
 
+  test('parent props for view names without a getter are undefined rather than never settling', async () => {
+    const spy = vi.fn()
+
+    const parent = createRoute({
+      name: 'parent',
+      components: {
+        one: component,
+        two: component,
+        three: component,
+      },
+    }, {
+      one: () => ({ foo: 123 }),
+      two: () => ({ bar: 456 }),
+    })
+
+    const child = createRoute({
+      name: 'child',
+      parent: parent,
+      path: '/child',
+    }, (__, { parent }) => {
+      const props = parent.props as Record<string, unknown>
+
+      // "three" has a view but no getter, "missing" has neither — both must be
+      // undefined instead of promises that never settle
+      return spy({ three: props.three, missing: props.missing })
+    })
+
+    const router = createRouter([parent, child], {
+      initialUrl: '/child',
+    })
+
+    await router.start()
+
+    expect(spy).toHaveBeenCalledWith({ three: undefined, missing: undefined })
+  })
+
   test('async parent props with multiple views are passed to child props', async () => {
     const spy = vi.fn()
 

--- a/src/services/createRoute.spec.ts
+++ b/src/services/createRoute.spec.ts
@@ -232,8 +232,8 @@ describe('props', () => {
       name: 'parent',
       parent: grandparent,
       path: '/parent',
-    }, (__, { parent }) => {
-      seen.push({ self: 'parent', parentName: parent.name, parentProps: parent.props })
+    }, async (__, { parent }) => {
+      seen.push({ self: 'parent', parentName: parent.name, parentProps: await parent.props })
 
       return { level: 'parent' }
     })
@@ -242,8 +242,12 @@ describe('props', () => {
       name: 'child',
       parent,
       path: '/child',
-    }, (__, { parent }) => {
-      seen.push({ self: 'child', parentName: parent.name, parentProps: parent.props })
+    }, async (__, { parent }) => {
+      // parent.props is a promise at runtime, but its type collapses to undefined because the parent's
+      // own getter consumes the callback context, which makes its inferred props type as wide as the
+      // constraint in ToRoute
+      // eslint-disable-next-line @typescript-eslint/await-thenable
+      seen.push({ self: 'child', parentName: parent.name, parentProps: await parent.props })
 
       return { level: 'child' }
     })
@@ -253,6 +257,7 @@ describe('props', () => {
     })
 
     await router.start()
+    await flushPromises()
 
     expect(seen).toStrictEqual([
       { self: 'parent', parentName: 'grandparent', parentProps: { level: 'grandparent' } },
@@ -271,8 +276,10 @@ describe('props', () => {
       name: 'child',
       parent: parent,
       path: '/child',
-    }, (__, { parent }) => {
-      return spy({ value: parent.props.foo })
+    }, async (__, { parent }) => {
+      const { foo: value } = await parent.props
+
+      return spy({ value })
     })
 
     const router = createRouter([parent, child], {
@@ -280,6 +287,7 @@ describe('props', () => {
     })
 
     await router.start()
+    await flushPromises()
 
     expect(spy).toHaveBeenCalledWith({ value: 123 })
   })
@@ -331,9 +339,9 @@ describe('props', () => {
       name: 'child',
       parent: parent,
       path: '/child',
-    }, (__, { parent }) => {
+    }, async (__, { parent }) => {
       try {
-        const value = parent.props
+        const value = await parent.props
 
         caught({ didNotThrow: value })
       } catch (thrown) {
@@ -400,11 +408,11 @@ describe('props', () => {
       name: 'child',
       parent: parent,
       path: '/child',
-    }, (__, { parent }) => {
-      return spy({
-        value1: parent.props.one.foo,
-        value2: parent.props.two.bar,
-      })
+    }, async (__, { parent }) => {
+      const { foo: value1 } = await parent.props.one
+      const { bar: value2 } = await parent.props.two
+
+      return spy({ value1, value2 })
     })
 
     const router = createRouter([parent, child], {

--- a/src/services/createRoute.spec.ts
+++ b/src/services/createRoute.spec.ts
@@ -219,6 +219,46 @@ describe('props', () => {
     expect(spy).toHaveBeenCalledWith({ name: 'parent', props: undefined })
   })
 
+  test('each depth is given its own parent context, not the resolved route\'s parent', async () => {
+    const seen: unknown[] = []
+
+    const grandparent = createRoute({
+      name: 'grandparent',
+      path: '/grandparent',
+    }, () => ({ level: 'grandparent' }))
+
+    const parent = createRoute({
+      name: 'parent',
+      parent: grandparent,
+      path: '/parent',
+    }, (__, { parent }) => {
+      seen.push({ self: 'parent', parentName: parent.name, parentProps: parent.props })
+
+      return { level: 'parent' }
+    })
+
+    const child = createRoute({
+      name: 'child',
+      parent,
+      path: '/child',
+    }, (__, { parent }) => {
+      seen.push({ self: 'child', parentName: parent.name, parentProps: parent.props })
+
+      return { level: 'child' }
+    })
+
+    const router = createRouter([child], {
+      initialUrl: '/grandparent/parent/child',
+    })
+
+    await router.start()
+
+    expect(seen).toStrictEqual([
+      { self: 'parent', parentName: 'grandparent', parentProps: { level: 'grandparent' } },
+      { self: 'child', parentName: 'parent', parentProps: { level: 'parent' } },
+    ])
+  })
+
   test('sync parent props are passed to child props', async () => {
     const spy = vi.fn()
 

--- a/src/types/addView.ts
+++ b/src/types/addView.ts
@@ -57,10 +57,15 @@ type ParentMatchName<
   ? TParent['name']
   : string
 
+/**
+ * A parent's props are always given to a child as a promise. They may not have been computed when the
+ * child's getter runs — prefetching at a different strategy, or not at all, means the child has to wait
+ * for them — so the type cannot promise a value that is already available.
+ */
 type MatchPropsReturnType<TProps> = TProps extends PropsGetter
-  ? ReturnType<TProps>
+  ? Promise<Awaited<ReturnType<TProps>>>
   : TProps extends Record<string, PropsGetter>
-    ? { [K in keyof TProps]: ReturnType<TProps[K]> }
+    ? { [K in keyof TProps]: Promise<Awaited<ReturnType<TProps[K]>>> }
     : undefined
 
 /**

--- a/src/types/props.ts
+++ b/src/types/props.ts
@@ -36,9 +36,9 @@ type GetParentPropsReturnType<
 > = TParent extends Route
   ? LastInArray<TParent['views']> extends RouteViews<infer TProps>
     ? TProps extends PropsGetter
-      ? ReturnType<TProps>
+      ? Promise<Awaited<ReturnType<TProps>>>
       : TProps extends Record<string, PropsGetter>
-        ? { [K in keyof TProps]: ReturnType<TProps[K]> }
+        ? { [K in keyof TProps]: Promise<Awaited<ReturnType<TProps[K]>>> }
         : undefined
     : undefined
   : undefined


### PR DESCRIPTION
## Review of `wait-for-parent-props`

This PR contains the findings from a review of the parent-props-as-promises work, with fixes and regression tests for each. The underlying design of the branch is sound — depth-based parent contexts fix a real bug (every view previously got the *resolved route's* parent via `matches.at(-2)`), the error-rethrow semantics in `toParentProps` are right, and the detached effect scope for waiters is correctly justified. The four findings below are all edge cases in the new waiter machinery.

### 1. A child prefetching at a later strategy than its parent stalled and warned spuriously

`getParentProps` only consulted the current strategy's `pending` batch and the committed store. With parent `eager` + child `intent`/`lazy`, the parent's props promise already existed in the eager batch when the child's batch ran — but was invisible, so the child warned "the parent's props are not being prefetched" (false) and parked on a waiter until navigation, defeating the child's prefetch entirely.

**Fix:** `getPrefetchProps` now accepts the already-accumulated batches and seeds its response with them; `usePrefetching` passes the merged batches (extracted into `getAccumulatedProps()`, shared with `commit`). The reverse ordering (parent's strategy fires *after* the child's) still waits for the store, which is genuinely correct there and remains covered by the branch's existing tests.

### 2. Parent props that compute to `undefined` deadlocked navigation

The waiter's watch callback used `value === undefined` to mean "not computed yet", while `store.has(key)` treats a stored `undefined` as computed — the two paths disagreed. A getter returning `undefined` (a type violation, but trivial in plain JS) committed the value, the waiter never fired, the awaiting child's promise never settled, and `setProps`' `Promise.all` hung: navigation froze with no error.

**Fix:** the waiter watches `store.has(key)` instead of the value, so existence — not truthiness — resolves it.

### 3. Unknown prop names on the named-views Proxy hung forever

The Proxy returned a waiter promise for *any* string key, including names with no getter in the parent's props record — keys that can never be stored. Previously `parent.props.typo` gave `undefined`; on this branch it never settled. Types protect TS users, but `any`-typed or plain-JS consumers got a silent hang.

**Fix:** the Proxy checks `Object.prototype.hasOwnProperty.call(parentViews.props, propName)` and falls through to `undefined` for unknown names (`hasOwnProperty.call` rather than `in` so prototype names like `constructor` don't take the waiter path; not `Object.hasOwn` since the build targets ES2020).

### 4. Abandoned waiters left promises pending forever

By design, waiters discarded when navigation moved elsewhere never settled. The practical consequence: a user getter with `try { await parent.props } finally { cleanup() }` never ran its `finally`.

**Fix:** waiters carry their `reject` alongside the watch handle, and `discardUnusedWaiters` rejects with a new `ParentPropsAbandonedError` (exported from `main.ts`, since user getters can catch it). No unhandled rejections leak — an abandoned getter's promise always flows through `getPropsValue`, whose `.catch` settles it. **Note:** this is the one observable semantics change — getters that previously silently never resumed now throw — so it may deserve a changelog line.

### Tests

One regression test per finding, styled after their siblings:

- `routerLink.browser.spec.ts` — #1 (eager parent visible to intent child without navigating), #2 (undefined props still resolve and navigation completes), #4 (abandoning navigation rejects with `ParentPropsAbandonedError`)
- `createRoute.spec.ts` — #3 (view name without a getter and fully unknown name both read as `undefined`)

Each fails on the base branch: #1 by assertion, #2 by hanging navigation, #3 by assertion, #4 by never settling.

### Remaining review notes (not addressed here)

- The docs line "`parent.props` is always a promise" isn't quite accurate for named views, where `parent.props` is an object *of* promises.
- The `await-thenable` eslint-disable in `createRoute.spec.ts` documents a real inference wart (parent props collapsing to `undefined` when the parent's getter uses the callback context) — may deserve a tracking issue.
- Parent `lazy` + child `intent` where hover precedes visibility still waits until commit — the child's batch runs before the parent's exists. It resolves correctly at commit; covering it would require waiters that also watch future batches, which didn't seem worth the machinery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)