### PR TITLE
Settle a child's parent props when navigation abandons them

### DIFF
--- a/src/components/routerLink.browser.spec.ts
+++ b/src/components/routerLink.browser.spec.ts
@@ -11,7 +11,7 @@ import { visibilityObserverKey } from '@/compositions/useVisibilityObserver'
 import { VisibilityObserver } from '@/services/createVisibilityObserver'
 import { UrlString } from '@/types/urlString'
 import { RouterPushOptions } from '@/types/routerPush'
-import { RouterLink } from '@/main'
+import { ParentPropsAbandonedError, RouterLink } from '@/main'
 
 test('renders an anchor tag with the correct href and slot content', () => {
   const path = '/path/[paramName]'
@@ -1266,6 +1266,172 @@ describe('prefetch props', () => {
     expect(settled).toStrictEqual([undefined])
 
     warn.mockRestore()
+  })
+
+  test('a child waiting on parent props is rejected when navigation abandons them', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const caught: unknown[] = []
+
+    const home = createRoute({
+      name: 'home',
+      path: '/',
+      component: () => h(RouterLink, { to: (resolve) => resolve('child') }),
+    })
+
+    const other = createRoute({
+      name: 'other',
+      path: '/other',
+      component: echo,
+    }, () => ({ value: 'other' }))
+
+    const parent = createRoute({
+      name: 'parent',
+      path: '/parent',
+      component: { props: ['foo'], template: '<div><RouterView /></div>' },
+      prefetch: { props: false },
+    }, async () => ({ foo: 123 }))
+
+    const child = createRoute({
+      parent,
+      name: 'child',
+      path: '/child',
+      component: echo,
+      prefetch: { props: 'eager' },
+    }, async (__, { parent }) => {
+      try {
+        await parent.props
+      } catch (error) {
+        caught.push(error)
+      }
+
+      return { value: 'child' }
+    })
+
+    const router = createRouter([home, child, other], {
+      initialUrl: '/',
+    })
+
+    await router.start()
+
+    mount({ template: '<RouterView />' }, {
+      global: {
+        plugins: [router],
+      },
+    })
+
+    await flushPromises()
+
+    expect(caught).toStrictEqual([])
+
+    await router.push('other')
+    await flushPromises()
+
+    expect(caught).toHaveLength(1)
+    expect(caught[0]).toBeInstanceOf(ParentPropsAbandonedError)
+
+    warn.mockRestore()
+  })
+
+  test('a getter that never awaits abandoned parent props does not leak an unhandled rejection', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    const home = createRoute({
+      name: 'home',
+      path: '/',
+      component: () => h(RouterLink, { to: (resolve) => resolve('child') }),
+    })
+
+    const other = createRoute({
+      name: 'other',
+      path: '/other',
+      component: echo,
+    }, () => ({ value: 'other' }))
+
+    const parent = createRoute({
+      name: 'parent',
+      path: '/parent',
+      component: { props: ['foo'], template: '<div><RouterView /></div>' },
+      prefetch: { props: false },
+    }, async () => ({ foo: 123 }))
+
+    const child = createRoute({
+      parent,
+      name: 'child',
+      path: '/child',
+      component: echo,
+      prefetch: { props: 'eager' },
+    }, (__, { parent }) => {
+      void parent.props
+
+      return { value: 'child' }
+    })
+
+    const router = createRouter([home, child, other], {
+      initialUrl: '/',
+    })
+
+    await router.start()
+
+    mount({ template: '<RouterView />' }, {
+      global: {
+        plugins: [router],
+      },
+    })
+
+    await flushPromises()
+
+    await router.push('other')
+    await flushPromises()
+
+    expect(router.route.name).toBe('other')
+
+    warn.mockRestore()
+  })
+
+  test('a getter that never awaits failed parent props does not leak an unhandled rejection', async () => {
+    const home = createRoute({
+      name: 'home',
+      path: '/',
+      component: () => h(RouterLink, { to: (resolve) => resolve('child') }),
+    })
+
+    const parent = createRoute({
+      name: 'parent',
+      path: '/parent',
+      component: { props: ['foo'], template: '<div><RouterView /></div>' },
+      prefetch: { props: 'eager' },
+    }, () => {
+      throw new Error('parent getter failed')
+    })
+
+    const child = createRoute({
+      parent,
+      name: 'child',
+      path: '/child',
+      component: echo,
+      prefetch: { props: 'eager' },
+    }, (__, { parent }) => {
+      void parent.props
+
+      return { value: 'child' }
+    })
+
+    const router = createRouter([home, child], {
+      initialUrl: '/',
+    })
+
+    await router.start()
+
+    mount({ template: '<RouterView />' }, {
+      global: {
+        plugins: [router],
+      },
+    })
+
+    await flushPromises()
+
+    expect(router.route.name).toBe('home')
   })
 
   test('a child does not wait when the parent props are prefetched at the same strategy', async () => {

--- a/src/errors/parentPropsAbandonedError.ts
+++ b/src/errors/parentPropsAbandonedError.ts
@@ -1,0 +1,8 @@
+/**
+ * Thrown from `parent.props` when navigation moves elsewhere before the parent's props were computed.
+ */
+export class ParentPropsAbandonedError extends Error {
+  public constructor() {
+    super('Parent props were discarded before they were computed because navigation moved elsewhere.')
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,6 +75,7 @@ export * from './types/useLink'
 // Errors
 export { DuplicateParamsError } from './errors/duplicateParamsError'
 export { MetaPropertyConflict } from './errors/metaPropertyConflict'
+export { ParentPropsAbandonedError } from './errors/parentPropsAbandonedError'
 export { RouterNotInstalledError } from './errors/routerNotInstalledError'
 export { UseRouteInvalidError } from './errors/useRouteInvalidError'
 

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -6,6 +6,7 @@ import { ResolvedRoute } from '@/types/resolved'
 import { RouteViews } from '@/types/routeViews'
 import { ContextPushError } from '@/errors/contextPushError'
 import { ContextRejectionError } from '@/errors/contextRejectionError'
+import { ParentPropsAbandonedError } from '@/errors/parentPropsAbandonedError'
 import { getPropsValue, PropsResult } from '@/utilities/props'
 import { PropsCallbackParent } from '@/types/props'
 import { MaybePromise } from '@/types/utilities'
@@ -14,6 +15,8 @@ import { CallbackContextPush, CallbackContextReject, CallbackContextSuccess } fr
 import { createRouterCallbackContext } from './createRouterCallbackContext'
 
 type ComponentProps = { id: string, name: string, depth: number, props?: PropsGetter }
+
+type Waiter = { stop: WatchHandle, abandon: () => void }
 
 type SetPropsResponse = CallbackContextSuccess | CallbackContextPush | CallbackContextReject
 
@@ -34,7 +37,7 @@ const NO_PROPS: PropsResult = { kind: 'value', value: undefined }
 export function createPropStore(): PropStore {
   const { setVueApp, runWithContext } = createVueAppStore()
   const store: Map<string, StoredProps> = reactive(new Map())
-  const waiters = new Map<string, Set<WatchHandle>>()
+  const waiters = new Map<string, Set<Waiter>>()
 
   /**
    * Detached because waiters outlive the component whose prefetch created them.
@@ -193,6 +196,15 @@ export function createPropStore(): PropStore {
    * parent's own lifecycle to compute them when neither has them yet.
    */
   function getParentProps(id: string, name: string, route: ResolvedRoute, prefetch: boolean = false, pending?: Record<string, StoredProps>): Promise<unknown> {
+    const props = readParentProps(id, name, route, prefetch, pending)
+
+    // reading without awaiting must not surface as an unhandled rejection
+    props.catch(() => {})
+
+    return props
+  }
+
+  function readParentProps(id: string, name: string, route: ResolvedRoute, prefetch: boolean, pending?: Record<string, StoredProps>): Promise<unknown> {
     const key = getPropKey(id, name, route)
     const batched = pending?.[key]
 
@@ -214,35 +226,39 @@ export function createPropStore(): PropStore {
   }
 
   /**
-   * Resolves once the given props are stored. Never resolves if navigation discards the waiter first.
+   * Resolves once the given props are stored, and rejects if navigation discards the waiter first, so a
+   * getter awaiting them resumes either way.
    */
   function waitForProps(key: string): Promise<PropsResult> {
-    return new Promise((resolve) => {
-      const stops = waiters.get(key) ?? new Set<WatchHandle>()
+    return new Promise((resolve, reject) => {
+      const stops = waiters.get(key) ?? new Set<Waiter>()
 
       waiters.set(key, stops)
 
       waiterScope.run(() => {
-        const stop = watch(() => store.get(key), (result) => {
-          if (result === undefined) {
-            return
-          }
+        const waiter: Waiter = {
+          stop: watch(() => store.get(key), (result) => {
+            if (result === undefined) {
+              return
+            }
 
-          discardWaiter(key, stop)
-          resolve(result)
-        })
+            discardWaiter(key, waiter)
+            resolve(result)
+          }),
+          abandon: () => reject(new ParentPropsAbandonedError()),
+        }
 
-        stops.add(stop)
+        stops.add(waiter)
       })
     })
   }
 
-  function discardWaiter(key: string, stop: WatchHandle): void {
-    stop()
+  function discardWaiter(key: string, waiter: Waiter): void {
+    waiter.stop()
 
     const stops = waiters.get(key)
 
-    stops?.delete(stop)
+    stops?.delete(waiter)
 
     if (stops?.size === 0) {
       waiters.delete(key)
@@ -255,7 +271,11 @@ export function createPropStore(): PropStore {
         continue
       }
 
-      stops.forEach((stop) => stop())
+      stops.forEach((waiter) => {
+        waiter.stop()
+        waiter.abandon()
+      })
+
       waiters.delete(key)
     }
   }


### PR DESCRIPTION
# Description

Stacked on #797.

Navigating away while a child is waiting on its parent's props left that child suspended forever. The getter never resumed, so cleanup never ran:

```ts
createRoute({
  name: 'child',
  parent,
  path: '/child',
}).addView(ChildPage, {
  props: async (route, { parent }) => {
    const spinner = showSpinner()

    try {
      const { id } = await parent.props
      // before: navigating elsewhere while waiting means neither of these ever run
      return { id }
    } finally {
      spinner.hide()
    }
  },
})
```

Those props now reject with `ParentPropsAbandonedError`, so a getter awaiting them resumes and can clean up or handle the interruption. A getter that reads `parent.props` without awaiting is unaffected — reading is never a source of unhandled rejections, whether the props were abandoned or the parent's getter failed.

## Breaking change

Awaiting `parent.props` can now throw where it previously never resumed. A getter that awaits parent props and navigates away mid-flight will see `ParentPropsAbandonedError` rather than silently stalling.
