### PR TITLE
Add AGENTS.md and SKILL.md for LLM agent discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,12 +78,22 @@ router.replace('home')
 ```ts
 import { useRoute } from '@kitbag/router'
 
-// Unnarrrowed — all possible params are optional
+// Unnarrowed — all possible params are optional
 const route = useRoute()
 
 // Narrowed to a specific route — params are typed
 const userRoute = useRoute('user')
 userRoute.params.userId // number
+```
+
+Params are reactive and support `v-model` for two-way binding (especially useful for query params):
+
+```vue
+<input v-model="route.params.search" />
+<select v-model="route.params.sort">
+  <option value="asc">Ascending</option>
+  <option value="desc">Descending</option>
+</select>
 ```
 
 ### 5. Use hooks for guards, redirects, and lifecycle
@@ -97,10 +107,17 @@ const protectedRoute = createRoute({
 })
   .addView(Dashboard)
 
-// Route-level hook — use throw to stop execution
-protectedRoute.onBeforeRouteEnter((_to, { reject }) => {
+// Route-level before-hook — use `throw reject(...)` to stop execution
+protectedRoute.onBeforeRouteEnter((to, { reject, replace }) => {
   if (!isAuthenticated()) {
     throw reject('NotFound')
+  }
+})
+
+// Route-level after-hook — second arg includes `push` for navigation
+protectedRoute.onAfterRouteEnter((to, { push }) => {
+  if (to.params.search === 'secret') {
+    push('hiddenRoute')
   }
 })
 
@@ -114,9 +131,73 @@ onBeforeRouteLeave((to, { abort }) => {
 })
 ```
 
+## Additional Features
+
+### Query params, `unionOf`, and `withDefault`
+
+Query params are first-class. Use shorthand strings for untyped params, or `withParams` with `unionOf`/`withDefault` for constrained values:
+
+```ts
+import { createRoute, withParams, unionOf, withDefault } from '@kitbag/router'
+
+// Shorthand — defaults to String type
+const search = createRoute({
+  name: 'search',
+  path: '/search',
+  query: 'q=[?q]',
+})
+
+// Typed with constrained values and a default
+const keys = createRoute({
+  name: 'keys',
+  path: '/keys',
+  query: withParams('sort=[?sort]', {
+    sort: withDefault(unionOf(['asc', 'desc']), 'asc'),
+  }),
+})
+```
+
+### Context — scoping routes and rejections
+
+Routes can declare `context` — an array of other routes or rejections that are only accessible when that route is active:
+
+```ts
+const secretPage = createRoute({ name: 'secret', path: '/secret' })
+  .addView(SecretView)
+
+const main = createRoute({
+  name: 'main',
+  path: '/main',
+  context: [secretPage],
+}).addView(MainView)
+
+// Rejections can also be scoped via context
+const notAuthorized = createRejection({ type: 'NotAuthorized', component: LoginView })
+
+const protectedRoute = createRoute({
+  name: 'protected',
+  path: '/protected',
+  context: [notAuthorized],
+})
+```
+
+### RouterView scoped slot for transitions
+
+Use the `#default` slot with `{ component }` to wrap route views in `<transition>`:
+
+```vue
+<router-view>
+  <template #default="{ component }">
+    <transition name="fade" mode="out-in">
+      <component :is="component" />
+    </transition>
+  </template>
+</router-view>
+```
+
 ## Type Inference Gotchas
 
-1. **You must register the router** via declaration merging or use `createRouterAssets` — without this, composables like `useRoute` and `useRouter` have no type context.
+1. **You must register the router** via declaration merging — without this, composables like `useRoute` and `useRouter` have no type context.
 2. **Routes array must use `as const`** — without it TypeScript widens route names to `string` and params lose their types.
 3. **`useRoute('name')` narrows types** — only use this inside components you know are mounted under that route. Using the wrong name gives a runtime error.
 4. **Param names must be unique** across the full route tree (including parent routes). Duplicate param names throw `DuplicateParamsError`.
@@ -136,7 +217,7 @@ LLMs trained on older data may generate outdated patterns. The correct forms are
 | `router.beforeEach(...)` | Use `onBeforeRouteEnter` on the route or pass hooks to `createRouter` |
 | `{ path: '/user/:id' }` | `{ path: withParams('/user/[id]', { id: Number }) }` (square brackets, explicit type) |
 | `meta: { requiresAuth: true }` inline | `createRoute({ meta: { requiresAuth: true } })` (same place, but access differs) |
-| `import { useRejection } from 'vue-router'` | `import { useRejection } from '@kitbag/router'` (rejections are a Kitbag concept) |
+| `reject('NotFound')` | `throw reject('NotFound')` (`throw` is needed to stop hook execution) |
 
 ## Key Differences from vue-router
 
@@ -148,3 +229,5 @@ LLMs trained on older data may generate outdated patterns. The correct forms are
 - **Props are type-safe** — assigned via `.addView(Component, { props: (route) => ({ ... }) })`.
 - **Query params are first-class** — defined with the same `withParams` syntax on the `query` property.
 - **Plugins** bundle routes, rejections, and hooks into reusable units via `createRouterPlugin`.
+- **Context** scopes routes and rejections to only be accessible when a parent route is active.
+- **Params support `v-model`** — two-way binding works directly on `route.params`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,150 @@
+# @kitbag/router - Agent Guide
+
+Type-safe router for Vue 3. Not a fork of vue-router — different API, different mental model.
+
+Docs: https://kitbag.dev/router
+
+## Install
+
+```bash
+npm install @kitbag/router
+```
+
+## 5 Canonical Patterns
+
+### 1. Define routes with `createRoute` and `addView`
+
+```ts
+import { createRoute, withParams } from '@kitbag/router'
+import Home from './views/Home.vue'
+import User from './views/User.vue'
+
+const home = createRoute({ name: 'home', path: '/' })
+  .addView(Home)
+
+const user = createRoute({
+  name: 'user',
+  path: withParams('/user/[userId]', { userId: Number }),
+})
+  .addView(User, {
+    props: (route) => ({ id: route.params.userId }),
+  })
+
+const routes = [home, user] as const
+```
+
+Always use `as const` on your routes array for correct type inference.
+
+### 2. Create and install the router
+
+```ts
+import { createRouter } from '@kitbag/router'
+
+const router = createRouter(routes)
+
+// Register types via declaration merging
+declare module '@kitbag/router' {
+  interface Register {
+    router: typeof router
+  }
+}
+
+app.use(router)
+```
+
+### 3. Navigate with type-safe `push`, `replace`, and `RouterLink`
+
+```ts
+import { useRouter } from '@kitbag/router'
+
+const router = useRouter()
+
+// Programmatic — params are type-checked against route definition
+router.push('user', { userId: 42 })
+router.replace('home')
+```
+
+```vue
+<template>
+  <!-- Callback-style `to` gives type-safe resolve -->
+  <router-link :to="(resolve) => resolve('user', { userId: 42 })">
+    Profile
+  </router-link>
+</template>
+```
+
+### 4. Access the current route with `useRoute`
+
+```ts
+import { useRoute } from '@kitbag/router'
+
+// Unnarrrowed — all possible params are optional
+const route = useRoute()
+
+// Narrowed to a specific route — params are typed
+const userRoute = useRoute('user')
+userRoute.params.userId // number
+```
+
+### 5. Use hooks for guards, redirects, and lifecycle
+
+```ts
+import { createRoute } from '@kitbag/router'
+
+const protectedRoute = createRoute({
+  name: 'dashboard',
+  path: '/dashboard',
+})
+  .addView(Dashboard)
+
+// Route-level hook
+protectedRoute.onBeforeRouteEnter((to, { reject, replace }) => {
+  if (!isAuthenticated()) {
+    reject('NotFound')
+  }
+})
+
+// In-component hooks
+import { onBeforeRouteLeave } from '@kitbag/router'
+
+onBeforeRouteLeave((to, { abort }) => {
+  if (hasUnsavedChanges.value) {
+    abort()
+  }
+})
+```
+
+## Type Inference Gotchas
+
+1. **You must register the router** via declaration merging or use `createRouterAssets` — without this, composables like `useRoute` and `useRouter` have no type context.
+2. **Routes array must use `as const`** — without it TypeScript widens route names to `string` and params lose their types.
+3. **`useRoute('name')` narrows types** — only use this inside components you know are mounted under that route. Using the wrong name gives a runtime error.
+4. **Param names must be unique** across the full route tree (including parent routes). Duplicate param names throw `DuplicateParamsError`.
+
+## APIs That Changed — Don't Write the Old Form
+
+LLMs trained on older data may generate outdated patterns. The correct forms are:
+
+| Wrong (old/never existed) | Correct |
+|---|---|
+| `createRoute({ component: Foo })` | `createRoute({ ... }).addView(Foo)` |
+| `createRoute({ props: { ... } })` | `.addView(Foo, { props: (route) => ({ ... }) })` |
+| `router.addRoute(...)` | Routes are static — pass all routes to `createRouter(routes)` |
+| `useRoute().params.value.id` | `useRoute().params.id` (params is already reactive, not a ref) |
+| `<router-link to="/path">` | `<router-link :to="(resolve) => resolve('name', params)">` (callback style) |
+| `<router-link :to="{ name: 'foo' }">` | `<router-link :to="(resolve) => resolve('foo')">` |
+| `router.beforeEach(...)` | Use `onBeforeRouteEnter` on the route or pass hooks to `createRouter` |
+| `{ path: '/user/:id' }` | `{ path: withParams('/user/[id]', { id: Number }) }` (square brackets, explicit type) |
+| `meta: { requiresAuth: true }` inline | `createRoute({ meta: { requiresAuth: true } })` (same place, but access differs) |
+| `import { useRejection } from 'vue-router'` | `import { useRejection } from '@kitbag/router'` (rejections are a Kitbag concept) |
+
+## Key Differences from vue-router
+
+- **No `$route`/`$router` globals** — use `useRoute()` and `useRouter()` composables.
+- **No route config arrays with `children`** — use `parent` property on `createRoute` to build hierarchy.
+- **No catch-all `/:pathMatch(.*)*`** — use the built-in `NotFound` rejection.
+- **Params use `[brackets]`** not `:colon` syntax. Optional: `[?param]`, greedy: `[param*]`.
+- **Rejections** replace vue-router's 404/error handling. Create custom rejections with `createRejection`.
+- **Props are type-safe** — assigned via `.addView(Component, { props: (route) => ({ ... }) })`.
+- **Query params are first-class** — defined with the same `withParams` syntax on the `query` property.
+- **Plugins** bundle routes, rejections, and hooks into reusable units via `createRouterPlugin`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,8 +1,18 @@
 # @kitbag/router - Agent Guide
 
 Type-safe router for Vue 3. Not a fork of vue-router — different API, different mental model.
+This file documents library usage for consumers of the npm package.
 
 Docs: https://kitbag.dev/router
+
+## Working in this repo
+
+If you are contributing to @kitbag/router itself:
+
+- `npm run test` — run Vitest tests
+- `npm run lint` — run ESLint
+- `npm run build` — build the library
+- Source code lives in `src/`, docs in `docs/`
 
 ## Install
 
@@ -107,18 +117,16 @@ const protectedRoute = createRoute({
 })
   .addView(Dashboard)
 
-// Route-level before-hook — use `throw reject(...)` to stop execution
+// Route-level before-hook — reject() throws internally, no `throw` needed
 protectedRoute.onBeforeRouteEnter((to, { reject, replace }) => {
   if (!isAuthenticated()) {
-    throw reject('NotFound')
+    reject('NotFound')
   }
 })
 
 // Route-level after-hook — second arg includes `push` for navigation
 protectedRoute.onAfterRouteEnter((to, { push }) => {
-  if (to.params.search === 'secret') {
-    push('hiddenRoute')
-  }
+  push('home')
 })
 
 // In-component hooks
@@ -197,7 +205,7 @@ Use the `#default` slot with `{ component }` to wrap route views in `<transition
 
 ## Type Inference Gotchas
 
-1. **You must register the router** via declaration merging — without this, composables like `useRoute` and `useRouter` have no type context.
+1. **You must register the router** via declaration merging — without this, composables like `useRoute` and `useRouter` have no type context. For multi-router setups with `isGlobalRouter: false`, use `createRouterAssets` to get typed composables and components bound to a specific router instance.
 2. **Routes array must use `as const`** — without it TypeScript widens route names to `string` and params lose their types.
 3. **`useRoute('name')` narrows types** — only use this inside components you know are mounted under that route. Using the wrong name gives a runtime error.
 4. **Param names must be unique** across the full route tree (including parent routes). Duplicate param names throw `DuplicateParamsError`.
@@ -206,18 +214,18 @@ Use the `#default` slot with `{ component }` to wrap route views in `<transition
 
 LLMs trained on older data may generate outdated patterns. The correct forms are:
 
-| Wrong (old/never existed) | Correct |
+| Deprecated / old form | Correct |
 |---|---|
 | `createRoute({ component: Foo })` | `createRoute({ ... }).addView(Foo)` |
 | `createRoute({ props: { ... } })` | `.addView(Foo, { props: (route) => ({ ... }) })` |
 | `router.addRoute(...)` | Routes are static — pass all routes to `createRouter(routes)` |
 | `useRoute().params.value.id` | `useRoute().params.id` (params is already reactive, not a ref) |
-| `<router-link to="/path">` | `<router-link :to="(resolve) => resolve('name', params)">` (callback style) |
+| `<router-link to="/path">` | Prefer `<router-link :to="(resolve) => resolve('name', params)">` (callback style is type-safe; plain URL strings also accepted) |
 | `<router-link :to="{ name: 'foo' }">` | `<router-link :to="(resolve) => resolve('foo')">` |
 | `router.beforeEach(...)` | Use `onBeforeRouteEnter` on the route or pass hooks to `createRouter` |
 | `{ path: '/user/:id' }` | `{ path: withParams('/user/[id]', { id: Number }) }` (square brackets, explicit type) |
 | `meta: { requiresAuth: true }` inline | `createRoute({ meta: { requiresAuth: true } })` (same place, but access differs) |
-| `reject('NotFound')` | `throw reject('NotFound')` (`throw` is needed to stop hook execution) |
+| `return next(false)` / `next('/login')` | `reject('NotFound')` (throws internally, no `return`/`throw` needed) |
 
 ## Key Differences from vue-router
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,10 +97,10 @@ const protectedRoute = createRoute({
 })
   .addView(Dashboard)
 
-// Route-level hook
-protectedRoute.onBeforeRouteEnter((to, { reject, replace }) => {
+// Route-level hook — use throw to stop execution
+protectedRoute.onBeforeRouteEnter((_to, { reject }) => {
   if (!isAuthenticated()) {
-    reject('NotFound')
+    throw reject('NotFound')
   }
 })
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,9 @@
   },
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "AGENTS.md",
+    "skills"
   ],
   "main": "./dist/kitbag-router.umd.cjs",
   "module": "./dist/kitbag-router.js",

--- a/skills/kitbag-router/SKILL.md
+++ b/skills/kitbag-router/SKILL.md
@@ -80,9 +80,9 @@ app.use(router)
 
 Params use **square brackets**, not colons:
 
-- `[id]` — required param (matches one or more characters including `/`)
-- `[?id]` — optional param
-- `[id*]` — greedy (explicitly captures multiple segments)
+- `[id]` — required param, matches a single path segment (stops at `/`)
+- `[?id]` — optional param, type is `string | undefined`
+- `[id*]` — greedy, matches across segments including `/`
 - `[?id*]` — optional greedy
 
 Type params with `withParams`:
@@ -262,7 +262,18 @@ link.push() // navigate
 
 ```ts
 import { useQueryValue } from '@kitbag/router'
-const tab = useQueryValue('tab') // Ref<string | undefined>
+
+// Returns { value, values, remove }, not a bare ref
+const { value: tab } = useQueryValue('tab')
+//              ^? Ref<string | null>
+
+// With a param type and accessing multiple values
+const { values: tabs } = useQueryValue('tab', Number)
+//              ^? Ref<number[]>
+
+// remove() deletes the query key from the URL
+const { value, remove } = useQueryValue('temp')
+remove() // removes ?temp=... from URL
 ```
 
 ## Type Utilities
@@ -309,9 +320,9 @@ const router = createRouter(routes, {
   rejections: [AuthRequired],
 })
 
-// Trigger from a hook — use throw to stop execution
+// Trigger from a hook — reject() throws internally, no `throw` needed
 myRoute.onBeforeRouteEnter((_to, { reject }) => {
-  throw reject('AuthRequired')
+  reject('AuthRequired')
 })
 ```
 
@@ -327,23 +338,24 @@ import { createRouterPlugin } from '@kitbag/router'
 const authPlugin = createRouterPlugin({
   routes: [loginRoute],
   rejections: [AuthRequired],
-  onBeforeRouteEnter: [(_to, { reject }) => {
-    if (!isAuthenticated()) throw reject('AuthRequired')
-  }],
 })
 
-const router = createRouter(routes, {
-  plugins: [authPlugin],
+// Hooks are registered as methods on the plugin, not in the options
+authPlugin.onBeforeRouteEnter((_to, { reject }) => {
+  if (!isAuthenticated()) reject('AuthRequired')
 })
+
+// Plugins are the 3rd positional argument to createRouter, not in options
+const router = createRouter(routes, { rejections: [AuthRequired] }, [authPlugin])
 ```
 
 ## Common Mistakes
 
 - **Don't use `:param` syntax** — use `[param]` with square brackets.
 - **Don't use `{ component: ... }` in route config** — use `.addView(Component)` chain.
-- **Don't use `<router-link to="/path">`** — use the callback `:to="(resolve) => resolve('name')"`.
+- **Prefer callback-style `<router-link :to="(resolve) => resolve('name')">`** for type-safe internal links. Plain URL strings and `ResolvedRoute` values are also accepted.
 - **Don't use `router.beforeEach`** — use `onBeforeRouteEnter` on routes or pass hooks to `createRouter`.
 - **Don't forget `as const`** on the routes array.
 - **Don't forget declaration merging** — register your router type or composables won't be typed.
 - **`useRoute().params` is reactive directly** — don't wrap in `.value`, it's not a ref. Supports `v-model`.
-- **Use `throw reject(...)` in hooks** — not just `reject(...)`. The `throw` is needed to stop hook execution.
+- **`reject()`, `abort()`, and `push()` throw internally** — no `throw` keyword needed in hooks.

--- a/skills/kitbag-router/SKILL.md
+++ b/skills/kitbag-router/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: kitbag-router
+description: >
+  Use when writing Vue 3 routing code with @kitbag/router — route definitions
+  with createRoute, type-safe navigation, params with withParams, route hooks,
+  rejections, RouterLink, RouterView, useRoute, useRouter, or useLink.
+---
+
+# @kitbag/router Skill
+
+Type-safe router for Vue 3. This is NOT vue-router — it has a completely different API.
+
+## Installation
+
+```bash
+npm install @kitbag/router
+```
+
+## Route Definitions
+
+Routes are created individually with `createRoute`, not as a config array:
+
+```ts
+import { createRoute, withParams } from '@kitbag/router'
+
+// Simple route
+const home = createRoute({ name: 'home', path: '/' })
+  .addView(HomeView)
+
+// Route with typed params
+const post = createRoute({
+  name: 'post',
+  path: withParams('/blog/[slug]', { slug: String }),
+})
+  .addView(PostView, {
+    props: (route) => ({ slug: route.params.slug }),
+  })
+
+// Nested route (parent-child)
+const settings = createRoute({ name: 'settings', path: '/settings' })
+  .addView(SettingsLayout)
+
+const profile = createRoute({
+  parent: settings,
+  name: 'profile',
+  path: '/profile',
+})
+  .addView(ProfileView)
+```
+
+Collect routes in an array with `as const`:
+
+```ts
+const routes = [home, post, settings, profile] as const
+```
+
+## Router Setup
+
+```ts
+import { createRouter } from '@kitbag/router'
+
+const router = createRouter(routes)
+
+// REQUIRED for type inference — register via declaration merging
+declare module '@kitbag/router' {
+  interface Register {
+    router: typeof router
+  }
+}
+
+// Install as Vue plugin
+app.use(router)
+```
+
+## Param Syntax
+
+Params use **square brackets**, not colons:
+
+- `[id]` — required param (matches one or more characters including `/`)
+- `[?id]` — optional param
+- `[id*]` — greedy (explicitly captures multiple segments)
+- `[?id*]` — optional greedy
+
+Type params with `withParams`:
+
+```ts
+import { withParams } from '@kitbag/router'
+
+// Built-in types: String, Number, Boolean, Date, RegExp, JSON
+path: withParams('/user/[userId]', { userId: Number })
+
+// Query params work the same way
+query: withParams('tab=[activeTab]', { activeTab: String })
+```
+
+Custom param types with `createParam` or any Zod/Valibot schema.
+
+## Navigation
+
+```ts
+const router = useRouter()
+
+// Type-safe — route name and params are checked at compile time
+router.push('post', { slug: 'hello-world' })
+router.replace('home')
+
+// Resolve without navigating
+const resolved = router.resolve('post', { slug: 'hello-world' })
+```
+
+## Components
+
+### RouterView
+
+```vue
+<template>
+  <router-view />
+  <!-- Named views -->
+  <router-view name="sidebar" />
+</template>
+```
+
+### RouterLink
+
+```vue
+<template>
+  <!-- Type-safe callback style (preferred) -->
+  <router-link :to="(resolve) => resolve('post', { slug: 'hello' })">
+    Read Post
+  </router-link>
+
+  <!-- Slot props for active state -->
+  <router-link :to="(resolve) => resolve('home')" v-slot="{ isExactActive }">
+    <span :class="{ active: isExactActive }">Home</span>
+  </router-link>
+</template>
+```
+
+## Composables
+
+### useRoute
+
+```ts
+import { useRoute } from '@kitbag/router'
+
+// All possible route params (union type)
+const route = useRoute()
+
+// Narrowed to specific route — params fully typed
+const postRoute = useRoute('post')
+postRoute.params.slug // string
+```
+
+### useRouter
+
+```ts
+import { useRouter } from '@kitbag/router'
+const router = useRouter()
+router.push('home')
+```
+
+### useLink
+
+```ts
+import { useLink } from '@kitbag/router'
+const link = useLink('post', { slug: 'hello' })
+link.isMatch // boolean ref
+link.isExactMatch // boolean ref
+link.push() // navigate
+```
+
+### useQueryValue
+
+```ts
+import { useQueryValue } from '@kitbag/router'
+const tab = useQueryValue('tab') // Ref<string | undefined>
+```
+
+## Hooks
+
+Register at route level or in components:
+
+```ts
+// Route-level
+myRoute.onBeforeRouteEnter((to, { reject, replace, abort }) => { ... })
+myRoute.onAfterRouteEnter((to) => { ... })
+myRoute.onBeforeRouteLeave((to, { abort }) => { ... })
+myRoute.onBeforeRouteUpdate((to, { abort }) => { ... })
+
+// In-component
+import { onBeforeRouteLeave, onBeforeRouteUpdate } from '@kitbag/router'
+onBeforeRouteLeave((to, { abort }) => { ... })
+```
+
+## Rejections (not vue-router errors)
+
+Handle 404 and custom rejections:
+
+```ts
+import { createRejection } from '@kitbag/router'
+
+const AuthRequired = createRejection({
+  type: 'AuthRequired',
+  component: LoginView,
+})
+
+const router = createRouter(routes, {
+  rejections: [AuthRequired],
+})
+
+// Trigger from a hook
+myRoute.onBeforeRouteEnter((to, { reject }) => {
+  reject('AuthRequired')
+})
+```
+
+Built-in `NotFound` rejection handles unmatched URLs automatically.
+
+## Plugins
+
+Bundle routes, rejections, and hooks for reuse:
+
+```ts
+import { createRouterPlugin } from '@kitbag/router'
+
+const authPlugin = createRouterPlugin({
+  routes: [loginRoute],
+  rejections: [AuthRequired],
+  onBeforeRouteEnter: [(to, { reject }) => {
+    if (!isAuthenticated()) reject('AuthRequired')
+  }],
+})
+
+const router = createRouter(routes, {
+  plugins: [authPlugin],
+})
+```
+
+## Common Mistakes
+
+- **Don't use `:param` syntax** — use `[param]` with square brackets.
+- **Don't use `{ component: ... }` in route config** — use `.addView(Component)` chain.
+- **Don't use `<router-link to="/path">`** — use the callback `:to="(resolve) => resolve('name')"`.
+- **Don't use `router.beforeEach`** — use `onBeforeRouteEnter` on routes or pass hooks to `createRouter`.
+- **Don't forget `as const`** on the routes array.
+- **Don't forget declaration merging** — register your router type or composables won't be typed.
+- **`useRoute().params` is reactive directly** — don't wrap in `.value`, it's not a ref.

--- a/skills/kitbag-router/SKILL.md
+++ b/skills/kitbag-router/SKILL.md
@@ -46,6 +46,10 @@ const profile = createRoute({
   path: '/profile',
 })
   .addView(ProfileView)
+
+// addView also accepts render functions
+const inline = createRoute({ name: 'inline', path: '/inline' })
+  .addView({ render: () => h('div', 'Inline content') })
 ```
 
 Collect routes in an array with `as const`:
@@ -89,11 +93,70 @@ import { withParams } from '@kitbag/router'
 // Built-in types: String, Number, Boolean, Date, RegExp, JSON
 path: withParams('/user/[userId]', { userId: Number })
 
-// Query params work the same way
+// Query params — with withParams for typed params
 query: withParams('tab=[activeTab]', { activeTab: String })
+
+// Query params — shorthand string for untyped params (defaults to String)
+query: 'search=[?search]'
 ```
 
-Custom param types with `createParam` or any Zod/Valibot schema.
+### unionOf and withDefault
+
+Use `unionOf` to restrict a param to specific string values, and `withDefault` to set a default:
+
+```ts
+import { withParams, unionOf, withDefault } from '@kitbag/router'
+
+const keys = createRoute({
+  name: 'keys',
+  path: '/keys',
+  query: withParams('sort=[?sort]', {
+    sort: withDefault(unionOf(['asc', 'desc']), 'asc'),
+  }),
+})
+```
+
+### Custom param types with createParam
+
+```ts
+import { createParam } from '@kitbag/router'
+
+const sortParam = createParam((value, { invalid }) => {
+  if (['asc', 'desc'].includes(value)) return value
+  throw invalid('invalid sort direction')
+}, 'asc') // second arg is default value
+```
+
+Custom params also work with Zod/Valibot schemas.
+
+## Context
+
+Routes can declare `context` — an array of other routes or rejections that become accessible only when that route is active:
+
+```ts
+const secretPage = createRoute({
+  name: 'secret',
+  path: '/secret',
+}).addView(SecretView)
+
+const main = createRoute({
+  name: 'main',
+  path: '/main',
+  context: [secretPage],
+}).addView(MainView)
+
+// Rejections can also be scoped via context
+const notAuthorized = createRejection({
+  type: 'NotAuthorized',
+  component: LoginView,
+})
+
+const protectedRoute = createRoute({
+  name: 'protected',
+  path: '/protected',
+  context: [notAuthorized],
+})
+```
 
 ## Navigation
 
@@ -117,6 +180,22 @@ const resolved = router.resolve('post', { slug: 'hello-world' })
   <router-view />
   <!-- Named views -->
   <router-view name="sidebar" />
+</template>
+```
+
+#### Scoped slot for transitions
+
+Use the `#default` slot with `{ component }` to wrap route views in `<transition>`:
+
+```vue
+<template>
+  <router-view>
+    <template #default="{ component }">
+      <transition name="fade" mode="out-in">
+        <component :is="component" />
+      </transition>
+    </template>
+  </router-view>
 </template>
 ```
 
@@ -151,6 +230,16 @@ const postRoute = useRoute('post')
 postRoute.params.slug // string
 ```
 
+Params are reactive and support `v-model` for two-way binding (useful for query params):
+
+```vue
+<input v-model="route.params.search" />
+<select v-model="route.params.sort">
+  <option value="asc">Ascending</option>
+  <option value="desc">Descending</option>
+</select>
+```
+
 ### useRouter
 
 ```ts
@@ -176,14 +265,26 @@ import { useQueryValue } from '@kitbag/router'
 const tab = useQueryValue('tab') // Ref<string | undefined>
 ```
 
+## Type Utilities
+
+### RouterRouteName
+
+Extract the union of all route names from a router instance:
+
+```ts
+import { RouterRouteName } from '@kitbag/router'
+
+export type MyRouteNames = RouterRouteName<typeof router>
+```
+
 ## Hooks
 
-Register at route level or in components:
+Register at route level or in components. Before-hooks receive a second argument with control methods. After-hooks also receive a second argument with `push` for navigation.
 
 ```ts
 // Route-level
 myRoute.onBeforeRouteEnter((to, { reject, replace, abort }) => { ... })
-myRoute.onAfterRouteEnter((to) => { ... })
+myRoute.onAfterRouteEnter((to, { push }) => { ... })
 myRoute.onBeforeRouteLeave((to, { abort }) => { ... })
 myRoute.onBeforeRouteUpdate((to, { abort }) => { ... })
 
@@ -208,9 +309,9 @@ const router = createRouter(routes, {
   rejections: [AuthRequired],
 })
 
-// Trigger from a hook
-myRoute.onBeforeRouteEnter((to, { reject }) => {
-  reject('AuthRequired')
+// Trigger from a hook — use throw to stop execution
+myRoute.onBeforeRouteEnter((_to, { reject }) => {
+  throw reject('AuthRequired')
 })
 ```
 
@@ -226,8 +327,8 @@ import { createRouterPlugin } from '@kitbag/router'
 const authPlugin = createRouterPlugin({
   routes: [loginRoute],
   rejections: [AuthRequired],
-  onBeforeRouteEnter: [(to, { reject }) => {
-    if (!isAuthenticated()) reject('AuthRequired')
+  onBeforeRouteEnter: [(_to, { reject }) => {
+    if (!isAuthenticated()) throw reject('AuthRequired')
   }],
 })
 
@@ -244,4 +345,5 @@ const router = createRouter(routes, {
 - **Don't use `router.beforeEach`** — use `onBeforeRouteEnter` on routes or pass hooks to `createRouter`.
 - **Don't forget `as const`** on the routes array.
 - **Don't forget declaration merging** — register your router type or composables won't be typed.
-- **`useRoute().params` is reactive directly** — don't wrap in `.value`, it's not a ref.
+- **`useRoute().params` is reactive directly** — don't wrap in `.value`, it's not a ref. Supports `v-model`.
+- **Use `throw reject(...)` in hooks** — not just `reject(...)`. The `throw` is needed to stop hook execution.


### PR DESCRIPTION
## Summary

- Adds `AGENTS.md` at package root with install instructions, 5 canonical usage patterns, type-inference gotchas, an "APIs that changed — don't write the old form" table, and key differences from vue-router
- Adds `skills/kitbag-router/SKILL.md` with frontmatter trigger conditions and a complete API reference covering routes, params, navigation, components, composables, hooks, rejections, and plugins
- Updates `package.json` `"files"` to include both so they ship in the npm tarball

These files help LLM coding agents generate correct @kitbag/router code instead of hallucinating vue-router patterns from stale training data. Compatible with [TanStack Intent](https://tanstack.com/intent/latest) discovery and manual agent config.

## Test plan

- [ ] Verify `npm pack --dry-run` includes `AGENTS.md` and `skills/kitbag-router/SKILL.md`
- [ ] Review AGENTS.md content for accuracy against current API
- [ ] Review SKILL.md frontmatter description for appropriate trigger conditions

🤖 Generated with [Claude Code](https://claude.com/claude-code)