### PR TITLE
Compute props through the data store

### DIFF
--- a/src/components/routerLink.browser.spec.ts
+++ b/src/components/routerLink.browser.spec.ts
@@ -11,7 +11,7 @@ import { visibilityObserverKey } from '@/compositions/useVisibilityObserver'
 import { VisibilityObserver } from '@/services/createVisibilityObserver'
 import { UrlString } from '@/types/urlString'
 import { RouterPushOptions } from '@/types/routerPush'
-import { ParentPropsAbandonedError, RouterLink } from '@/main'
+import { NavigationAbandonedError, RouterLink } from '@/main'
 
 test('renders an anchor tag with the correct href and slot content', () => {
   const path = '/path/[paramName]'
@@ -1328,7 +1328,7 @@ describe('prefetch props', () => {
     await flushPromises()
 
     expect(caught).toHaveLength(1)
-    expect(caught[0]).toBeInstanceOf(ParentPropsAbandonedError)
+    expect(caught[0]).toBeInstanceOf(NavigationAbandonedError)
 
     warn.mockRestore()
   })

--- a/src/compositions/usePrefetching.ts
+++ b/src/compositions/usePrefetching.ts
@@ -1,4 +1,4 @@
-import { InjectionKey, MaybeRefOrGetter, ref, Ref, toValue, watch } from 'vue'
+import { InjectionKey, MaybeRefOrGetter, onScopeDispose, ref, Ref, toValue, watch } from 'vue'
 import { createUsePropStore } from '@/compositions/usePropStore'
 import type { PrefetchConfigs, PrefetchStrategy } from '@/types/prefetch'
 import { getPrefetchOption } from '@/utilities/prefetch'
@@ -7,8 +7,6 @@ import { isAsyncComponent } from '@/utilities/components'
 import { useVisibilityObserver } from './useVisibilityObserver'
 import { useEventListener } from './useEventListener'
 import { Router } from '@/types/router'
-import { PropsResult } from '@/utilities/props'
-import { MaybePromise } from '@/types/utilities'
 
 type UsePrefetchingConfig = PrefetchConfigs & {
   route: ResolvedRoute | undefined,
@@ -25,26 +23,20 @@ export function createUsePrefetching<TRouter extends Router>(routerKey: Injectio
   const usePropStore = createUsePropStore(routerKey)
 
   return (config) => {
-    const prefetchedProps = new Map<PrefetchStrategy, Record<string, MaybePromise<PropsResult>>>()
     const element = ref<HTMLElement>()
 
-    const { getPrefetchProps, setPrefetchProps } = usePropStore()
+    const { createPrefetchStore } = usePropStore()
+    const store = createPrefetchStore()
     const { isElementVisible } = useVisibilityObserver(element)
 
     const commit: UsePrefetching['commit'] = () => {
-      setPrefetchProps(getAccumulatedProps())
+      store.commit()
     }
 
-    function getAccumulatedProps(): Record<string, MaybePromise<PropsResult>> {
-      return Array.from(prefetchedProps.values()).reduce<Record<string, MaybePromise<PropsResult>>>((accumulator, value) => {
-        Object.assign(accumulator, value)
-
-        return accumulator
-      }, {})
-    }
+    onScopeDispose(() => store.dispose())
 
     watch(() => toValue(config), ({ route, ...configs }) => {
-      prefetchedProps.clear()
+      store.reset()
 
       if (!route) {
         return
@@ -78,10 +70,7 @@ export function createUsePrefetching<TRouter extends Router>(routerKey: Injectio
 
     function doPrefetchingForStrategy(strategy: PrefetchStrategy, route: ResolvedRoute, configs: PrefetchConfigs): void {
       prefetchComponentsForRoute(strategy, route, configs)
-
-      if (!prefetchedProps.has(strategy)) {
-        prefetchedProps.set(strategy, getPrefetchProps(strategy, route, configs, getAccumulatedProps()))
-      }
+      store.prefetch(strategy, route, configs)
     }
 
     return {

--- a/src/errors/navigationAbandonedError.ts
+++ b/src/errors/navigationAbandonedError.ts
@@ -1,0 +1,8 @@
+/**
+ * Thrown when data a getter is waiting on is discarded because navigation moved elsewhere.
+ */
+export class NavigationAbandonedError extends Error {
+  public constructor() {
+    super('Discarded before it was computed because navigation moved elsewhere.')
+  }
+}

--- a/src/errors/parentPropsAbandonedError.ts
+++ b/src/errors/parentPropsAbandonedError.ts
@@ -1,8 +1,0 @@
-/**
- * Thrown from `parent.props` when navigation moves elsewhere before the parent's props were computed.
- */
-export class ParentPropsAbandonedError extends Error {
-  public constructor() {
-    super('Parent props were discarded before they were computed because navigation moved elsewhere.')
-  }
-}

--- a/src/main.ts
+++ b/src/main.ts
@@ -75,7 +75,7 @@ export * from './types/useLink'
 // Errors
 export { DuplicateParamsError } from './errors/duplicateParamsError'
 export { MetaPropertyConflict } from './errors/metaPropertyConflict'
-export { ParentPropsAbandonedError } from './errors/parentPropsAbandonedError'
+export { NavigationAbandonedError } from './errors/navigationAbandonedError'
 export { RouterNotInstalledError } from './errors/routerNotInstalledError'
 export { UseRouteInvalidError } from './errors/useRouteInvalidError'
 

--- a/src/services/createNavigationStores.spec.ts
+++ b/src/services/createNavigationStores.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'vitest'
+import { createNavigationStores } from './createNavigationStores'
+import { createDataStore } from './createDataStore'
+import { NavigationAbandonedError } from '@/errors/navigationAbandonedError'
+
+describe('promote', () => {
+  test('adopts the staged store', () => {
+    const stores = createNavigationStores()
+    const staged = createDataStore()
+
+    stores.stage(staged)
+    stores.promote()
+
+    expect(stores.current()).toBe(staged)
+  })
+
+  test('starts a fresh store when nothing was staged', () => {
+    const stores = createNavigationStores()
+    const before = stores.current()
+
+    stores.promote()
+
+    expect(stores.current()).not.toBe(before)
+  })
+
+  test('hands back the store it replaced', () => {
+    const stores = createNavigationStores()
+    const before = stores.current()
+
+    expect(stores.promote()).toBe(before)
+  })
+
+  test('only adopts a staged store once', () => {
+    const stores = createNavigationStores()
+    const staged = createDataStore()
+
+    stores.stage(staged)
+    stores.promote()
+    stores.promote()
+
+    expect(stores.current()).not.toBe(staged)
+  })
+})
+
+describe('stage', () => {
+  test('disposes a store it displaces, so anything waiting on it resumes', async () => {
+    const stores = createNavigationStores()
+    const displaced = createDataStore()
+    const waiting = displaced.subscribe('key')
+
+    stores.stage(displaced)
+    stores.stage(createDataStore())
+
+    await expect(waiting).rejects.toThrow(NavigationAbandonedError)
+  })
+})

--- a/src/services/createNavigationStores.ts
+++ b/src/services/createNavigationStores.ts
@@ -1,0 +1,62 @@
+import { createDataStore, DataStore } from './createDataStore'
+import { NavigationAbandonedError } from '@/errors/navigationAbandonedError'
+import { ResolvedRoute } from '@/types/resolved'
+
+/**
+ * Which store the rendered route reads from, and which one the next navigation will adopt.
+ *
+ * A navigation gets its own store so the one it replaces can be disposed outright. A followed link stages
+ * the store it prefetched into, which the navigation it triggers picks up — staged rather than handed over
+ * directly because a link is followed before that navigation starts.
+ */
+export type NavigationStores = {
+  current: () => DataStore,
+  /**
+   * Parks a followed link's store for the navigation it triggered. A store already parked is disposed,
+   * since following a second link before the first navigation arrives abandons the first.
+   */
+  stage: (store: DataStore) => void,
+  /**
+   * Swaps in the staged store, or a fresh one, and hands back the store being replaced for disposal.
+   */
+  promote: () => DataStore,
+}
+
+/**
+ * The store in use, and the one a followed link left for the next navigation. Staging only happens when a
+ * link is followed, so starting the router, pushing directly and history navigation all leave it unset.
+ */
+type Stores = {
+  current: DataStore,
+  staged?: DataStore,
+}
+
+export function createNavigationStores(): NavigationStores {
+  const stores: Stores = { current: createDataStore() }
+
+  const current: NavigationStores['current'] = () => stores.current
+
+  const stage: NavigationStores['stage'] = (store) => {
+    stores.staged?.dispose(new NavigationAbandonedError())
+    stores.staged = store
+  }
+
+  const promote: NavigationStores['promote'] = () => {
+    const previous = stores.current
+
+    stores.current = stores.staged ?? createDataStore()
+    stores.staged = undefined
+
+    return previous
+  }
+
+  return {
+    current,
+    stage,
+    promote,
+  }
+}
+
+export function getDataKey(id: string, name: string, route: ResolvedRoute): string {
+  return [id, name, route.id, JSON.stringify(route.params)].join('-')
+}

--- a/src/services/createNavigationStores.ts
+++ b/src/services/createNavigationStores.ts
@@ -10,6 +10,9 @@ import { ResolvedRoute } from '@/types/resolved'
  * directly because a link is followed before that navigation starts.
  */
 export type NavigationStores = {
+  /**
+   * The store the rendered route reads props from.
+   */
   current: () => DataStore,
   /**
    * Parks a followed link's store for the navigation it triggered. A store already parked is disposed,

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -40,7 +40,13 @@ type SetPropsResponse = CallbackContextSuccess | CallbackContextPush | CallbackC
  * discarded otherwise.
  */
 export type PrefetchStore = {
+  /**
+   * Computes props for views whose prefetch option matches the given strategy.
+   */
   prefetch: (strategy: PrefetchStrategy, route: ResolvedRoute, configs: PrefetchConfigs) => void,
+  /**
+   * Stages the prefetched store for the next navigation to adopt.
+   */
   commit: () => void,
   /**
    * Abandons what was prefetched and starts over, for a link that now points somewhere else.
@@ -152,6 +158,8 @@ export function createPropStore(): PropStore {
       case 'value':
       case 'error':
         return result
+      default:
+        return result satisfies never
     }
   }
 
@@ -292,6 +300,10 @@ async function toResult(props: Promise<unknown>): Promise<PropsResult> {
   try {
     return { kind: 'value', value: await props }
   } catch (error) {
+    if (error instanceof NavigationAbandonedError) {
+      return NO_PROPS
+    }
+
     return { kind: 'error', error }
   }
 }

--- a/src/services/createPropStore.ts
+++ b/src/services/createPropStore.ts
@@ -1,4 +1,3 @@
-import { effectScope, reactive, watch, WatchHandle } from 'vue'
 import { PropsGetter } from '@/types/createRouteOptions'
 import type { PrefetchConfigs, PrefetchStrategy } from '@/types/prefetch'
 import { getPrefetchOption } from '@/utilities/prefetch'
@@ -7,128 +6,125 @@ import { RouteViews } from '@/types/routeViews'
 import { DEFAULT_VIEW_NAME, isWithBareViewProps, isWithViewProps } from './createRouteViews'
 import { ContextPushError } from '@/errors/contextPushError'
 import { ContextRejectionError } from '@/errors/contextRejectionError'
-import { ParentPropsAbandonedError } from '@/errors/parentPropsAbandonedError'
-import { getPropsValue, PropsResult } from '@/utilities/props'
+import { NavigationAbandonedError } from '@/errors/navigationAbandonedError'
 import { PropsCallbackParent } from '@/types/props'
-import { MaybePromise } from '@/types/utilities'
 import { createVueAppStore, HasVueAppStore } from './createVueAppStore'
 import { CallbackContextPush, CallbackContextReject, CallbackContextSuccess } from '@/types/callbackContext'
 import { createRouterCallbackContext } from './createRouterCallbackContext'
+import { createDataStore, DataStore } from './createDataStore'
+import { createNavigationStores, getDataKey } from './createNavigationStores'
+import { PropsResult } from '@/utilities/props'
+import { MaybePromise } from '@/types/utilities'
 
-type ComponentProps = { id: string, name: string, depth: number, props?: PropsGetter }
-
-type Waiter = { stop: WatchHandle, abandon: () => void }
-
-type SetPropsResponse = CallbackContextSuccess | CallbackContextPush | CallbackContextReject
-
-type StoredProps = MaybePromise<PropsResult>
-
-export type PropStore = HasVueAppStore & {
-  getPrefetchProps: (strategy: PrefetchStrategy, route: ResolvedRoute, configs: PrefetchConfigs, prefetched?: Record<string, StoredProps>) => Record<string, StoredProps>,
-  setPrefetchProps: (props: Record<string, StoredProps>) => void,
-  setProps: (route: ResolvedRoute) => Promise<SetPropsResponse>,
-  getProps: (id: string, name: string, route: ResolvedRoute) => StoredProps,
+type ViewProps = {
+  id: string,
+  name: string,
+  depth: number,
+  routePrefetch: PrefetchConfigs['routePrefetch'],
+  viewPrefetch: PrefetchConfigs['viewPrefetch'],
+  props?: PropsGetter,
 }
 
 /**
- * What a view with no props getter renders with, since such a view stores nothing.
+ * A navigation that was superseded before its props settled. The navigation that replaced it owns the
+ * outcome, so this one reports that it went nowhere rather than a success it never had.
  */
-const NO_PROPS: PropsResult = { kind: 'value', value: undefined }
+type SetPropsAbandoned = {
+  status: 'ABANDONED',
+}
+
+type SetPropsResponse = CallbackContextSuccess | CallbackContextPush | CallbackContextReject | SetPropsAbandoned
+
+/**
+ * A link's own bucket of prefetched props, handed to the current navigation when the link is followed and
+ * discarded otherwise.
+ */
+export type PrefetchStore = {
+  prefetch: (strategy: PrefetchStrategy, route: ResolvedRoute, configs: PrefetchConfigs) => void,
+  commit: () => void,
+  /**
+   * Abandons what was prefetched and starts over, for a link that now points somewhere else.
+   */
+  reset: () => void,
+  /**
+   * Abandons what was prefetched, for a link that is gone.
+   */
+  dispose: () => void,
+}
+
+export type PropStore = HasVueAppStore & {
+  createPrefetchStore: () => PrefetchStore,
+  setProps: (route: ResolvedRoute) => Promise<SetPropsResponse>,
+  getProps: (id: string, name: string, route: ResolvedRoute) => MaybePromise<PropsResult>,
+}
 
 export function createPropStore(): PropStore {
   const { setVueApp, runWithContext } = createVueAppStore()
-  const store: Map<string, StoredProps> = reactive(new Map())
-  const waiters = new Map<string, Set<Waiter>>()
+  const navigation = createNavigationStores()
 
-  /**
-   * Detached because waiters outlive the component whose prefetch created them.
-   */
-  const waiterScope = effectScope(true)
+  const createPrefetchStore: PropStore['createPrefetchStore'] = () => {
+    const link = { store: createDataStore() }
 
-  /**
-   * Seeded with props already prefetched at earlier strategies, which are not in the store until commit.
-   */
-  const getPrefetchProps: PropStore['getPrefetchProps'] = (strategy, route, prefetch, prefetched = {}) => {
-    const { push, replace, reject, update } = createRouterCallbackContext({ to: route })
+    const dispose: PrefetchStore['dispose'] = () => {
+      link.store.dispose(new NavigationAbandonedError())
+    }
 
-    return route.matches
-      .map((match, index) => ({ match, views: match.views, depth: index }))
-      .flatMap(({ match, views, depth }) => getComponentProps(match.id, views, depth).map((componentProps) => ({ match, views, componentProps })))
-      .filter(({ match, views, componentProps }) => getPrefetchOption({
-        ...prefetch,
-        routePrefetch: match.prefetch,
-        viewPrefetch: views[componentProps.name].prefetch,
-      }, 'props') === strategy)
-      .map(({ componentProps }) => componentProps)
-      .reduce<Record<string, StoredProps>>((response, { id, name, depth, props }) => {
-        if (!props) {
-          return response
+    const reset: PrefetchStore['reset'] = () => {
+      dispose()
+      link.store = createDataStore()
+    }
+
+    const prefetch: PrefetchStore['prefetch'] = (strategy, route, configs) => {
+      for (const view of getViewProps(route).filter(hasGetter)) {
+        const option = getPrefetchOption({
+          ...configs,
+          routePrefetch: view.routePrefetch,
+          viewPrefetch: view.viewPrefetch,
+        }, 'props')
+
+        if (option !== strategy) {
+          continue
         }
 
-        const key = getPropKey(id, name, route)
-        const value = runWithContext(() => getPropsValue(() => props(route, {
-          push,
-          replace,
-          reject,
-          update,
-          parent: getParentContext(route, depth, true, response),
-        })))
+        link.store.set(getPropKey(view, route), () => runGetter(view, route, link.store))
+      }
+    }
 
-        response[key] = value
+    const commit: PrefetchStore['commit'] = () => {
+      navigation.stage(link.store)
+      link.store = createDataStore()
+    }
 
-        return response
-      }, { ...prefetched })
-  }
-
-  const setPrefetchProps: PropStore['setPrefetchProps'] = (props) => {
-    Object.entries(props).forEach(([key, value]) => {
-      store.set(key, value)
-    })
+    return {
+      prefetch,
+      commit,
+      reset,
+      dispose,
+    }
   }
 
   const setProps: PropStore['setProps'] = async (route) => {
-    const { push, replace, reject, update } = createRouterCallbackContext({ to: route })
-    const componentProps = route.matches.flatMap((match, depth) => getComponentProps(match.id, match.views, depth))
-    const keys: string[] = []
-    const promises: Promise<unknown>[] = []
+    const previous = navigation.promote()
+    const store = navigation.current()
 
-    for (const { id, name, depth, props } of componentProps) {
-      if (!props) {
-        continue
-      }
+    previous.dispose(new NavigationAbandonedError())
 
-      const key = getPropKey(id, name, route)
+    const views = getViewProps(route).filter(hasGetter)
+    const keys = views.map((view) => getPropKey(view, route))
 
-      keys.push(key)
-
-      if (!store.has(key)) {
-        const value = runWithContext(() => getPropsValue(() => props(route, {
-          push,
-          replace,
-          reject,
-          update,
-          parent: getParentContext(route, depth),
-        })))
-
-        store.set(key, value)
-      }
-
-      promises.push((async () => {
-        const result = await store.get(key)
-
-        if (result?.kind === 'error') {
-          throw result.error
-        }
-      })())
-    }
-
-    clearUnusedStoreEntries(keys)
+    views.forEach((view, index) => {
+      store.set(keys[index], () => runGetter(view, route))
+    })
 
     try {
-      await Promise.all(promises)
+      await Promise.all(keys.map((key) => store.subscribe(key)))
 
       return { status: 'SUCCESS' }
     } catch (error) {
+      if (error instanceof NavigationAbandonedError) {
+        return { status: 'ABANDONED' }
+      }
+
       if (error instanceof ContextPushError) {
         return error.response
       }
@@ -142,16 +138,40 @@ export function createPropStore(): PropStore {
   }
 
   const getProps: PropStore['getProps'] = (id, name, route) => {
-    const key = getPropKey(id, name, route)
+    const key = getDataKey(id, name, route)
+    const result = navigation.current().get(key)
 
-    return store.get(key) ?? NO_PROPS
+    switch (result.kind) {
+      case 'missing':
+        return NO_PROPS
+
+      case 'pending':
+      case 'running':
+        return toResult(navigation.current().subscribe(key))
+
+      case 'value':
+      case 'error':
+        return result
+    }
+  }
+
+  function runGetter(view: ViewProps & { props: PropsGetter }, route: ResolvedRoute, store?: DataStore): unknown {
+    const { push, replace, reject, update } = createRouterCallbackContext({ to: route })
+
+    return runWithContext(() => view.props(route, {
+      push,
+      replace,
+      reject,
+      update,
+      parent: getParentContext(route, view.depth, store),
+    }))
   }
 
   /**
-   * The parent context for the view at the given depth. Must be resolved per depth rather than from the
-   * last match: every view in a nested route gets its own parent, not the resolved route's parent.
+   * The parent context for the view at the given depth. Resolved per depth rather than from the last
+   * match: every view in a nested route gets its own parent, not the resolved route's parent.
    */
-  function getParentContext(route: ResolvedRoute, depth: number, prefetch: boolean = false, pending?: Record<string, StoredProps>): PropsCallbackParent {
+  function getParentContext(route: ResolvedRoute, depth: number, store?: DataStore): PropsCallbackParent {
     if (depth === 0) {
       return
     }
@@ -163,7 +183,7 @@ export function createPropStore(): PropStore {
       return {
         name: parentName,
         get props() {
-          return getParentProps(parentMatch.id, DEFAULT_VIEW_NAME, route, prefetch, pending)
+          return getParentProps(parentMatch.id, DEFAULT_VIEW_NAME, route, store)
         },
       }
     }
@@ -173,12 +193,12 @@ export function createPropStore(): PropStore {
         name: parentName,
         props: new Proxy({}, {
           get(target, propName) {
-            // a name with no getter can never be stored, so waiting on it would never settle
+            // a name with no getter is never computed, so waiting on it would never settle
             if (typeof propName !== 'string' || !(propName in parentViews) || !parentViews[propName].props) {
               return Reflect.get(target, propName)
             }
 
-            return getParentProps(parentMatch.id, propName, route, prefetch, pending)
+            return getParentProps(parentMatch.id, propName, route, store)
           },
         }),
       }
@@ -191,143 +211,102 @@ export function createPropStore(): PropStore {
   }
 
   /**
-   * Reads a parent view's props, checking the batch being prefetched before the store, and waiting for the
-   * parent's own lifecycle to compute them when neither has them yet.
+   * A parent's props resolve from whichever arrives first, the prefetching this getter belongs to or the
+   * navigation, so a getter never has to know which of the two will compute them.
    */
-  function getParentProps(id: string, name: string, route: ResolvedRoute, prefetch: boolean = false, pending?: Record<string, StoredProps>): Promise<unknown> {
-    const props = readParentProps(id, name, route, prefetch, pending)
+  function getParentProps(id: string, name: string, route: ResolvedRoute, store?: DataStore): Promise<unknown> {
+    const key = getDataKey(id, name, route)
 
-    // reading without awaiting must not surface as an unhandled rejection
+    if (!store) {
+      return navigation.current().subscribe(key)
+    }
+
+    if (store.get(key).kind === 'missing' && navigation.current().get(key).kind === 'missing') {
+      warnWaitingForParentProps(name, route)
+    }
+
+    const props = firstToArrive([
+      store.subscribe(key),
+      navigation.current().subscribe(key),
+    ])
+
+    // firstToArrive derives a new promise, so the handler the store attached does not cover it
     props.catch(() => {})
 
     return props
   }
 
-  function readParentProps(id: string, name: string, route: ResolvedRoute, prefetch: boolean, pending?: Record<string, StoredProps>): Promise<unknown> {
-    const key = getPropKey(id, name, route)
-    const batched = pending?.[key]
-
-    if (batched !== undefined) {
-      return toParentProps(batched)
-    }
-
-    const stored = store.get(key)
-
-    if (stored !== undefined) {
-      return toParentProps(stored)
-    }
-
-    if (prefetch) {
-      warnWaitingForParentProps(name, route)
-    }
-
-    return toParentProps(waitForProps(key))
+  function getViewProps(route: ResolvedRoute): ViewProps[] {
+    return route.matches.flatMap((match, depth) => viewsToProps(match.id, match.views, depth, match.prefetch))
   }
 
-  /**
-   * Resolves once the given props are stored, and rejects if navigation discards the waiter first, so a
-   * getter awaiting them resumes either way.
-   */
-  function waitForProps(key: string): Promise<PropsResult> {
-    return new Promise((resolve, reject) => {
-      const stops = waiters.get(key) ?? new Set<Waiter>()
-
-      waiters.set(key, stops)
-
-      waiterScope.run(() => {
-        const waiter: Waiter = {
-          stop: watch(() => store.get(key), (result) => {
-            if (result === undefined) {
-              return
-            }
-
-            discardWaiter(key, waiter)
-            resolve(result)
-          }),
-          abandon: () => reject(new ParentPropsAbandonedError()),
-        }
-
-        stops.add(waiter)
-      })
-    })
+  function viewsToProps(id: string, views: RouteViews, depth: number, routePrefetch: PrefetchConfigs['routePrefetch']): ViewProps[] {
+    return Object.entries(views).map(([name, view]) => ({
+      id,
+      name,
+      depth,
+      routePrefetch,
+      viewPrefetch: view.prefetch,
+      props: view.props as PropsGetter | undefined,
+    }))
   }
 
-  function discardWaiter(key: string, waiter: Waiter): void {
-    waiter.stop()
-
-    const stops = waiters.get(key)
-
-    stops?.delete(waiter)
-
-    if (stops?.size === 0) {
-      waiters.delete(key)
-    }
-  }
-
-  function discardUnusedWaiters(keysToKeep: string[]): void {
-    for (const [key, stops] of waiters) {
-      if (keysToKeep.includes(key)) {
-        continue
-      }
-
-      stops.forEach((waiter) => {
-        waiter.stop()
-        waiter.abandon()
-      })
-
-      waiters.delete(key)
-    }
-  }
-
-  function warnWaitingForParentProps(name: string, route: ResolvedRoute): void {
-    const routeName = route.name || 'unknown'
-
-    console.warn(`
-      Waiting on parent props "${name}" while prefetching props for route "${routeName}".
-      The parent's props are not being prefetched at this point, so these props cannot resolve until the
-      parent's props are computed — either by the parent's own prefetch strategy or by navigating.
-      Prefetch the parent's props with the same strategy to avoid stalling here.
-    `)
-  }
-
-  /**
-   * Always a promise, since the props may not have been computed yet. Rethrows a failed getter's error.
-   */
-  async function toParentProps(result: MaybePromise<PropsResult>): Promise<unknown> {
-    const resolved = await result
-
-    if (resolved.kind === 'error') {
-      throw resolved.error
-    }
-
-    return resolved.value
-  }
-
-  function getPropKey(id: string, name: string, route: ResolvedRoute): string {
-    return [id, name, route.id, JSON.stringify(route.params)].join('-')
-  }
-
-  function getComponentProps(id: string, views: RouteViews, depth: number): ComponentProps[] {
-    return Object.entries(views).map(([name, view]) => ({ id, name, depth, props: view.props as PropsGetter | undefined }))
-  }
-
-  function clearUnusedStoreEntries(keysToKeep: string[]): void {
-    for (const key of store.keys()) {
-      if (keysToKeep.includes(key)) {
-        continue
-      }
-
-      store.delete(key)
-    }
-
-    discardUnusedWaiters(keysToKeep)
+  function getPropKey(view: ViewProps, route: ResolvedRoute): string {
+    return getDataKey(view.id, view.name, route)
   }
 
   return {
-    getPrefetchProps,
-    setPrefetchProps,
-    getProps,
+    createPrefetchStore,
     setProps,
+    getProps,
     setVueApp,
   }
+}
+
+/**
+ * The first source to produce a value. Both failing surfaces a real getter error over an abandonment,
+ * since abandonment only says nobody is computing that source any more.
+ */
+async function firstToArrive(sources: Promise<unknown>[]): Promise<unknown> {
+  try {
+    return await Promise.any(sources)
+  } catch (error) {
+    if (error instanceof AggregateError) {
+      throw error.errors.find((reason) => !(reason instanceof NavigationAbandonedError)) ?? error.errors[0]
+    }
+
+    throw error
+  }
+}
+
+/**
+ * What a view with no props getter renders with, since such a view stores nothing.
+ */
+const NO_PROPS: PropsResult = { kind: 'value', value: undefined }
+
+/**
+ * The render layer expects every outcome as a value it can inspect, so a rejection is folded back into a
+ * result rather than being handed on as one.
+ */
+async function toResult(props: Promise<unknown>): Promise<PropsResult> {
+  try {
+    return { kind: 'value', value: await props }
+  } catch (error) {
+    return { kind: 'error', error }
+  }
+}
+
+function hasGetter(view: ViewProps): view is ViewProps & { props: PropsGetter } {
+  return Boolean(view.props)
+}
+
+function warnWaitingForParentProps(name: string, route: ResolvedRoute): void {
+  const routeName = route.name || 'unknown'
+
+  console.warn(`
+    Waiting on parent props "${name}" while prefetching props for route "${routeName}".
+    The parent's props are not being prefetched at this point, so these props cannot resolve until the
+    parent's props are computed — either by the parent's own prefetch strategy or by navigating.
+    Prefetch the parent's props with the same strategy to avoid stalling here.
+  `)
 }

--- a/src/services/createRoute.spec.ts
+++ b/src/services/createRoute.spec.ts
@@ -1,4 +1,5 @@
 import { flushPromises } from '@vue/test-utils'
+import echo from '@/components/echo'
 import { describe, expect, test, vi } from 'vitest'
 import { createRoute } from '@/services/createRoute'
 import { component } from '@/utilities/testHelpers'
@@ -197,6 +198,30 @@ describe('combine', () => {
 })
 
 describe('props', () => {
+  test('a navigation superseded before its props settle does not report an error', async () => {
+    const { promise, resolve } = Promise.withResolvers<{ value: string }>()
+    const onError = vi.fn()
+
+    const slow = createRoute({ name: 'slow', path: '/slow', component: echo }, () => promise)
+    const other = createRoute({ name: 'other', path: '/other', component: echo }, () => ({ value: 'other' }))
+    const home = createRoute({ name: 'home', path: '/', component: echo }, () => ({ value: 'home' }))
+
+    const router = createRouter([home, slow, other], { initialUrl: '/' })
+
+    router.onError(onError)
+
+    await router.start()
+
+    // leave slow's props in flight, then supersede it
+    void router.push('slow')
+    await router.push('other')
+
+    resolve({ value: 'slow' })
+    await flushPromises()
+
+    expect(onError).not.toHaveBeenCalled()
+  })
+
   test('parent context is passed to child props', async () => {
     const spy = vi.fn()
     const parent = createRoute({

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -203,6 +203,7 @@ export function createRouter<
 
         switch (response.status) {
           case 'SUCCESS':
+          case 'ABANDONED':
             break
 
           case 'PUSH':


### PR DESCRIPTION
# Description

Second step of #805, stacked on #806. No behaviour changes — every existing test passes unchanged.

Props move onto the store added in #806, one store per navigation. A link prefetches into its own store and stages it when followed; the navigation it triggers adopts that store, and the one it replaces is disposed outright rather than picked over for entries the new route still needs.

A getter waiting on its parent now awaits a value rather than watching for one to appear:

```ts
await Promise.any([
  own.subscribe(parentKey),                  // the parent's props, if this link prefetches them
  navigation.current().subscribe(parentKey), // or the ones navigation computes
])
```

That removes the waiter machinery entirely — the detached effect scope, the watch handles, and the bookkeeping to discard them. Prefetch strategies also stop being separate buckets, so a value prefetched on render is visible to a getter that runs on hover without being passed along explicitly.
