### PR TITLE
Drop a navigation guard that never fired

### DIFF
--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -165,7 +165,7 @@ export function createRouter<
     }
 
     if (!isExternal(url)) {
-      setPropsAndUpdateRoute(navigationId, to, from)
+      setPropsAndUpdateRoute(to, from)
     }
 
     const afterResponse = await hooks.runAfterRouteHooks({ to, from })
@@ -192,15 +192,9 @@ export function createRouter<
     history.startListening()
   }
 
-  function setPropsAndUpdateRoute(navigationId: string, to: ResolvedRoute, from: ResolvedRoute | null): void {
-    const currentNavigationId = navigationId
-
+  function setPropsAndUpdateRoute(to: ResolvedRoute, from: ResolvedRoute | null): void {
     propStore.setProps(to)
       .then((response) => {
-        if (currentNavigationId !== navigationId) {
-          return
-        }
-
         switch (response.status) {
           case 'SUCCESS':
           case 'ABANDONED':


### PR DESCRIPTION
# Description

Stacked on #807. No behaviour change — the code being removed never ran.

`setPropsAndUpdateRoute` held a guard meant to stop a superseded navigation from acting on props that arrived late:

```ts
const currentNavigationId = navigationId

propStore.setProps(to).then((response) => {
  if (currentNavigationId !== navigationId) {
    return
  }
```

`navigationId` is a parameter and is never reassigned, so the comparison was always false. It has been that way since it was introduced in ae08389e, which set out to "prevent outdated props from triggering context errors" — a real problem the guard never actually prevented.

That job is now done properly: a navigation whose props are discarded returns `ABANDONED`, which #807 added along with the first test covering the behaviour. With the guard gone the parameter is unused, so it goes too.
