### PR TITLE
Record how a props getter settled instead of just its value

### DIFF
--- a/src/components/routerView.browser.spec.ts
+++ b/src/components/routerView.browser.spec.ts
@@ -359,6 +359,32 @@ test('Binds props and attrs from route', async () => {
   expect(wrapper.html()).toBe('world')
 })
 
+test('Renders props the getter returned, even when they are an Error', async () => {
+  const showsType = { props: ['value'], template: '<div>rendered</div>' }
+
+  const route = createRoute({
+    name: 'route',
+    path: '/',
+    component: showsType,
+  }, () => new Error('a real prop') as never)
+
+  const router = createRouter([route], {
+    initialUrl: '/',
+  })
+
+  await router.start()
+
+  const wrapper = mount({ template: '<RouterView/>' }, {
+    global: {
+      plugins: [router],
+    },
+  })
+
+  await flushPromises()
+
+  expect(wrapper.html()).toBe('<div>rendered</div>')
+})
+
 test('Updates props and attrs when route params change', async () => {
   const syncProps = createRoute({
     name: 'sync',

--- a/src/compositions/usePrefetching.ts
+++ b/src/compositions/usePrefetching.ts
@@ -7,6 +7,8 @@ import { isAsyncComponent } from '@/utilities/components'
 import { useVisibilityObserver } from './useVisibilityObserver'
 import { useEventListener } from './useEventListener'
 import { Router } from '@/types/router'
+import { PropsResult } from '@/utilities/props'
+import { MaybePromise } from '@/types/utilities'
 
 type UsePrefetchingConfig = PrefetchConfigs & {
   route: ResolvedRoute | undefined,
@@ -23,14 +25,14 @@ export function createUsePrefetching<TRouter extends Router>(routerKey: Injectio
   const usePropStore = createUsePropStore(routerKey)
 
   return (config) => {
-    const prefetchedProps = new Map<PrefetchStrategy, Record<string, unknown>>()
+    const prefetchedProps = new Map<PrefetchStrategy, Record<string, MaybePromise<PropsResult>>>()
     const element = ref<HTMLElement>()
 
     const { getPrefetchProps, setPrefetchProps } = usePropStore()
     const { isElementVisible } = useVisibilityObserver(element)
 
     const commit: UsePrefetching['commit'] = () => {
-      const props = Array.from(prefetchedProps.values()).reduce((accumulator, value) => {
+      const props = Array.from(prefetchedProps.values()).reduce<Record<string, MaybePromise<PropsResult>>>((accumulator, value) => {
         Object.assign(accumulator, value)
 
         return accumulator

--- a/src/services/component.ts
+++ b/src/services/component.ts
@@ -2,6 +2,7 @@
 /* eslint-disable vue/one-component-per-file */
 import { AsyncComponentLoader, Component, FunctionalComponent, InjectionKey, defineComponent, getCurrentInstance, h, ref, watch } from 'vue'
 import { isPromise } from '@/utilities/promises'
+import { PropsResult } from '@/utilities/props'
 import { createUsePropStore } from '@/compositions/usePropStore'
 import { Router } from '@/types/router'
 import { createUseRoute } from '@/compositions/useRoute'
@@ -35,69 +36,60 @@ export function createComponentPropsWrapper(routerKey: InjectionKey<Router>, { i
       const route = useRoute()
 
       return () => {
-        const props = store.getProps(id, name, route)
+        const result = store.getProps(id, name, route)
 
-        if (props instanceof Error) {
+        if (isPromise(result)) {
+          // @ts-expect-error there isn't a way to check if suspense is used in the component without accessing a private property
+          if (instance?.suspense) {
+            return h(SuspenseAsyncComponentPropsWrapper, { component, props: result })
+          }
+
+          return h(AsyncComponentPropsWrapper, { component, props: result })
+        }
+
+        if (result.kind === 'error') {
           return ''
         }
 
-        if (isPromise(props)) {
-          // @ts-expect-error there isn't a way to check if suspense is used in the component without accessing a private property
-          if (instance?.suspense) {
-            return h(SuspenseAsyncComponentPropsWrapper, { component, props })
-          }
-
-          return h(AsyncComponentPropsWrapper, { component, props })
-        }
-
-        return h(component, props)
+        return h(component, result.value)
       }
     },
   })
 }
 
-const AsyncComponentPropsWrapper = defineComponent((input: { component: Component, props: unknown }) => {
-  const values = ref()
+const AsyncComponentPropsWrapper = defineComponent((input: { component: Component, props: Promise<PropsResult> }) => {
+  const result = ref<PropsResult>()
 
   watch(() => input.props, async (props) => {
-    values.value = await props
+    result.value = await props
   }, { immediate: true, deep: true })
 
-  return () => {
-    if (values.value instanceof Error) {
-      return ''
-    }
-
-    if (values.value) {
-      return h(input.component, values.value)
-    }
-
-    return ''
-  }
+  return () => renderResult(input.component, result.value)
 }, {
   props: ['component', 'props'],
 })
 
-const SuspenseAsyncComponentPropsWrapper = defineComponent(async (input: { component: Component, props: unknown }) => {
-  const values = ref()
+const SuspenseAsyncComponentPropsWrapper = defineComponent(async (input: { component: Component, props: Promise<PropsResult> }) => {
+  const result = ref<PropsResult>()
 
-  values.value = await input.props
+  result.value = await input.props
 
-  watch(() => values.value, async (props) => {
-    values.value = await props
+  watch(() => input.props, async (props) => {
+    result.value = await props
   }, { deep: true })
 
-  return () => {
-    if (values.value instanceof Error) {
-      return ''
-    }
-
-    if (values.value) {
-      return h(input.component, values.value)
-    }
-
-    return ''
-  }
+  return () => renderResult(input.component, result.value)
 }, {
   props: ['component', 'props'],
 })
+
+/**
+ * Renders the component with whatever the getter settled on. No result means the promise has not resolved.
+ */
+function renderResult(component: Component, result: PropsResult | undefined): ReturnType<typeof h> | string {
+  if (result === undefined || result.kind === 'error') {
+    return ''
+  }
+
+  return h(component, result.value)
+}

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -7,8 +7,9 @@ import { RouteViews } from '@/types/routeViews'
 import { ContextPushError } from '@/errors/contextPushError'
 import { ContextRejectionError } from '@/errors/contextRejectionError'
 import { isPromise } from '@/utilities/promises'
-import { getPropsValue } from '@/utilities/props'
+import { getPropsValue, PropsResult } from '@/utilities/props'
 import { PropsCallbackParent } from '@/types/props'
+import { MaybePromise } from '@/types/utilities'
 import { createVueAppStore, HasVueAppStore } from './createVueAppStore'
 import { CallbackContextPush, CallbackContextReject, CallbackContextSuccess } from '@/types/callbackContext'
 import { createRouterCallbackContext } from './createRouterCallbackContext'
@@ -17,16 +18,23 @@ type ComponentProps = { id: string, name: string, depth: number, props?: PropsGe
 
 type SetPropsResponse = CallbackContextSuccess | CallbackContextPush | CallbackContextReject
 
+type StoredProps = MaybePromise<PropsResult>
+
 export type PropStore = HasVueAppStore & {
-  getPrefetchProps: (strategy: PrefetchStrategy, route: ResolvedRoute, configs: PrefetchConfigs) => Record<string, unknown>,
-  setPrefetchProps: (props: Record<string, unknown>) => void,
+  getPrefetchProps: (strategy: PrefetchStrategy, route: ResolvedRoute, configs: PrefetchConfigs) => Record<string, StoredProps>,
+  setPrefetchProps: (props: Record<string, StoredProps>) => void,
   setProps: (route: ResolvedRoute) => Promise<SetPropsResponse>,
-  getProps: (id: string, name: string, route: ResolvedRoute) => unknown,
+  getProps: (id: string, name: string, route: ResolvedRoute) => StoredProps,
 }
+
+/**
+ * What a view with no props getter renders with, since such a view stores nothing.
+ */
+const NO_PROPS: PropsResult = { kind: 'value', value: undefined }
 
 export function createPropStore(): PropStore {
   const { setVueApp, runWithContext } = createVueAppStore()
-  const store: Map<string, unknown> = reactive(new Map())
+  const store: Map<string, StoredProps> = reactive(new Map())
 
   const getPrefetchProps: PropStore['getPrefetchProps'] = (strategy, route, prefetch) => {
     const { push, replace, reject, update } = createRouterCallbackContext({ to: route })
@@ -40,7 +48,7 @@ export function createPropStore(): PropStore {
         viewPrefetch: views.prefetch?.[componentProps.name],
       }, 'props') === strategy)
       .map(({ componentProps }) => componentProps)
-      .reduce<Record<string, unknown>>((response, { id, name, depth, props }) => {
+      .reduce<Record<string, StoredProps>>((response, { id, name, depth, props }) => {
         if (!props) {
           return response
         }
@@ -94,10 +102,10 @@ export function createPropStore(): PropStore {
       }
 
       promises.push((async () => {
-        const value = await store.get(key)
+        const result = await store.get(key)
 
-        if (value instanceof Error) {
-          throw value
+        if (result?.kind === 'error') {
+          throw result.error
         }
       })())
     }
@@ -124,7 +132,7 @@ export function createPropStore(): PropStore {
   const getProps: PropStore['getProps'] = (id, name, route) => {
     const key = getPropKey(id, name, route)
 
-    return store.get(key)
+    return store.get(key) ?? NO_PROPS
   }
 
   /**
@@ -172,9 +180,10 @@ export function createPropStore(): PropStore {
   }
 
   function getParentProps(id: string, name: string, route: ResolvedRoute, prefetch: boolean = false): unknown {
-    const value = getProps(id, name, route)
+    const key = getPropKey(id, name, route)
+    const stored = store.get(key)
 
-    if (prefetch && !value) {
+    if (prefetch && stored === undefined) {
       const routeName = route.name || 'unknown'
 
       console.warn(`
@@ -183,30 +192,28 @@ export function createPropStore(): PropStore {
       `)
     }
 
-    return unwrapPropsError(value)
+    return unwrapPropsError(stored ?? NO_PROPS)
   }
 
   /**
-   * A failed props getter is stored as its error rather than thrown, so that navigation can inspect the
-   * settled value. Consumers of a parent's props expect the props themselves, so the error is rethrown
-   * here instead of being handed back as though it were a valid value.
+   * Rethrows a failed getter's error, which is otherwise recorded rather than thrown.
    */
-  function unwrapPropsError(value: unknown): unknown {
-    if (value instanceof Error) {
-      throw value
-    }
-
-    if (isPromise(value)) {
-      return value.then((resolved) => {
-        if (resolved instanceof Error) {
-          throw resolved
+  function unwrapPropsError(result: StoredProps): unknown {
+    if (isPromise(result)) {
+      return result.then((resolved) => {
+        if (resolved.kind === 'error') {
+          throw resolved.error
         }
 
-        return resolved
+        return resolved.value
       })
     }
 
-    return value
+    if (result.kind === 'error') {
+      throw result.error
+    }
+
+    return result.value
   }
 
   function getPropKey(id: string, name: string, route: ResolvedRoute): string {

--- a/src/utilities/props.ts
+++ b/src/utilities/props.ts
@@ -1,20 +1,28 @@
+import { MaybePromise } from '@/types/utilities'
 import { isPromise } from './promises'
 
 /**
- * Takes a props callback and returns a value
- * For sync props, this will return the props value or an error.
- * For async props, this will return a promise that resolves to the props value or an error.
+ * How a props getter settled. Tagged so that a getter returning `undefined` or an `Error` stays a value.
  */
-export function getPropsValue(callback: () => unknown): unknown {
+export type PropsResult = { kind: 'value', value: unknown } | { kind: 'error', error: unknown }
+
+/**
+ * Runs a props callback and captures how it settled rather than letting it throw, so that navigation can
+ * tell a push or rejection apart from a genuine failure. Sync getters settle synchronously.
+ */
+export function getPropsValue(callback: () => unknown): MaybePromise<PropsResult> {
   try {
     const value = callback()
 
     if (isPromise(value)) {
-      return value.catch((error: unknown) => error)
+      return value.then(
+        (resolved): PropsResult => ({ kind: 'value', value: resolved }),
+        (error: unknown): PropsResult => ({ kind: 'error', error }),
+      )
     }
 
-    return value
+    return { kind: 'value', value }
   } catch (error) {
-    return error
+    return { kind: 'error', error }
   }
 }


### PR DESCRIPTION
# Description

Stacked on #794.

Props were stored as whatever the getter returned, which left two real values indistinguishable from the states they stood in for.

A getter returning an `Error` looked the same as one that threw, so the view rendered nothing:

```ts
createRoute({
  name: 'route',
  path: '/route',
}).addView(ShowsProps, {
  props: () => someValueThatMightBeAnError(),
})
// before: renders nothing whenever the value happens to be an Error
// after:  renders, because a returned Error is a value like any other
```

A getter returning `undefined` looked the same as one that had not run yet. On its own that is harmless, but it becomes a hang once children can wait for their parent's props (#795).

Each entry now records how the getter settled alongside what it produced, so `undefined` and `Error` are ordinary values a getter may return. Nothing about the public API changes.
