### PR TITLE
Add a store for values that may not be computed yet

### DIFF
--- a/src/services/createDataStore.spec.ts
+++ b/src/services/createDataStore.spec.ts
@@ -1,0 +1,198 @@
+import { describe, expect, test, vi } from 'vitest'
+import { effect } from 'vue'
+import { createDataStore } from './createDataStore'
+
+describe('set and subscribe', () => {
+  test('a value subscribed to before anything computes it resolves when it is computed', async () => {
+    const store = createDataStore()
+    const settled: unknown[] = []
+
+    store.subscribe('key').then((value) => settled.push(value))
+
+    expect(settled).toStrictEqual([])
+
+    store.set('key', () => 'computed')
+
+    await Promise.resolve()
+
+    expect(settled).toStrictEqual(['computed'])
+  })
+
+  test('a value subscribed to after it is computed resolves immediately', async () => {
+    const store = createDataStore()
+
+    store.set('key', () => 'computed')
+
+    await expect(store.subscribe('key')).resolves.toBe('computed')
+  })
+
+  test('an async getter resolves the value when it settles', async () => {
+    const store = createDataStore()
+
+    store.set('key', async () => 'computed')
+
+    await expect(store.subscribe('key')).resolves.toBe('computed')
+  })
+
+  test('a getter that returns undefined resolves with undefined', async () => {
+    const store = createDataStore()
+
+    store.set('key', () => undefined)
+
+    await expect(store.subscribe('key')).resolves.toBeUndefined()
+    expect(store.get('key')).toStrictEqual({ kind: 'value', value: undefined })
+  })
+
+  test('a getter that returns an Error resolves with it as a value', async () => {
+    const store = createDataStore()
+    const value = new Error('a real value')
+
+    store.set('key', () => value)
+
+    await expect(store.subscribe('key')).resolves.toBe(value)
+    expect(store.get('key')).toStrictEqual({ kind: 'value', value })
+  })
+
+  test('a getter that throws rejects the value', async () => {
+    const store = createDataStore()
+    const error = new Error('failed')
+
+    store.set('key', () => {
+      throw error
+    })
+
+    await expect(store.subscribe('key')).rejects.toBe(error)
+    expect(store.get('key')).toStrictEqual({ kind: 'error', error })
+  })
+
+  test('an async getter that rejects rejects the value', async () => {
+    const store = createDataStore()
+    const error = new Error('failed')
+
+    store.set('key', async () => {
+      throw error
+    })
+
+    await expect(store.subscribe('key')).rejects.toBe(error)
+  })
+
+  test('setting a key twice does not call the second getter', () => {
+    const store = createDataStore()
+    const second = vi.fn()
+
+    store.set('key', () => 'first')
+    store.set('key', second)
+
+    expect(second).not.toHaveBeenCalled()
+    expect(store.get('key')).toStrictEqual({ kind: 'value', value: 'first' })
+  })
+
+  test('subscribing to a key does not count as setting it', () => {
+    const store = createDataStore()
+    const getter = vi.fn(() => 'computed')
+
+    store.subscribe('key')
+    store.set('key', getter)
+
+    expect(getter).toHaveBeenCalledOnce()
+  })
+})
+
+describe('get', () => {
+  test('is running while the getter is in flight', async () => {
+    const store = createDataStore()
+
+    store.set('key', async () => 'computed')
+
+    expect(store.get('key')).toStrictEqual({ kind: 'running' })
+
+    await store.subscribe('key')
+
+    expect(store.get('key')).toStrictEqual({ kind: 'value', value: 'computed' })
+  })
+
+  test('tells apart nothing asked for it, something waiting on it, and its getter in flight', () => {
+    const store = createDataStore()
+
+    store.subscribe('waited')
+    store.set('running', async () => 'computed')
+
+    expect(store.get('never')).toStrictEqual({ kind: 'missing' })
+    expect(store.get('waited')).toStrictEqual({ kind: 'pending' })
+    expect(store.get('running')).toStrictEqual({ kind: 'running' })
+  })
+
+  test('a sync getter settles without waiting a tick', () => {
+    const store = createDataStore()
+
+    store.set('key', () => 'computed')
+
+    expect(store.get('key')).toStrictEqual({ kind: 'value', value: 'computed' })
+  })
+
+  test('tracks reactively, so a render reading it updates when the value settles', async () => {
+    const store = createDataStore()
+    const seen: (string | undefined)[] = []
+
+    effect(() => {
+      const result = store.get('key')
+
+      seen.push(result.kind === 'value' ? String(result.value) : undefined)
+    })
+
+    expect(seen).toStrictEqual([undefined])
+
+    store.set('key', async () => 'computed')
+    await store.subscribe('key')
+
+    expect(seen.at(-1)).toBe('computed')
+  })
+
+  test('is missing for a key nothing has touched', () => {
+    const store = createDataStore()
+
+    expect(store.get('key')).toStrictEqual({ kind: 'missing' })
+  })
+})
+
+describe('dispose', () => {
+  test('rejects a pending value so anything waiting resumes', async () => {
+    const store = createDataStore()
+    const reason = new Error('abandoned')
+    const waiting = store.subscribe('key')
+
+    store.dispose(reason)
+
+    await expect(waiting).rejects.toBe(reason)
+  })
+
+  test('discards the value', () => {
+    const store = createDataStore()
+
+    store.set('key', () => 'computed')
+    store.dispose(new Error('abandoned'))
+
+    expect(store.get('key')).toStrictEqual({ kind: 'missing' })
+  })
+
+  test('leaves an already settled value settled for anything holding it', async () => {
+    const store = createDataStore()
+
+    store.set('key', () => 'computed')
+
+    const held = store.subscribe('key')
+
+    store.dispose(new Error('abandoned'))
+
+    await expect(held).resolves.toBe('computed')
+  })
+
+  test('a value nobody is waiting on does not leak an unhandled rejection', async () => {
+    const store = createDataStore()
+
+    store.subscribe('key')
+    store.dispose(new Error('abandoned'))
+
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  })
+})

--- a/src/services/createDataStore.ts
+++ b/src/services/createDataStore.ts
@@ -1,0 +1,145 @@
+import { markRaw, reactive, shallowRef, ShallowRef } from 'vue'
+import { isPromise } from '@/utilities/promises'
+
+export type DataResultValue = { kind: 'value', value: unknown }
+
+export type DataResultError = { kind: 'error', error: unknown }
+
+export type DataResultPending = { kind: 'pending' }
+
+export type DataResultRunning = { kind: 'running' }
+
+export type DataResultMissing = { kind: 'missing' }
+
+/**
+ * Where a key has got to: nothing has asked for it, something is waiting on it, its getter is in flight,
+ * or how that getter settled. Tagged so that a getter returning `undefined` or an `Error` stays a value.
+ */
+export type DataResult = DataResultValue | DataResultError | DataResultPending | DataResultRunning | DataResultMissing
+
+const PENDING: DataResultPending = { kind: 'pending' }
+
+const RUNNING: DataResultRunning = { kind: 'running' }
+
+const MISSING: DataResultMissing = { kind: 'missing' }
+
+type Entry = {
+  promise: Promise<unknown>,
+  resolve: (value: unknown) => void,
+  reject: (reason: unknown) => void,
+  state: ShallowRef<DataResult>,
+}
+
+/**
+ * A set of values that live and die together. A link owns one for whatever it points at, and the current
+ * navigation owns one.
+ */
+export type DataStore = {
+  /**
+   * The value for a key, whether or not anything has computed it yet. Subscribing to a key nobody has set
+   * leaves a promise waiting for whoever does.
+   */
+  subscribe: (key: string) => Promise<unknown>,
+  /**
+   * Computes a key, unless something already has. A key promoted from another store while its getter is
+   * still running is left alone, so navigation adopts it rather than computing it a second time.
+   */
+  set: (key: string, getter: () => unknown) => void,
+  /**
+   * What is known about a key, without waiting for it. Reactive, and readable during render.
+   */
+  get: (key: string) => DataResult,
+  /**
+   * Ends the store. Every value is rejected so that anything waiting on one resumes rather than staying
+   * suspended, then discarded.
+   */
+  dispose: (reason: Error) => void,
+}
+
+export function createDataStore(): DataStore {
+  const entries: Map<string, Entry> = reactive(new Map())
+
+  function create(): Entry {
+    const { promise, resolve, reject } = Promise.withResolvers<unknown>()
+
+    // a value nobody happens to await must not surface as an unhandled rejection
+    promise.catch(() => {})
+
+    return markRaw({ promise, resolve, reject, state: shallowRef<DataResult>(PENDING) })
+  }
+
+  function entry(key: string): Entry {
+    const existing = entries.get(key)
+
+    if (existing) {
+      return existing
+    }
+
+    const created = create()
+
+    entries.set(key, created)
+
+    return created
+  }
+
+  function settle(target: Entry, result: DataResultValue | DataResultError): void {
+    const current = target.state.value
+
+    if (current.kind === 'value' || current.kind === 'error') {
+      return
+    }
+
+    target.state.value = result
+
+    if (result.kind === 'value') {
+      target.resolve(result.value)
+    } else {
+      target.reject(result.error)
+    }
+  }
+
+  const subscribe: DataStore['subscribe'] = (key) => entry(key).promise
+
+  const set: DataStore['set'] = (key, getter) => {
+    const target = entry(key)
+
+    if (target.state.value.kind !== 'pending') {
+      return
+    }
+
+    target.state.value = RUNNING
+
+    try {
+      const value = getter()
+
+      if (isPromise(value)) {
+        value.then(
+          (resolved) => settle(target, { kind: 'value', value: resolved }),
+          (error: unknown) => settle(target, { kind: 'error', error }),
+        )
+
+        return
+      }
+
+      settle(target, { kind: 'value', value })
+    } catch (error) {
+      settle(target, { kind: 'error', error })
+    }
+  }
+
+  const get: DataStore['get'] = (key) => entries.get(key)?.state.value ?? MISSING
+
+  const dispose: DataStore['dispose'] = (reason) => {
+    for (const [key, dying] of entries) {
+      entries.delete(key)
+      settle(dying, { kind: 'error', error: reason })
+    }
+  }
+
+  return {
+    subscribe,
+    set,
+    get,
+    dispose,
+  }
+}


### PR DESCRIPTION
# Description

First step of #805. Nothing uses this yet — the store is added on its own so it can be reviewed without the churn of rewiring props at the same time.

A value becomes a promise the moment it is first asked for, rather than only existing once its getter has run. Whoever needs it can await it without knowing when, or by whom, it will be computed:

```ts
store.subscribe('user')          // nothing has computed this yet — waits
store.set('user', getUser)       // resolves the promise the subscriber already holds
```

Alongside the promise, each key records where it has got to — nothing has asked for it, something is waiting on it, its getter is in flight, or how that getter settled. Rendering reads that synchronously instead of waiting a tick, and a getter returning `undefined` or an `Error` stays an ordinary value rather than being mistaken for "not ready" or "failed".

A store is also the unit of lifetime. Disposing one rejects everything still outstanding, so anything waiting resumes rather than being suspended for the life of the page — which is what prefetching needs, since most prefetched work is for a navigation that never happens.
