### PR TITLE
Give every match a loaders record

### DIFF
--- a/src/services/createExternalRoute.ts
+++ b/src/services/createExternalRoute.ts
@@ -39,7 +39,7 @@ export function createExternalRoute(options: CreateRouteOptions & (WithoutHost |
   const redirects = createRouteRedirects({
     getRoute: () => route,
   })
-  const rawRoute = markRaw({ id, meta: {}, state: {}, ...options, views: {} })
+  const rawRoute = markRaw({ id, meta: {}, state: {}, ...options, views: {}, loaders: {} })
 
   const url = createUrl({
     host,

--- a/src/services/createRoute.ts
+++ b/src/services/createRoute.ts
@@ -45,7 +45,7 @@ export function createRoute(options: CreateRouteOptions, props?: CreateRouteProp
   const { store, redirect, ...hooks } = createRouteHooks()
   const { setTitle, getTitle } = createRouteTitle(options.parent)
   const views = createRouteViews(options, props)
-  const rawRoute = markRaw({ ...options, id, meta, state, name, views })
+  const rawRoute = markRaw({ ...options, id, meta, state, name, views, loaders: {} })
 
   const redirects = createRouteRedirects({
     getRoute: () => route,

--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -158,6 +158,11 @@ type ToMatch<
    * The views this route renders, keyed by view name.
    */
   views: PropsToViews<TProps>,
+  /**
+   * The loaders this route runs, keyed by loader name. Always empty here — loaders are only added via
+   * the route's `addLoader`.
+   */
+  loaders: {},
 }
 
 /**

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -11,6 +11,7 @@ import { GetRouteTitle } from '@/types/routeTitle'
 import { Hooks } from '@/models/hooks'
 import { RouteRedirect } from './redirects'
 import { RouteViews } from '@/types/routeViews'
+import { LoadersDataReturnType, RouteLoaders } from '@/types/routeLoaders'
 
 export const IS_ROUTE_SYMBOL = Symbol('IS_ROUTE_SYMBOL')
 
@@ -32,12 +33,14 @@ export type RouteInternal = {
 export type Routes = readonly Route[]
 
 /**
- * The Route properties originally provided to `createRoute`, plus the views that route renders. The
- * deprecated `component`/`components` options are folded into `views` (see {@link RouteViews}).
+ * The Route properties originally provided to `createRoute`, plus the views that route renders and the
+ * loaders it runs. The deprecated `component`/`components` options are folded into `views` (see
+ * {@link RouteViews}).
  */
 export type CreatedRouteOptions = Omit<CreateRouteOptions, 'component' | 'components'> & {
   id: string,
   views: RouteViews,
+  loaders: RouteLoaders,
 }
 
 // `matches` is a complete per-depth snapshot of the options each route was created with, so the
@@ -72,6 +75,24 @@ type RouteStateOf<TMatches extends CreatedRouteOptions[]> = CreatedRouteOptions[
   : TMatches extends [infer THead, ...infer TRest extends CreatedRouteOptions[]]
     ? (THead extends { state: infer TState extends Record<string, Param> } ? ToState<TState> : {}) & RouteStateOf<TRest>
     : {}
+
+/**
+ * The loaders of every matched route, combined. A plain intersection: a loader name is unique across a
+ * route and its ancestors, which `addLoader` enforces.
+ */
+type RouteLoadersOf<TMatches extends CreatedRouteOptions[]> = CreatedRouteOptions[] extends TMatches
+  ? RouteLoaders
+  : TMatches extends [infer THead, ...infer TRest extends CreatedRouteOptions[]]
+    ? (THead extends { loaders: infer TLoaders extends RouteLoaders } ? TLoaders : {}) & RouteLoadersOf<TRest>
+    : {}
+
+/**
+ * The data every matched route's loaders resolve to, which is what a resolved route exposes as `data`.
+ * Undefined when nothing in the route tree declares a loader.
+ */
+export type RouteDataOf<TMatches extends CreatedRouteOptions[]> = CreatedRouteOptions[] extends TMatches
+  ? Record<string, Promise<unknown>> | undefined
+  : LoadersDataReturnType<RouteLoadersOf<TMatches>>
 
 /**
  * The context of every matched route, flattened from greatest ancestor to narrowest matched.

--- a/src/types/routeLoaders.ts
+++ b/src/types/routeLoaders.ts
@@ -1,0 +1,31 @@
+import { PrefetchConfig } from '@/types/prefetch'
+import { AnyFunction } from '@/types/utilities'
+
+/**
+ * A single loader: how to load its data, and how to prefetch it. Unlike a view, a loader always has a
+ * getter — a loader without one would have nothing to contribute.
+ *
+ * @template TData - What this loader's getter returns, carried so a route's data can be typed from it.
+ */
+export type RouteLoader<TData = unknown> = {
+  load: AnyFunction<TData>,
+  prefetch?: PrefetchConfig,
+}
+
+/**
+ * The loaders for a single route, keyed by loader name (the unnamed loader under 'default').
+ */
+export type RouteLoaders = Record<string, RouteLoader<unknown>>
+
+/**
+ * The data a set of loaders resolves to. A lone unnamed loader is given directly rather than under a
+ * 'default' key, matching how the loader is written. Each loader's data is always a promise, since a
+ * loader never blocks rendering, even when the loader itself is synchronous.
+ */
+export type LoadersDataReturnType<TLoaders> = keyof TLoaders extends never
+  ? undefined
+  : keyof TLoaders extends 'default'
+    ? LoaderData<Extract<TLoaders, { default: unknown }>['default']>
+    : { [K in keyof TLoaders]: LoaderData<TLoaders[K]> }
+
+type LoaderData<TLoader> = TLoader extends { load: AnyFunction<infer TData> } ? Promise<Awaited<TData>> : never


### PR DESCRIPTION
# Description

Third step of #805, stacked on #809. No behaviour changes — nothing reads these records yet.

Loaders are a route's data, declared the way views are declared but with no component attached and no hold on rendering. Storing them per match, alongside views, means a route's data can be derived from its matches the same way its views already are — including an ancestor's loaders, which a child should be able to use as its own.

`route.data` is that derivation: the loaders of every match combined, flattened to the loader's data directly when the only loader in the tree is unnamed. This PR adds the types and the empty record; the method that fills it and the store that runs it follow.