### PR TITLE
Add loaders to routes with a chainable addLoader

### DIFF
--- a/src/errors/loaderNameConflict.ts
+++ b/src/errors/loaderNameConflict.ts
@@ -1,0 +1,11 @@
+/**
+ * An error thrown when a loader is added with the same name as a loader on one of the route's ancestors.
+ * A route's data combines the loaders of every match, so the same name twice would be ambiguous rather
+ * than an override.
+ * @group Errors
+ */
+export class LoaderNameConflict extends Error {
+  public constructor(name?: string) {
+    super(`Loader "${name}" conflicts with a loader of the same name on an ancestor route.`)
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,7 +16,14 @@ export type {
   AddViewPropsGetter,
   AddViewPropsCallbackContext
 } from './types/addView'
+export type {
+  RouteAddLoader,
+  AddLoaderOptions,
+  LoaderGetter
+} from './types/addLoader'
+export type { RouteCallbackContext } from './types/routeCallbackContext'
 export type { RouteViews } from './types/routeViews'
+export type { RouteLoader, RouteLoaders } from './types/routeLoaders'
 export type {
   RejectionHooks,
   HookRemove,
@@ -74,6 +81,7 @@ export * from './types/useLink'
 
 // Errors
 export { DuplicateParamsError } from './errors/duplicateParamsError'
+export { LoaderNameConflict } from './errors/loaderNameConflict'
 export { MetaPropertyConflict } from './errors/metaPropertyConflict'
 export { NavigationAbandonedError } from './errors/navigationAbandonedError'
 export { RouterNotInstalledError } from './errors/routerNotInstalledError'

--- a/src/services/addLoader.spec-d.ts
+++ b/src/services/addLoader.spec-d.ts
@@ -1,0 +1,118 @@
+import { describe, expectTypeOf, test } from 'vitest'
+import { createRoute } from './createRoute'
+import { RouteLoader } from '@/types/routeLoaders'
+import { BuiltInRejectionType } from '@/types/rejection'
+import { component } from '@/utilities/testHelpers'
+import { RouteView } from '@/types/routeViews'
+
+type User = { id: string, name: string }
+
+describe('addLoader', () => {
+  test('an async loader carries what it returns', () => {
+    const route = createRoute({ name: 'route' }).addLoader(async (): Promise<User> => ({ id: '1', name: 'kitbag' }))
+
+    expectTypeOf<typeof route['matches'][0]['loaders']>().toEqualTypeOf<{ default: RouteLoader<Promise<User>> }>()
+  })
+
+  test('a sync loader carries what it returns', () => {
+    const route = createRoute({ name: 'route' }).addLoader(() => 'kitbag')
+
+    expectTypeOf<typeof route['matches'][0]['loaders']>().toEqualTypeOf<{ default: RouteLoader<string> }>()
+  })
+
+  test('a named loader is carried under its name', () => {
+    const route = createRoute({ name: 'route' }).addLoader(async (): Promise<User> => ({ id: '1', name: 'kitbag' }), {
+      name: 'user',
+    })
+
+    expectTypeOf<typeof route['matches'][0]['loaders']>().toEqualTypeOf<{ user: RouteLoader<Promise<User>> }>()
+  })
+
+  test('multiple loaders accumulate', () => {
+    const route = createRoute({ name: 'route' })
+      .addLoader(async (): Promise<User> => ({ id: '1', name: 'kitbag' }))
+      .addLoader(() => [1, 2], { name: 'posts' })
+
+    expectTypeOf<typeof route['matches'][0]['loaders']>().toEqualTypeOf<{
+      default: RouteLoader<Promise<User>>,
+      posts: RouteLoader<number[]>,
+    }>()
+  })
+
+  test('a loader added under a name the route already used replaces it', () => {
+    const route = createRoute({ name: 'route' })
+      .addLoader(() => 'first', { name: 'user' })
+      .addLoader(() => 1, { name: 'user' })
+
+    expectTypeOf<typeof route['matches'][0]['loaders']>().toEqualTypeOf<{ user: RouteLoader<number> }>()
+  })
+
+  test('prefetch does not affect what the loader carries', () => {
+    const route = createRoute({ name: 'route' }).addLoader(() => 'kitbag', {
+      prefetch: 'eager',
+    })
+
+    expectTypeOf<typeof route['matches'][0]['loaders']>().toEqualTypeOf<{ default: RouteLoader<string> }>()
+  })
+
+  test('a loader leaves the route views untouched', () => {
+    const route = createRoute({ name: 'route' })
+      .addView(component)
+      .addLoader(() => 'kitbag')
+
+    expectTypeOf<typeof route['matches'][0]['views']>().toEqualTypeOf<{ default: RouteView }>()
+    expectTypeOf<typeof route['matches'][0]['loaders']>().toEqualTypeOf<{ default: RouteLoader<string> }>()
+  })
+
+  test('a view added after a loader keeps the loader', () => {
+    const route = createRoute({ name: 'route' })
+      .addLoader(() => 'kitbag')
+      .addView(component, {
+        props: () => ({ foo: 'bar' }),
+      })
+
+    expectTypeOf<typeof route['matches'][0]['views']>().toEqualTypeOf<{ default: RouteView<{ foo: string }> }>()
+    expectTypeOf<typeof route['matches'][0]['loaders']>().toEqualTypeOf<{ default: RouteLoader<string> }>()
+  })
+
+  test('an ancestor loader stays on the ancestor match', () => {
+    const parent = createRoute({ name: 'parent', path: '/parent' }).addLoader(() => 'kitbag')
+    const child = createRoute({ parent, name: 'child', path: '/child' }).addLoader(() => 1, { name: 'posts' })
+
+    expectTypeOf<typeof child['matches'][0]['loaders']>().toEqualTypeOf<{ default: RouteLoader<string> }>()
+    expectTypeOf<typeof child['matches'][1]['loaders']>().toEqualTypeOf<{ posts: RouteLoader<number> }>()
+  })
+})
+
+describe('loader callback', () => {
+  test('the route argument is the resolved route, with params', () => {
+    createRoute({ name: 'route', path: '/route/[id]' }).addLoader((route) => {
+      expectTypeOf(route.params.id).toEqualTypeOf<string>()
+
+      return route.params.id
+    })
+  })
+
+  test('the context includes the navigation helpers and the parent', () => {
+    const parent = createRoute({ name: 'parent', path: '/parent' }).addView(component, {
+      props: (): { foo: string } => ({ foo: 'bar' }),
+    })
+
+    createRoute({ parent, name: 'child', path: '/child/[id]' }).addLoader(async (_route, context) => {
+      expectTypeOf<Parameters<typeof context.reject>[0]>().toEqualTypeOf<BuiltInRejectionType>()
+      expectTypeOf(context.parent.name).toEqualTypeOf<'parent'>()
+
+      context.push('child', { id: 'value' })
+      context.replace('child', { id: 'value' })
+      context.update('id', 'value')
+
+      // @ts-expect-error should not accept a route the route has no context for
+      context.push('unrelated')
+
+      // @ts-expect-error should not accept an invalid param name
+      context.update('invalidParamName', 'value')
+
+      return await context.parent.props
+    })
+  })
+})

--- a/src/services/addLoader.spec.ts
+++ b/src/services/addLoader.spec.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from 'vitest'
+import { createRoute } from '@/services/createRoute'
+import { LoaderNameConflict } from '@/errors/loaderNameConflict'
+import { RouteLoaders } from '@/types/routeLoaders'
+import { RouteViews } from '@/types/routeViews'
+import { component } from '@/utilities/testHelpers'
+
+const load = (): { foo: string } => ({ foo: 'bar' })
+const other = (): { baz: number } => ({ baz: 1 })
+
+function lastMatch(route: { matches: { loaders: RouteLoaders, views: RouteViews }[] }): { loaders: RouteLoaders, views: RouteViews } {
+  return route.matches[route.matches.length - 1]
+}
+
+function pick(route: { matches: { loaders: RouteLoaders, views: RouteViews }[] }, key: 'load' | 'prefetch'): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(lastMatch(route).loaders)
+      .filter(([, loader]) => loader[key] !== undefined)
+      .map(([name, loader]) => [name, loader[key]]),
+  )
+}
+
+describe('loaders', () => {
+  test('a loader added without a name is stored under "default"', () => {
+    const route = createRoute({ name: 'route' }).addLoader(load)
+
+    expect(pick(route, 'load')).toStrictEqual({ default: load })
+  })
+
+  test('a named loader is stored under its name', () => {
+    const route = createRoute({ name: 'route' }).addLoader(load, { name: 'posts' })
+
+    expect(pick(route, 'load')).toStrictEqual({ posts: load })
+  })
+
+  test('multiple loaders accumulate in the same loaders entry', () => {
+    const route = createRoute({ name: 'route' })
+      .addLoader(load)
+      .addLoader(other, { name: 'posts' })
+
+    expect(pick(route, 'load')).toStrictEqual({ default: load, posts: other })
+  })
+
+  test('a route starts with no loaders', () => {
+    const route = createRoute({ name: 'route' })
+
+    expect(lastMatch(route).loaders).toStrictEqual({})
+  })
+
+  test('adding a loader under a name the route already used overrides it', () => {
+    const route = createRoute({ name: 'route' })
+      .addLoader(load, { name: 'posts' })
+      .addLoader(other, { name: 'posts' })
+
+    expect(pick(route, 'load')).toStrictEqual({ posts: other })
+  })
+})
+
+describe('prefetch', () => {
+  test('prefetch is stored under the loader name', () => {
+    const route = createRoute({ name: 'route' }).addLoader(load, { prefetch: false })
+
+    expect(pick(route, 'prefetch')).toStrictEqual({ default: false })
+  })
+
+  test('each loader keeps its own prefetch config', () => {
+    const route = createRoute({ name: 'route' })
+      .addLoader(load, { prefetch: 'eager' })
+      .addLoader(other, { name: 'posts', prefetch: false })
+
+    expect(pick(route, 'prefetch')).toStrictEqual({ default: 'eager', posts: false })
+  })
+
+  test('loaders without a prefetch config are left absent', () => {
+    const route = createRoute({ name: 'route' })
+      .addLoader(load)
+      .addLoader(other, { name: 'posts', prefetch: 'intent' })
+
+    expect(pick(route, 'prefetch')).toStrictEqual({ posts: 'intent' })
+  })
+})
+
+describe('ancestor conflicts', () => {
+  test('a loader with the same name as an ancestor throws', () => {
+    const parent = createRoute({ name: 'parent', path: '/parent' }).addLoader(load)
+    const child = createRoute({ parent, name: 'child', path: '/child' })
+
+    expect(() => child.addLoader(other)).toThrow(LoaderNameConflict)
+  })
+
+  test('a named loader with the same name as an ancestor throws', () => {
+    const parent = createRoute({ name: 'parent', path: '/parent' }).addLoader(load, { name: 'posts' })
+    const child = createRoute({ parent, name: 'child', path: '/child' })
+
+    expect(() => child.addLoader(other, { name: 'posts' })).toThrow(LoaderNameConflict)
+  })
+
+  test('a loader with a name no ancestor uses is added', () => {
+    const parent = createRoute({ name: 'parent', path: '/parent' }).addLoader(load)
+    const child = createRoute({ parent, name: 'child', path: '/child' }).addLoader(other, { name: 'posts' })
+
+    expect(pick(child, 'load')).toStrictEqual({ posts: other })
+    expect(child.matches[0].loaders).toStrictEqual({ default: { load, prefetch: undefined } })
+  })
+})
+
+describe('immutability + chaining', () => {
+  test('addLoader returns a new route without mutating the original', () => {
+    const route = createRoute({ name: 'route' })
+    const withLoader = route.addLoader(load)
+
+    expect(withLoader).not.toBe(route)
+    expect(pick(route, 'load')).toStrictEqual({})
+    expect(pick(withLoader, 'load')).toStrictEqual({ default: load })
+  })
+
+  test('adding a view after a loader keeps both', () => {
+    const route = createRoute({ name: 'route' })
+      .addLoader(load)
+      .addView(component)
+
+    expect(pick(route, 'load')).toStrictEqual({ default: load })
+    expect(lastMatch(route).views.default.component).toBe(component)
+  })
+
+  test('adding a loader after a view keeps both', () => {
+    const route = createRoute({ name: 'route' })
+      .addView(component)
+      .addLoader(load)
+
+    expect(pick(route, 'load')).toStrictEqual({ default: load })
+    expect(lastMatch(route).views.default.component).toBe(component)
+  })
+
+  test('addLoader on a child returns the merged route with its ancestors', () => {
+    const parent = createRoute({ name: 'parent', path: '/parent' })
+    const child = createRoute({ name: 'child', parent, path: '/child' })
+
+    const withLoader = child.addLoader(load)
+
+    expect(withLoader.name).toBe('child')
+    expect(withLoader.matches).toHaveLength(2)
+    expect(pick(withLoader, 'load')).toStrictEqual({ default: load })
+  })
+})

--- a/src/services/addLoader.ts
+++ b/src/services/addLoader.ts
@@ -1,0 +1,67 @@
+import { markRaw } from 'vue'
+import { LoaderNameConflict } from '@/errors/loaderNameConflict'
+import { PrefetchConfig } from '@/types/prefetch'
+import { CreatedRouteOptions, Route } from '@/types/route'
+import { AnyFunction } from '@/types/utilities'
+
+export const DEFAULT_LOADER_NAME = 'default'
+
+/**
+ * The loose runtime shape of the `addLoader` options. Purposely wide: the name type each
+ * `RouteAddLoader` describes is refined per route.
+ */
+type LoaderOptions = {
+  name?: string,
+  prefetch?: PrefetchConfig,
+}
+
+/**
+ * The runtime arguments accepted by `addLoader`.
+ */
+type AddLoaderParameters = [load: AnyFunction, options?: LoaderOptions]
+
+/**
+ * The loose runtime signature of the `addLoader` method. Purposely wide: it returns Route rather than the
+ * refined chainable route each `RouteAddLoader` overload describes.
+ */
+export type AddLoader = (...args: AddLoaderParameters) => Route
+
+type Loader = {
+  name: string,
+  load: AnyFunction,
+  prefetch: PrefetchConfig | undefined,
+}
+
+export function toLoader(load: AnyFunction, options: LoaderOptions | undefined): Loader {
+  return {
+    name: options?.name ?? DEFAULT_LOADER_NAME,
+    load,
+    prefetch: options?.prefetch,
+  }
+}
+
+/**
+ * Returns a new match with the loader merged into its loaders under the loader's name.
+ *
+ * Matches are `markRaw` so that making a route reactive does not turn its loaders into reactive proxies.
+ * Spreading a match drops that, so the rebuilt one is marked again.
+ */
+export function addLoaderToMatch(match: CreatedRouteOptions, { name, load, prefetch }: Loader): CreatedRouteOptions {
+  return markRaw({
+    ...match,
+    loaders: {
+      ...match.loaders,
+      [name]: { load, prefetch },
+    },
+  })
+}
+
+/**
+ * A route's data combines the loaders of every match, so a name an ancestor already uses would be
+ * ambiguous. Adding a loader the route itself already has is an override, and allowed.
+ */
+export function checkForLoaderConflict(ancestors: CreatedRouteOptions[], name: string): void {
+  if (ancestors.some((ancestor) => name in ancestor.loaders)) {
+    throw new LoaderNameConflict(name)
+  }
+}

--- a/src/services/addView.ts
+++ b/src/services/addView.ts
@@ -19,6 +19,12 @@ type ViewOptions = {
  */
 type AddViewParameters = [component: Component, options?: ViewOptions]
 
+/**
+ * The loose runtime signature of the `addView` method. Purposely wide: it returns Route rather than the
+ * refined chainable route each `RouteAddView` overload describes.
+ */
+export type AddView = (...args: AddViewParameters) => Route
+
 type View = {
   name: string,
   component: Component,
@@ -26,7 +32,7 @@ type View = {
   prefetch: PrefetchConfig | undefined,
 }
 
-function toView(component: Component, options: ViewOptions | undefined): View {
+export function toView(component: Component, options: ViewOptions | undefined): View {
   return {
     name: options?.name ?? DEFAULT_VIEW_NAME,
     component,
@@ -41,7 +47,7 @@ function toView(component: Component, options: ViewOptions | undefined): View {
  * Matches are `markRaw` so that making a route reactive does not turn its components into reactive
  * proxies. Spreading a match drops that, so the rebuilt one is marked again.
  */
-function addViewToMatch(match: CreatedRouteOptions, { name, component, props, prefetch }: View): CreatedRouteOptions {
+export function addViewToMatch(match: CreatedRouteOptions, { name, component, props, prefetch }: View): CreatedRouteOptions {
   return markRaw({
     ...match,
     views: {
@@ -49,38 +55,4 @@ function addViewToMatch(match: CreatedRouteOptions, { name, component, props, pr
       [name]: { component, props, prefetch },
     },
   })
-}
-
-/**
- * The loose runtime signature of the `addView` method. Purposely wide: it returns Route rather than the
- * refined chainable route each `RouteAddView` overload describes.
- */
-type AddView = (...args: AddViewParameters) => Route
-
-/**
- * Attaches a chainable, immutable `addView` method to a route. Each call adds a view to the route's own
- * (last) `views` entry and returns a new route with the view merged in and `addView` re-attached — no
- * mutation of the input route.
- */
-export function withAddView<TRoute extends Route>(route: TRoute): TRoute {
-  const addView: AddView = (component, options) => {
-    const view = toView(component, options)
-    const currentMatch = route.matches.at(-1)
-
-    if (!currentMatch) {
-      return withAddView(route)
-    }
-
-    const nextMatch = addViewToMatch(currentMatch, view)
-
-    return withAddView({
-      ...route,
-      matches: [...route.matches.slice(0, -1), nextMatch],
-    })
-  }
-
-  return {
-    ...route,
-    addView,
-  }
 }

--- a/src/services/createExternalRoute.ts
+++ b/src/services/createExternalRoute.ts
@@ -39,7 +39,7 @@ export function createExternalRoute(options: CreateRouteOptions & (WithoutHost |
   const redirects = createRouteRedirects({
     getRoute: () => route,
   })
-  const rawRoute = markRaw({ id, meta: {}, state: {}, ...options, views: {} })
+  const rawRoute = markRaw({ id, meta: {}, state: {}, ...options, views: {}, loaders: {} })
 
   const url = createUrl({
     host,

--- a/src/services/createRoute.ts
+++ b/src/services/createRoute.ts
@@ -45,7 +45,7 @@ export function createRoute(options: CreateRouteOptions, props?: CreateRouteProp
   const { store, redirect, ...hooks } = createRouteHooks()
   const { setTitle, getTitle } = createRouteTitle(options.parent)
   const views = createRouteViews(options, props)
-  const rawRoute = markRaw({ ...options, id, meta, state, name, views })
+  const rawRoute = markRaw({ ...options, id, meta, state, name, views, loaders: {} })
 
   const redirects = createRouteRedirects({
     getRoute: () => route,

--- a/src/services/createRoute.ts
+++ b/src/services/createRoute.ts
@@ -12,8 +12,8 @@ import { createRouteRedirects } from '@/services/createRouteRedirects'
 import { combineUrl } from '@/services/combineUrl'
 import { createRouteTitle, RouteSetTitle } from '@/types/routeTitle'
 import { createRouteViews } from '@/services/createRouteViews'
-import { RouteWithMethods } from '@/types/addView'
-import { withAddView } from '@/services/addView'
+import { RouteWithMethods } from '@/types/routeWithMethods'
+import { withRouteMethods } from '@/services/withRouteMethods'
 
 type CreateRouteWithProps<
   TOptions extends CreateRouteOptions,
@@ -84,7 +84,7 @@ export function createRoute(options: CreateRouteOptions, props?: CreateRouteProp
     const merged = combineRoutes(options.parent, route)
 
     if (options.hoist) {
-      return withAddView(merged)
+      return withRouteMethods(merged)
     }
 
     const url = combineUrl(options.parent, {
@@ -93,11 +93,11 @@ export function createRoute(options: CreateRouteOptions, props?: CreateRouteProp
       hash,
     })
 
-    return withAddView({
+    return withRouteMethods({
       ...merged,
       ...url,
     })
   }
 
-  return withAddView(route)
+  return withRouteMethods(route)
 }

--- a/src/services/createRoute.ts
+++ b/src/services/createRoute.ts
@@ -13,7 +13,7 @@ import { combineUrl } from '@/services/combineUrl'
 import { createRouteTitle, RouteSetTitle } from '@/types/routeTitle'
 import { createRouteViews } from '@/services/createRouteViews'
 import { RouteWithMethods } from '@/types/addView'
-import { withAddView } from '@/services/addView'
+import { withRouteMethods } from '@/services/withRouteMethods'
 
 type CreateRouteWithProps<
   TOptions extends CreateRouteOptions,
@@ -84,7 +84,7 @@ export function createRoute(options: CreateRouteOptions, props?: CreateRouteProp
     const merged = combineRoutes(options.parent, route)
 
     if (options.hoist) {
-      return withAddView(merged)
+      return withRouteMethods(merged)
     }
 
     const url = combineUrl(options.parent, {
@@ -93,11 +93,11 @@ export function createRoute(options: CreateRouteOptions, props?: CreateRouteProp
       hash,
     })
 
-    return withAddView({
+    return withRouteMethods({
       ...merged,
       ...url,
     })
   }
 
-  return withAddView(route)
+  return withRouteMethods(route)
 }

--- a/src/services/withRouteMethods.ts
+++ b/src/services/withRouteMethods.ts
@@ -1,0 +1,45 @@
+import { AddLoader, addLoaderToMatch, checkForLoaderConflict, toLoader } from '@/services/addLoader'
+import { AddView, addViewToMatch, toView } from '@/services/addView'
+import { CreatedRouteOptions, Route } from '@/types/route'
+
+type NextMatch = (match: CreatedRouteOptions) => CreatedRouteOptions
+
+/**
+ * Attaches the chainable, immutable route methods — `addView` and `addLoader`. Each call rebuilds the
+ * route's own (last) match and returns a new route with the methods re-attached, so neither mutates the
+ * route it was called on, and chaining one never drops the other.
+ */
+export function withRouteMethods<TRoute extends Route>(route: TRoute): TRoute {
+  function withNextMatch(next: NextMatch): TRoute {
+    const currentMatch = route.matches.at(-1)
+
+    if (!currentMatch) {
+      return withRouteMethods(route)
+    }
+
+    return withRouteMethods({
+      ...route,
+      matches: [...route.matches.slice(0, -1), next(currentMatch)],
+    })
+  }
+
+  const addView: AddView = (component, options) => {
+    const view = toView(component, options)
+
+    return withNextMatch((match) => addViewToMatch(match, view))
+  }
+
+  const addLoader: AddLoader = (load, options) => {
+    const loader = toLoader(load, options)
+
+    checkForLoaderConflict(route.matches.slice(0, -1), loader.name)
+
+    return withNextMatch((match) => addLoaderToMatch(match, loader))
+  }
+
+  return {
+    ...route,
+    addView,
+    addLoader,
+  }
+}

--- a/src/types/addLoader.ts
+++ b/src/types/addLoader.ts
@@ -1,0 +1,104 @@
+import { RouteWithMethods } from '@/types/routeWithMethods'
+import { PrefetchConfig } from '@/types/prefetch'
+import { ResolvedRoute } from '@/types/resolved'
+import { CreatedRouteOptions, Route } from '@/types/route'
+import { RouteCallbackContext } from '@/types/routeCallbackContext'
+import { RouteLoader, RouteLoaders } from '@/types/routeLoaders'
+import { Url } from '@/types/url'
+import { Identity, LastInArray } from '@/types/utilities'
+
+/**
+ * The getter for a loader added via `addLoader`. Receives the same two arguments as an `addView` props
+ * getter: the resolved route and a context object. Unlike a props getter it can return anything, since
+ * nothing binds what it returns to a component.
+ */
+export type LoaderGetter<
+  TRoute extends Route = Route
+> = (route: ResolvedRoute<TRoute>, context: RouteCallbackContext<TRoute>) => unknown
+
+/**
+ * The options for a loader added via `addLoader`.
+ *
+ * @template TName - The loader's name, inferred from the `name` option.
+ */
+export type AddLoaderOptions<
+  TName extends string | undefined = string
+> = {
+  /**
+   * The name of the loader, which is the key its data is exposed under on the route. Defaults to the
+   * unnamed loader, whose data is exposed as the route's data directly.
+   */
+  name?: TName,
+  /**
+   * Determines whether this loader is run when a router-link is rendered for this route. Overrides route
+   * level prefetch, and is itself overridden by link level prefetch.
+   */
+  prefetch?: PrefetchConfig,
+}
+
+/**
+ * The loaders of the route itself, from the last `matches` entry.
+ */
+type CurrentMatchLoaders<
+  TMatches extends CreatedRouteOptions[]
+> = LastInArray<TMatches> extends { loaders: infer TLoaders extends RouteLoaders } ? TLoaders : RouteLoaders
+
+/**
+ * Computes the new loaders after adding a loader, replacing any loader the route already stored under
+ * the same name.
+ */
+type AddLoaderLoaders<
+  TCurrent extends RouteLoaders,
+  TName extends string | undefined,
+  TData
+> = Identity<Omit<TCurrent, LoaderName<TName>> & Record<LoaderName<TName>, RouteLoader<TData>>> extends infer TNext extends RouteLoaders
+  ? TNext
+  : TCurrent
+
+type LoaderName<TName extends string | undefined> = TName extends string ? TName : 'default'
+
+/**
+ * Replaces the loaders on the last match, preserving all ancestors.
+ */
+type ReplaceLastMatchLoaders<
+  TMatches extends CreatedRouteOptions[],
+  TNewLoaders extends RouteLoaders
+> = TMatches extends [...infer THead extends CreatedRouteOptions[], infer TLast extends CreatedRouteOptions]
+  ? Identity<Omit<TLast, 'loaders'> & { loaders: TNewLoaders }> extends infer TNext extends CreatedRouteOptions
+    ? [...THead, TNext]
+    : TMatches
+  : TMatches
+
+/**
+ * The full return type of an `addLoader` call: the same url with the last match's loaders replaced.
+ */
+type AddLoaderReturn<
+  TUrl extends Url,
+  TMatches extends CreatedRouteOptions[],
+  TNewLoaders extends RouteLoaders
+> = ReplaceLastMatchLoaders<TMatches, TNewLoaders> extends infer TNext extends CreatedRouteOptions[]
+  ? RouteWithMethods<TUrl, TNext>
+  : never
+
+/**
+ * Adds a loader to a route. Chainable to register multiple loaders, each exposed under its own name on
+ * the resolved route's `data`.
+ */
+export type RouteAddLoader<
+  TUrl extends Url = Url,
+  TMatches extends CreatedRouteOptions[] = CreatedRouteOptions[]
+> = {
+  /**
+   * Adds a loader for this route. Loaders never block rendering, so their data is always a promise.
+   *
+   * @param load - The loader callback. Receives the resolved route and a context object.
+   * @param options - The loader's `name` and `prefetch` config.
+   */
+  addLoader: <
+    const TName extends string | undefined = undefined,
+    const TGetter extends LoaderGetter<Route<TUrl, TMatches>> = LoaderGetter<Route<TUrl, TMatches>>
+  >(
+    load: TGetter,
+    options?: AddLoaderOptions<TName>,
+  ) => AddLoaderReturn<TUrl, TMatches, AddLoaderLoaders<CurrentMatchLoaders<TMatches>, TName, ReturnType<TGetter>>>,
+}

--- a/src/types/addLoader.ts
+++ b/src/types/addLoader.ts
@@ -1,0 +1,104 @@
+import { RouteWithMethods } from '@/types/addView'
+import { PrefetchConfig } from '@/types/prefetch'
+import { ResolvedRoute } from '@/types/resolved'
+import { CreatedRouteOptions, Route } from '@/types/route'
+import { RouteCallbackContext } from '@/types/routeCallbackContext'
+import { RouteLoader, RouteLoaders } from '@/types/routeLoaders'
+import { Url } from '@/types/url'
+import { Identity, LastInArray } from '@/types/utilities'
+
+/**
+ * The getter for a loader added via `addLoader`. Receives the same two arguments as an `addView` props
+ * getter: the resolved route and a context object. Unlike a props getter it can return anything, since
+ * nothing binds what it returns to a component.
+ */
+export type LoaderGetter<
+  TRoute extends Route = Route
+> = (route: ResolvedRoute<TRoute>, context: RouteCallbackContext<TRoute>) => unknown
+
+/**
+ * The options for a loader added via `addLoader`.
+ *
+ * @template TName - The loader's name, inferred from the `name` option.
+ */
+export type AddLoaderOptions<
+  TName extends string | undefined = string
+> = {
+  /**
+   * The name of the loader, which is the key its data is exposed under on the route. Defaults to the
+   * unnamed loader, whose data is exposed as the route's data directly.
+   */
+  name?: TName,
+  /**
+   * Determines whether this loader is run when a router-link is rendered for this route. Overrides route
+   * level prefetch, and is itself overridden by link level prefetch.
+   */
+  prefetch?: PrefetchConfig,
+}
+
+/**
+ * The loaders of the route itself, from the last `matches` entry.
+ */
+type CurrentMatchLoaders<
+  TMatches extends CreatedRouteOptions[]
+> = LastInArray<TMatches> extends { loaders: infer TLoaders extends RouteLoaders } ? TLoaders : RouteLoaders
+
+/**
+ * Computes the new loaders after adding a loader, replacing any loader the route already stored under
+ * the same name.
+ */
+type AddLoaderLoaders<
+  TCurrent extends RouteLoaders,
+  TName extends string | undefined,
+  TData
+> = Identity<Omit<TCurrent, LoaderName<TName>> & Record<LoaderName<TName>, RouteLoader<TData>>> extends infer TNext extends RouteLoaders
+  ? TNext
+  : TCurrent
+
+type LoaderName<TName extends string | undefined> = TName extends string ? TName : 'default'
+
+/**
+ * Replaces the loaders on the last match, preserving all ancestors.
+ */
+type ReplaceLastMatchLoaders<
+  TMatches extends CreatedRouteOptions[],
+  TNewLoaders extends RouteLoaders
+> = TMatches extends [...infer THead extends CreatedRouteOptions[], infer TLast extends CreatedRouteOptions]
+  ? Identity<Omit<TLast, 'loaders'> & { loaders: TNewLoaders }> extends infer TNext extends CreatedRouteOptions
+    ? [...THead, TNext]
+    : TMatches
+  : TMatches
+
+/**
+ * The full return type of an `addLoader` call: the same url with the last match's loaders replaced.
+ */
+type AddLoaderReturn<
+  TUrl extends Url,
+  TMatches extends CreatedRouteOptions[],
+  TNewLoaders extends RouteLoaders
+> = ReplaceLastMatchLoaders<TMatches, TNewLoaders> extends infer TNext extends CreatedRouteOptions[]
+  ? RouteWithMethods<TUrl, TNext>
+  : never
+
+/**
+ * Adds a loader to a route. Chainable to register multiple loaders, each exposed under its own name on
+ * the resolved route's `data`.
+ */
+export type RouteAddLoader<
+  TUrl extends Url = Url,
+  TMatches extends CreatedRouteOptions[] = CreatedRouteOptions[]
+> = {
+  /**
+   * Adds a loader for this route. Loaders never block rendering, so their data is always a promise.
+   *
+   * @param load - The loader callback. Receives the resolved route and a context object.
+   * @param options - The loader's `name` and `prefetch` config.
+   */
+  addLoader: <
+    const TName extends string | undefined = undefined,
+    const TGetter extends LoaderGetter<Route<TUrl, TMatches>> = LoaderGetter<Route<TUrl, TMatches>>
+  >(
+    load: TGetter,
+    options?: AddLoaderOptions<TName>,
+  ) => AddLoaderReturn<TUrl, TMatches, AddLoaderLoaders<CurrentMatchLoaders<TMatches>, TName, ReturnType<TGetter>>>,
+}

--- a/src/types/addView.ts
+++ b/src/types/addView.ts
@@ -1,18 +1,12 @@
 import { Component } from 'vue'
 import { ComponentProps } from '@/services/component'
 import { ComponentPropsAreOptional, PropsGetter } from '@/types/createRouteOptions'
-import { InternalRouteHooks } from '@/types/hooks'
 import { ResolvedRoute } from '@/types/resolved'
 import { CreatedRouteOptions, Route } from '@/types/route'
-import { RouteContextToRejection, RouteContextToRoute } from '@/types/routeContext'
-import { RouteRedirects } from '@/types/redirects'
-import { RouteSetTitle } from '@/types/routeTitle'
-import { RouterPush } from '@/types/routerPush'
-import { RouterReject } from '@/types/routerReject'
-import { RouterReplace } from '@/types/routerReplace'
-import { RouteUpdate } from '@/types/routeUpdate'
+import { RouteCallbackContext } from '@/types/routeCallbackContext'
+import { RouteWithMethods } from '@/types/routeWithMethods'
 import { PrefetchConfig } from '@/types/prefetch'
-import { RouteView, RouteViews, ViewsPropsReturnType } from '@/types/routeViews'
+import { RouteView, RouteViews } from '@/types/routeViews'
 import { Url } from '@/types/url'
 import { AnyFunction, Identity, LastInArray, MaybePromise } from '@/types/utilities'
 
@@ -26,31 +20,12 @@ export type AddViewPropsGetter<
 > = (route: ResolvedRoute<TRoute>, context: AddViewPropsCallbackContext<TRoute>) => MaybePromise<ComponentProps<TComponent>>
 
 /**
- * Context provided to an `addView` props getter. Sourced from the route: rejections/routes from the
- * route's context, and the parent from the route's `views`/`matches` tuples.
+ * Context provided to an `addView` props getter. The same context a loader is given, since both are
+ * callbacks attached to a route.
  */
 export type AddViewPropsCallbackContext<
   TRoute extends Route
-> = {
-  reject: RouterReject<RouteContextToRejection<TRoute['context']>>,
-  push: RouterPush<[TRoute] | RouteContextToRoute<TRoute['context']>>,
-  replace: RouterReplace<[TRoute] | RouteContextToRoute<TRoute['context']>>,
-  update: RouteUpdate<ResolvedRoute<TRoute>>,
-  parent: AddViewParent<TRoute>,
-}
-
-/**
- * The parent context ({ name, props }) reconstructed from the second-to-last `matches` entry, which
- * carries both the parent's name and its views.
- */
-type AddViewParent<
-  TRoute extends Route
-> = TRoute['matches'] extends [...CreatedRouteOptions[], infer TParent extends CreatedRouteOptions, CreatedRouteOptions]
-  ? {
-      name: TParent['name'],
-      props: ViewsPropsReturnType<TParent['views']>,
-    }
-  : undefined
+> = RouteCallbackContext<TRoute>
 
 /**
  * When the getter is omitted the default type param resolves to the wide getter type, which then
@@ -149,22 +124,6 @@ type ReplaceLastMatchViews<
     ? [...THead, TNext]
     : TMatches
   : TMatches
-
-/**
- * A route plus every chainable/available method: addView itself, hooks, redirects, and title.
- *
- * Takes the url and matches rather than an assembled route so that adding a view can rebuild from them
- * directly. Taking the route would mean re-deriving the url from it on every call, and that reference is
- * what made chained calls nest one inside the last.
- */
-export type RouteWithMethods<
-  TUrl extends Url = Url,
-  TMatches extends CreatedRouteOptions[] = CreatedRouteOptions[]
-> = Route<TUrl, TMatches>
-  & RouteAddView<TUrl, TMatches>
-  & InternalRouteHooks<Route<TUrl, TMatches>, Route<TUrl, TMatches>['context']>
-  & RouteRedirects<Route<TUrl, TMatches>>
-  & RouteSetTitle<Route<TUrl, TMatches>>
 
 /**
  * The full return type of an `addView` call: the same url with the last match's views replaced.

--- a/src/types/addView.ts
+++ b/src/types/addView.ts
@@ -4,15 +4,12 @@ import { ComponentPropsAreOptional, PropsGetter } from '@/types/createRouteOptio
 import { InternalRouteHooks } from '@/types/hooks'
 import { ResolvedRoute } from '@/types/resolved'
 import { CreatedRouteOptions, Route } from '@/types/route'
-import { RouteContextToRejection, RouteContextToRoute } from '@/types/routeContext'
+import { RouteAddLoader } from '@/types/addLoader'
+import { RouteCallbackContext } from '@/types/routeCallbackContext'
 import { RouteRedirects } from '@/types/redirects'
 import { RouteSetTitle } from '@/types/routeTitle'
-import { RouterPush } from '@/types/routerPush'
-import { RouterReject } from '@/types/routerReject'
-import { RouterReplace } from '@/types/routerReplace'
-import { RouteUpdate } from '@/types/routeUpdate'
 import { PrefetchConfig } from '@/types/prefetch'
-import { RouteView, RouteViews, ViewsPropsReturnType } from '@/types/routeViews'
+import { RouteView, RouteViews } from '@/types/routeViews'
 import { Url } from '@/types/url'
 import { AnyFunction, Identity, LastInArray, MaybePromise } from '@/types/utilities'
 
@@ -26,31 +23,12 @@ export type AddViewPropsGetter<
 > = (route: ResolvedRoute<TRoute>, context: AddViewPropsCallbackContext<TRoute>) => MaybePromise<ComponentProps<TComponent>>
 
 /**
- * Context provided to an `addView` props getter. Sourced from the route: rejections/routes from the
- * route's context, and the parent from the route's `views`/`matches` tuples.
+ * Context provided to an `addView` props getter. The same context a loader is given, since both are
+ * callbacks attached to a route.
  */
 export type AddViewPropsCallbackContext<
   TRoute extends Route
-> = {
-  reject: RouterReject<RouteContextToRejection<TRoute['context']>>,
-  push: RouterPush<[TRoute] | RouteContextToRoute<TRoute['context']>>,
-  replace: RouterReplace<[TRoute] | RouteContextToRoute<TRoute['context']>>,
-  update: RouteUpdate<ResolvedRoute<TRoute>>,
-  parent: AddViewParent<TRoute>,
-}
-
-/**
- * The parent context ({ name, props }) reconstructed from the second-to-last `matches` entry, which
- * carries both the parent's name and its views.
- */
-type AddViewParent<
-  TRoute extends Route
-> = TRoute['matches'] extends [...CreatedRouteOptions[], infer TParent extends CreatedRouteOptions, CreatedRouteOptions]
-  ? {
-      name: TParent['name'],
-      props: ViewsPropsReturnType<TParent['views']>,
-    }
-  : undefined
+> = RouteCallbackContext<TRoute>
 
 /**
  * When the getter is omitted the default type param resolves to the wide getter type, which then
@@ -151,7 +129,7 @@ type ReplaceLastMatchViews<
   : TMatches
 
 /**
- * A route plus every chainable/available method: addView itself, hooks, redirects, and title.
+ * A route plus every chainable/available method: addView, addLoader, hooks, redirects, and title.
  *
  * Takes the url and matches rather than an assembled route so that adding a view can rebuild from them
  * directly. Taking the route would mean re-deriving the url from it on every call, and that reference is
@@ -162,6 +140,7 @@ export type RouteWithMethods<
   TMatches extends CreatedRouteOptions[] = CreatedRouteOptions[]
 > = Route<TUrl, TMatches>
   & RouteAddView<TUrl, TMatches>
+  & RouteAddLoader<TUrl, TMatches>
   & InternalRouteHooks<Route<TUrl, TMatches>, Route<TUrl, TMatches>['context']>
   & RouteRedirects<Route<TUrl, TMatches>>
   & RouteSetTitle<Route<TUrl, TMatches>>

--- a/src/types/createRouteOptions.ts
+++ b/src/types/createRouteOptions.ts
@@ -158,6 +158,11 @@ type ToMatch<
    * The views this route renders, keyed by view name.
    */
   views: PropsToViews<TProps>,
+  /**
+   * The loaders this route runs, keyed by loader name. Always empty here — loaders are only added via
+   * the route's `addLoader`.
+   */
+  loaders: {},
 }
 
 /**

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -11,6 +11,7 @@ import { GetRouteTitle } from '@/types/routeTitle'
 import { Hooks } from '@/models/hooks'
 import { RouteRedirect } from './redirects'
 import { RouteViews } from '@/types/routeViews'
+import { LoadersDataReturnType, RouteLoaders } from '@/types/routeLoaders'
 
 export const IS_ROUTE_SYMBOL = Symbol('IS_ROUTE_SYMBOL')
 
@@ -32,12 +33,14 @@ export type RouteInternal = {
 export type Routes = readonly Route[]
 
 /**
- * The Route properties originally provided to `createRoute`, plus the views that route renders. The
- * deprecated `component`/`components` options are folded into `views` (see {@link RouteViews}).
+ * The Route properties originally provided to `createRoute`, plus the views that route renders and the
+ * loaders it runs. The deprecated `component`/`components` options are folded into `views` (see
+ * {@link RouteViews}).
  */
 export type CreatedRouteOptions = Omit<CreateRouteOptions, 'component' | 'components'> & {
   id: string,
   views: RouteViews,
+  loaders: RouteLoaders,
 }
 
 // `matches` is a complete per-depth snapshot of the options each route was created with, so the
@@ -72,6 +75,24 @@ type RouteStateOf<TMatches extends CreatedRouteOptions[]> = CreatedRouteOptions[
   : TMatches extends [infer THead, ...infer TRest extends CreatedRouteOptions[]]
     ? (THead extends { state: infer TState extends Record<string, Param> } ? ToState<TState> : {}) & RouteStateOf<TRest>
     : {}
+
+/**
+ * The loaders of every matched route, combined. A plain intersection: a loader name is unique across a
+ * route and its ancestors, which `addLoader` enforces.
+ */
+type RouteLoadersOf<TMatches extends CreatedRouteOptions[]> = CreatedRouteOptions[] extends TMatches
+  ? RouteLoaders
+  : TMatches extends [infer THead, ...infer TRest extends CreatedRouteOptions[]]
+    ? (THead extends { loaders: infer TLoaders extends RouteLoaders } ? TLoaders : {}) & RouteLoadersOf<TRest>
+    : {}
+
+/**
+ * The data every matched route's loaders resolve to, which is what a resolved route exposes as `data`.
+ * Undefined when nothing in the route tree declares a loader.
+ */
+export type RouteDataOf<TMatches extends CreatedRouteOptions[]> = CreatedRouteOptions[] extends TMatches
+  ? Record<string, Promise<unknown>> | undefined
+  : LoadersDataReturnType<RouteLoadersOf<TMatches>>
 
 /**
  * The context of every matched route, flattened from greatest ancestor to narrowest matched.

--- a/src/types/routeCallbackContext.ts
+++ b/src/types/routeCallbackContext.ts
@@ -1,0 +1,35 @@
+import { ResolvedRoute } from '@/types/resolved'
+import { CreatedRouteOptions, Route } from '@/types/route'
+import { RouteContextToRejection, RouteContextToRoute } from '@/types/routeContext'
+import { RouterPush } from '@/types/routerPush'
+import { RouterReject } from '@/types/routerReject'
+import { RouterReplace } from '@/types/routerReplace'
+import { RouteUpdate } from '@/types/routeUpdate'
+import { ViewsPropsReturnType } from '@/types/routeViews'
+
+/**
+ * Context provided to a callback attached to a route — an `addView` props getter, or a loader. Sourced
+ * from the route: rejections/routes from the route's context, and the parent from the route's `matches`.
+ */
+export type RouteCallbackContext<
+  TRoute extends Route
+> = {
+  reject: RouterReject<RouteContextToRejection<TRoute['context']>>,
+  push: RouterPush<[TRoute] | RouteContextToRoute<TRoute['context']>>,
+  replace: RouterReplace<[TRoute] | RouteContextToRoute<TRoute['context']>>,
+  update: RouteUpdate<ResolvedRoute<TRoute>>,
+  parent: RouteCallbackParent<TRoute>,
+}
+
+/**
+ * The parent context ({ name, props }) reconstructed from the second-to-last `matches` entry, which
+ * carries both the parent's name and its views.
+ */
+type RouteCallbackParent<
+  TRoute extends Route
+> = TRoute['matches'] extends [...CreatedRouteOptions[], infer TParent extends CreatedRouteOptions, CreatedRouteOptions]
+  ? {
+      name: TParent['name'],
+      props: ViewsPropsReturnType<TParent['views']>,
+    }
+  : undefined

--- a/src/types/routeLoaders.ts
+++ b/src/types/routeLoaders.ts
@@ -15,7 +15,7 @@ export type RouteLoader<TData = unknown> = {
 /**
  * The loaders for a single route, keyed by loader name (the unnamed loader under 'default').
  */
-export type RouteLoaders = Record<string, RouteLoader<unknown>>
+export type RouteLoaders = Record<string, RouteLoader>
 
 /**
  * The data a set of loaders resolves to. A lone unnamed loader is given directly rather than under a

--- a/src/types/routeLoaders.ts
+++ b/src/types/routeLoaders.ts
@@ -1,0 +1,31 @@
+import { PrefetchConfig } from '@/types/prefetch'
+import { AnyFunction } from '@/types/utilities'
+
+/**
+ * A single loader: how to load its data, and how to prefetch it. Unlike a view, a loader always has a
+ * getter — a loader without one would have nothing to contribute.
+ *
+ * @template TData - What this loader's getter returns, carried so a route's data can be typed from it.
+ */
+export type RouteLoader<TData = unknown> = {
+  load: AnyFunction<TData>,
+  prefetch?: PrefetchConfig,
+}
+
+/**
+ * The loaders for a single route, keyed by loader name (the unnamed loader under 'default').
+ */
+export type RouteLoaders = Record<string, RouteLoader<unknown>>
+
+/**
+ * The data a set of loaders resolves to. A lone unnamed loader is given directly rather than under a
+ * 'default' key, matching how the loader is written. Each loader's data is always a promise, since a
+ * loader never blocks rendering, even when the loader itself is synchronous.
+ */
+export type LoadersDataReturnType<TLoaders> = keyof TLoaders extends never
+  ? undefined
+  : keyof TLoaders extends 'default'
+    ? LoaderData<Extract<TLoaders, { default: unknown }>['default']>
+    : { [K in keyof TLoaders]: LoaderData<TLoaders[K]> }
+
+type LoaderData<TLoader> = TLoader extends { load: AnyFunction<infer TData> } ? Promise<Awaited<TData>> : never

--- a/src/types/routeWithMethods.ts
+++ b/src/types/routeWithMethods.ts
@@ -1,0 +1,25 @@
+import { RouteAddLoader } from '@/types/addLoader'
+import { RouteAddView } from '@/types/addView'
+import { InternalRouteHooks } from '@/types/hooks'
+import { RouteRedirects } from '@/types/redirects'
+import { CreatedRouteOptions, Route } from '@/types/route'
+import { RouteSetTitle } from '@/types/routeTitle'
+import { Url } from '@/types/url'
+
+/**
+ * A route plus every chainable/available method: addView, addLoader, hooks, redirects, and title. The type
+ * level counterpart to `withRouteMethods`.
+ *
+ * Takes the url and matches rather than an assembled route so that adding a view or a loader can rebuild
+ * from them directly. Taking the route would mean re-deriving the url from it on every call, and that
+ * reference is what made chained calls nest one inside the last.
+ */
+export type RouteWithMethods<
+  TUrl extends Url = Url,
+  TMatches extends CreatedRouteOptions[] = CreatedRouteOptions[]
+> = Route<TUrl, TMatches>
+  & RouteAddView<TUrl, TMatches>
+  & RouteAddLoader<TUrl, TMatches>
+  & InternalRouteHooks<Route<TUrl, TMatches>, Route<TUrl, TMatches>['context']>
+  & RouteRedirects<Route<TUrl, TMatches>>
+  & RouteSetTitle<Route<TUrl, TMatches>>


### PR DESCRIPTION
# Description

Third step of #805, stacked on #809.

Loaders are a route's data, declared the way views are declared but with no component attached and no hold on rendering:

```ts
createRoute({ name: 'user', path: '/user/[id]' })
  .addView(UserView, { props: (route) => ({ id: route.params.id }) })
  .addLoader(async (route) => api.getUser(route.params.id))
  .addLoader(async (route) => api.getPosts(route.params.id), { name: 'posts' })
```

They are stored per match, alongside views, so a route's data can be derived from its matches the same way its views already are — including an ancestor's loaders, which a child should be able to use as its own.

Both chainable methods now rebuild through `withRouteMethods`. Previously `addView` re-attached only itself, so chaining a view after a loader would have dropped `addLoader` from the route — the two have to be re-attached together, and neither file needs to know about the other for that.

A loader name an ancestor already uses throws `LoaderNameConflict`. A route's data combines the loaders of every match, so the same name in two places would be ambiguous rather than an override — unlike adding a loader the route itself already has, which replaces it, as views do.

Nothing runs a loader yet. What this proves is declaration: names, prefetch configs, immutability, chaining in both orders, and ancestor conflicts.