### PR TITLE
Describe what a route's loaders resolve to

### DIFF
--- a/src/services/addLoader.spec-d.ts
+++ b/src/services/addLoader.spec-d.ts
@@ -2,10 +2,14 @@ import { describe, expectTypeOf, test } from 'vitest'
 import { createRoute } from './createRoute'
 import { RouteLoader } from '@/types/routeLoaders'
 import { BuiltInRejectionType } from '@/types/rejection'
+import { ResolvedRouteWithData } from '@/types/resolved'
+import { Route } from '@/types/route'
 import { component } from '@/utilities/testHelpers'
 import { RouteView } from '@/types/routeViews'
 
 type User = { id: string, name: string }
+
+type Data<TRoute extends Route> = ResolvedRouteWithData<TRoute>['data']
 
 describe('addLoader', () => {
   test('an async loader carries what it returns', () => {
@@ -81,6 +85,60 @@ describe('addLoader', () => {
 
     expectTypeOf<typeof child['matches'][0]['loaders']>().toEqualTypeOf<{ default: RouteLoader<string> }>()
     expectTypeOf<typeof child['matches'][1]['loaders']>().toEqualTypeOf<{ posts: RouteLoader<number> }>()
+  })
+})
+
+describe('route data', () => {
+  test('a route without loaders has no data', () => {
+    const route = createRoute({ name: 'route' }).addView(component)
+
+    expectTypeOf<Data<typeof route>>().toEqualTypeOf<undefined>()
+  })
+
+  test('a lone unnamed loader is the data itself', () => {
+    const route = createRoute({ name: 'route' }).addLoader(async (): Promise<User> => ({ id: '1', name: 'kitbag' }))
+
+    expectTypeOf<Data<typeof route>>().toEqualTypeOf<Promise<User>>()
+  })
+
+  test('a synchronous loader still resolves as a promise', () => {
+    const route = createRoute({ name: 'route' }).addLoader(() => 'kitbag')
+
+    expectTypeOf<Data<typeof route>>().toEqualTypeOf<Promise<string>>()
+  })
+
+  test('a lone named loader is keyed by its name', () => {
+    const route = createRoute({ name: 'route' }).addLoader(() => 'kitbag', { name: 'user' })
+
+    expectTypeOf<Data<typeof route>>().toEqualTypeOf<{ user: Promise<string> }>()
+  })
+
+  test('named loaders alongside an unnamed one are all keyed', () => {
+    const route = createRoute({ name: 'route' })
+      .addLoader(async (): Promise<User> => ({ id: '1', name: 'kitbag' }))
+      .addLoader(() => [1, 2], { name: 'posts' })
+
+    expectTypeOf<Data<typeof route>>().toEqualTypeOf<{
+      default: Promise<User>,
+      posts: Promise<number[]>,
+    }>()
+  })
+
+  test('an ancestor loader is part of the route data', () => {
+    const parent = createRoute({ name: 'parent', path: '/parent' }).addLoader(async (): Promise<User> => ({ id: '1', name: 'kitbag' }))
+    const child = createRoute({ parent, name: 'child', path: '/child' })
+
+    expectTypeOf<Data<typeof child>>().toEqualTypeOf<Promise<User>>()
+  })
+
+  test('a named loader on a child keys the ancestor loader too', () => {
+    const parent = createRoute({ name: 'parent', path: '/parent' }).addLoader(async (): Promise<User> => ({ id: '1', name: 'kitbag' }))
+    const child = createRoute({ parent, name: 'child', path: '/child' }).addLoader(() => [1, 2], { name: 'posts' })
+
+    expectTypeOf<Data<typeof child>>().toEqualTypeOf<{
+      default: Promise<User>,
+      posts: Promise<number[]>,
+    }>()
   })
 })
 

--- a/src/services/addLoader.spec-d.ts
+++ b/src/services/addLoader.spec-d.ts
@@ -2,14 +2,14 @@ import { describe, expectTypeOf, test } from 'vitest'
 import { createRoute } from './createRoute'
 import { RouteLoader } from '@/types/routeLoaders'
 import { BuiltInRejectionType } from '@/types/rejection'
-import { ResolvedRouteWithData } from '@/types/resolved'
+import { ResolvedRoute, WithData } from '@/types/resolved'
 import { Route } from '@/types/route'
 import { component } from '@/utilities/testHelpers'
 import { RouteView } from '@/types/routeViews'
 
 type User = { id: string, name: string }
 
-type Data<TRoute extends Route> = ResolvedRouteWithData<TRoute>['data']
+type Data<TRoute extends Route> = (ResolvedRoute<TRoute> & WithData<TRoute>)['data']
 
 describe('addLoader', () => {
   test('an async loader carries what it returns', () => {

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -61,17 +61,20 @@ export type ResolvedRoute<TRoute extends Route = Route> = Readonly<{
 }>
 
 /**
- * A resolved route together with what its loaders resolve to. Only the route being navigated to has data:
- * a route the router merely resolved is not being loaded, so data on it could never settle. That is why
- * this is separate from {@link ResolvedRoute} — the current route and a props getter's route have it,
- * `router.resolve` and hooks do not.
+ * A resolved route whose loaders' data is available. Only the route being navigated to has data: a route
+ * the router merely resolved is not being loaded, so data on it could never settle. The current route and
+ * a props getter's route have it, `router.resolve` and hooks do not.
  */
-export type ResolvedRouteWithData<TRoute extends Route = Route> = ResolvedRoute<TRoute> & {
+export type WithData<TRoute extends Route = Route> = {
   /**
    * What the route's loaders resolve to, keyed by loader name. A route whose only loader is unnamed
    * exposes that loader's data here directly. Always promises, since loaders never block rendering.
    */
   data: RouteDataOf<TRoute['matches']>,
+}
+
+export function isWithData<T extends Record<string, unknown>>(route: T): route is T & WithData {
+  return 'data' in route && route.data !== undefined
 }
 
 /**

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -1,4 +1,4 @@
-import { CreatedRouteOptions, Route, Routes } from '@/types/route'
+import { CreatedRouteOptions, Route, RouteDataOf, Routes } from '@/types/route'
 import { LastInArray } from '@/types/utilities'
 import { ExtractRouteStateParamsAsOptional } from '@/types/state'
 import { UrlString } from '@/types/urlString'
@@ -59,6 +59,20 @@ export type ResolvedRoute<TRoute extends Route = Route> = Readonly<{
    */
   title: Promise<string | undefined>,
 }>
+
+/**
+ * A resolved route together with what its loaders resolve to. Only the route being navigated to has data:
+ * a route the router merely resolved is not being loaded, so data on it could never settle. That is why
+ * this is separate from {@link ResolvedRoute} — the current route and a props getter's route have it,
+ * `router.resolve` and hooks do not.
+ */
+export type ResolvedRouteWithData<TRoute extends Route = Route> = ResolvedRoute<TRoute> & {
+  /**
+   * What the route's loaders resolve to, keyed by loader name. A route whose only loader is unnamed
+   * exposes that loader's data here directly. Always promises, since loaders never block rendering.
+   */
+  data: RouteDataOf<TRoute['matches']>,
+}
 
 /**
  * This type is the same as `ResolvedRoute<TRoutes[number]>` while remaining distributive

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -73,10 +73,6 @@ export type WithData<TRoute extends Route = Route> = {
   data: RouteDataOf<TRoute['matches']>,
 }
 
-export function isWithData<T extends Record<string, unknown>>(route: T): route is T & WithData {
-  return 'data' in route && route.data !== undefined
-}
-
 /**
  * This type is the same as `ResolvedRoute<TRoutes[number]>` while remaining distributive
  */

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -91,7 +91,7 @@ type RouteLoadersOf<TMatches extends CreatedRouteOptions[]> = CreatedRouteOption
  * Undefined when nothing in the route tree declares a loader.
  */
 export type RouteDataOf<TMatches extends CreatedRouteOptions[]> = CreatedRouteOptions[] extends TMatches
-  ? Record<string, Promise<unknown>> | undefined
+  ? Promise<unknown> | Record<string, Promise<unknown>> | undefined
   : LoadersDataReturnType<RouteLoadersOf<TMatches>>
 
 /**


### PR DESCRIPTION
# Description

Fifth step of #805, stacked on #811. Types only.

`RouteDataOf` combines the loaders of every match, so a child sees an ancestor's data as its own, and flattens to the loader's data directly when the only loader in the tree is unnamed:

```ts
const user = createRoute({ name: 'user', path: '/user/[id]' })
  .addLoader(async (route) => api.getUser(route.params.id))

// data -> Promise<User>

const posts = createRoute({ parent: user, name: 'user.posts', path: '/posts' })
  .addLoader(async (route) => api.getPosts(route.params.id), { name: 'posts' })

// data.default -> Promise<User>
// data.posts   -> Promise<Post[]>
```

Data is always a promise, even for a synchronous loader. Loaders do not hold up rendering, so a component reading data cannot be given a settled value — making that uniform is cheaper than making it conditional.

It is carried by `ResolvedRouteWithData` rather than by `ResolvedRoute`, because only the route being navigated to has data. A route the router merely resolved — `router.resolve`, `router.find`, the `to`/`from` a hook receives — is not being loaded, so data on it could only be a promise that never settles. #814 gives it to the two surfaces that do have it: the current route, and a props getter's route.

Also worth a look: the unregistered case types data as `Promise<unknown> | Record<string, Promise<unknown>> | undefined` rather than just a record, because a route whose data is a bare promise has to satisfy the constraint.