### PR TITLE
Allow state shadowing between parent and child routes

### DIFF
--- a/src/compositions/useRoute.ts
+++ b/src/compositions/useRoute.ts
@@ -4,6 +4,7 @@ import { UseRouteInvalidError } from '@/errors/useRouteInvalidError'
 import { IsRouteOptions, createIsRoute, RouteWithMatch } from '@/guards/routes'
 import { Router, RouterRouteName } from '@/types/router'
 import { RouterRoute } from '@/types/routerRoute'
+import { resolveMatchStates } from '@/services/state'
 
 type UseRouteFunction<TRouter extends Router> = {
   (): TRouter['route'],
@@ -13,6 +14,25 @@ type UseRouteFunction<TRouter extends Router> = {
   <
     const TRouteName extends RouterRouteName<TRouter>
   >(routeName: TRouteName, options?: IsRouteOptions): RouteWithMatch<TRouter['route'], TRouteName>,
+}
+
+function createScopedRoute(route: RouterRoute, routeName: string): RouterRoute {
+  const matches = route.matches
+  const matchIndex = matches.findIndex((m) => m.name === routeName)
+
+  if (matchIndex === -1 || matchIndex === matches.length - 1) {
+    return route
+  }
+
+  return new Proxy(route, {
+    get(target, prop, receiver) {
+      if (prop === 'state') {
+        return resolveMatchStates(target.matchStates, matchIndex)
+      }
+
+      return Reflect.get(target, prop, receiver)
+    },
+  })
 }
 
 export function createUseRoute<TRouter extends Router>(routerKey: InjectionKey<TRouter>): UseRouteFunction<TRouter>
@@ -37,6 +57,10 @@ export function createUseRoute(routerKey: InjectionKey<Router>): (routeName?: st
 
     watch(router.route, checkRouteNameIsValid, { immediate: true, deep: true })
 
-    return router.route
+    if (!routeName) {
+      return router.route
+    }
+
+    return createScopedRoute(router.route, routeName)
   }
 }

--- a/src/services/combineState.spec.ts
+++ b/src/services/combineState.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test } from 'vitest'
-import { DuplicateParamsError } from '@/errors/duplicateParamsError'
 import { combineState } from '@/services/combineState'
 
 test('given 2 states, returns new State joined together', () => {
@@ -14,11 +13,13 @@ test('given 2 states, returns new State joined together', () => {
   })
 })
 
-test('given 2 states with params that include duplicates, throws DuplicateParamsError', () => {
-  const aState = { foz: String }
-  const bState = { foz: Number }
+test('given 2 states with duplicate keys, child overrides parent', () => {
+  const parentState = { foz: String }
+  const childState = { foz: Number }
 
-  const action: () => void = () => combineState(aState, bState)
+  const response = combineState(parentState, childState)
 
-  expect(action).toThrow(DuplicateParamsError)
+  expect(response).toMatchObject({
+    foz: Number,
+  })
 })

--- a/src/services/combineState.ts
+++ b/src/services/combineState.ts
@@ -1,14 +1,11 @@
 import { Param } from '@/types/paramTypes'
-import { checkDuplicateParams } from '@/utilities/checkDuplicateParams'
 
 export type CombineState<
   TParent extends Record<string, Param>,
   TChild extends Record<string, Param>
-> = TParent & TChild
+> = Omit<TParent, keyof TChild> & TChild
 
 export function combineState<TParentState extends Record<string, Param>, TChildState extends Record<string, Param>>(parentState: TParentState, childState: TChildState): CombineState<TParentState, TChildState>
 export function combineState(parentState: Record<string, Param>, childState: Record<string, Param>): Record<string, Param> {
-  checkDuplicateParams(parentState, childState)
-
   return { ...parentState, ...childState }
 }

--- a/src/services/createResolvedRoute.ts
+++ b/src/services/createResolvedRoute.ts
@@ -1,6 +1,6 @@
 import { parseUrl, updateUrl } from '@/services/urlParser'
 import { createResolvedRouteQuery } from '@/services/createResolvedRouteQuery'
-import { getStateValues } from '@/services/state'
+import { getMatchStates, resolveMatchStates } from '@/services/state'
 import { RouterResolveOptions } from '@/types/routerResolve'
 import { ResolvedRoute } from '@/types/resolved'
 import { isRoute, Route } from '@/types/route'
@@ -19,11 +19,14 @@ export function createResolvedRoute(route: Route, params: Record<string, unknown
     throw new Error('createResolvedRoute called with a route that has no matches')
   }
 
+  const matchStates = getMatchStates(route.matches, options.state)
+
   const resolvedRoute = {
     ...route,
     matched,
     query: createResolvedRouteQuery(query),
-    state: getStateValues(route.state, options.state),
+    matchStates,
+    state: resolveMatchStates(matchStates),
     hash,
     params,
     href,

--- a/src/services/createRoute.spec.ts
+++ b/src/services/createRoute.spec.ts
@@ -75,6 +75,25 @@ describe('combine', () => {
     })
   })
 
+  test('given parent and child with same state key, child overrides parent', () => {
+    const parent = createRoute({
+      state: {
+        foo: String,
+      },
+    })
+
+    const child = createRoute({
+      parent: parent,
+      state: {
+        foo: Number,
+      },
+    })
+
+    expect(child.state).toMatchObject({
+      foo: Number,
+    })
+  })
+
   test('given parent and child without state, state matches parent', () => {
     const parent = createRoute({
       state: {

--- a/src/services/createRouter.spec.ts
+++ b/src/services/createRouter.spec.ts
@@ -772,6 +772,52 @@ describe('router.push', () => {
 
     expect(router.route.state).toMatchObject({ zoo: 123 })
   })
+
+  test('given parent and child with shadowed state key, child value wins in merged state', async () => {
+    const parent = createRoute({
+      name: 'shadowParent',
+      path: '/shadow-parent',
+      state: { foo: String },
+    })
+
+    const child = createRoute({
+      parent,
+      name: 'shadowParent.shadowChild',
+      component,
+      path: '/shadow-child',
+      state: { foo: Number },
+    })
+
+    const router = createRouter([child], { initialUrl: '/' })
+
+    await router.push('shadowParent.shadowChild', {}, { state: { foo: 42 } })
+
+    expect(router.route.state).toMatchObject({ foo: 42 })
+  })
+
+  test('given parent and child with shadowed state, matchStates stores values per match', async () => {
+    const parent = createRoute({
+      name: 'shadowParent',
+      path: '/shadow-parent',
+      state: { foo: String },
+    })
+
+    const child = createRoute({
+      parent,
+      name: 'shadowParent.shadowChild',
+      component,
+      path: '/shadow-child',
+      state: { foo: Number },
+    })
+
+    const router = createRouter([child], { initialUrl: '/' })
+
+    await router.push('shadowParent.shadowChild', {}, { state: { foo: 42 } })
+
+    expect(router.route.matchStates).toHaveLength(2)
+    expect(router.route.matchStates[0]).toMatchObject({ foo: '42' })
+    expect(router.route.matchStates[1]).toMatchObject({ foo: 42 })
+  })
 })
 
 describe('router.onError', () => {

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -7,7 +7,7 @@ import { createPropStore } from '@/services/createPropStore'
 import { createRouterHistory } from '@/services/createRouterHistory'
 import { createRouterHooks, getRouterHooksKey } from '@/services/createRouterHooks'
 import { getInitialUrl } from '@/services/getInitialUrl'
-import { setStateValues } from '@/services/state'
+import { setMatchStates } from '@/services/state'
 import { Routes } from '@/types/route'
 import { Router, RouterOptions } from '@/types/router'
 import { RouterPush, RouterPushOptions } from '@/types/routerPush'
@@ -272,13 +272,13 @@ export function createRouter<
       const { replace, ...options }: RouterPushOptions = { ...maybeOptions }
       const params: any = { ...paramsOrOptions }
       const resolved = resolve(source, params, options)
-      const state = setStateValues({ ...resolved.matched.state }, { ...resolved.state, ...options.state })
+      const state = setMatchStates(resolved.matches, { ...resolved.state, ...options.state })
 
       return set(resolved.href, { replace, state })
     }
 
     const { replace, ...options }: RouterPushOptions = { ...paramsOrOptions }
-    const state = setStateValues({ ...source.matched.state }, { ...source.state, ...options.state })
+    const state = setMatchStates(source.matches, { ...source.state, ...options.state })
 
     const url = updateUrl(source.href, {
       query: options.query,

--- a/src/services/createRouterRoute.ts
+++ b/src/services/createRouterRoute.ts
@@ -110,6 +110,8 @@ export function createRouterRoute<TRoute extends ResolvedRoute>(routerKey: Injec
     },
   })
 
+  const matchStates = computed(() => route.matchStates)
+
   const state = computed({
     get() {
       return new Proxy(route.state, {
@@ -131,6 +133,7 @@ export function createRouterRoute<TRoute extends ResolvedRoute>(routerKey: Injec
     matched,
     matches,
     state,
+    matchStates,
     query,
     hash,
     params,

--- a/src/services/state.spec.ts
+++ b/src/services/state.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'vitest'
-import { getStateValues, setStateValues } from '@/services/state'
+import { getMatchStates, getStateValues, resolveMatchStates, setMatchStates, setStateValues } from '@/services/state'
 import { withDefault } from '@/services/withDefault'
 
 describe('setStateValues', () => {
@@ -108,5 +108,75 @@ describe('getStateValues', () => {
     expect(response).toMatchObject({
       foo: 456,
     })
+  })
+})
+
+describe('setMatchStates', () => {
+  test('serializes state per match', () => {
+    const matches: { state: Record<string, typeof String | typeof Number> }[] = [
+      { state: { foo: String } },
+      { state: { foo: Number, bar: Number } },
+    ]
+
+    const result = setMatchStates(matches, { foo: 42, bar: 10 })
+
+    expect(result).toHaveLength(2)
+    expect(result[0]).toMatchObject({ foo: '42' })
+    expect(result[1]).toMatchObject({ foo: '42', bar: '10' })
+  })
+})
+
+describe('getMatchStates', () => {
+  test('given per-match array, deserializes each match independently', () => {
+    const matches = [
+      { state: { foo: String } },
+      { state: { foo: Number } },
+    ]
+    const stored = [
+      { foo: '42' },
+      { foo: '42' },
+    ]
+
+    const result = getMatchStates(matches, stored)
+
+    expect(result[0]).toMatchObject({ foo: '42' })
+    expect(result[1]).toMatchObject({ foo: 42 })
+  })
+
+  test('given flat state object, distributes to all matches', () => {
+    const matches = [
+      { state: { foo: String } },
+      { state: { foo: Number } },
+    ]
+
+    const result = getMatchStates(matches, { foo: 42 })
+
+    expect(result[0]).toMatchObject({ foo: 42 })
+    expect(result[1]).toMatchObject({ foo: 42 })
+  })
+})
+
+describe('resolveMatchStates', () => {
+  test('merges match states with later matches overriding', () => {
+    const matchStates = [
+      { foo: 'hello', bar: 'world' },
+      { foo: 42 },
+    ]
+
+    const result = resolveMatchStates(matchStates)
+
+    expect(result).toMatchObject({ foo: 42, bar: 'world' })
+  })
+
+  test('given upToIndex, only includes matches up to that index', () => {
+    const matchStates = [
+      { foo: 'hello', bar: 'world' },
+      { foo: 42 },
+    ]
+
+    const result = resolveMatchStates(matchStates, 0)
+
+    expect(result).toMatchObject({ foo: 'hello', bar: 'world' })
+    expect(result).not.toHaveProperty('baz')
   })
 })

--- a/src/services/state.ts
+++ b/src/services/state.ts
@@ -63,3 +63,50 @@ export const setStateValues = (params: Record<string, Param>, state: unknown): R
 
   return values
 }
+
+type MatchWithState = { state?: Record<string, Param> }
+
+/**
+ * Serializes state values per match for storage in history. Each match's state
+ * keys are serialized using that match's param definitions.
+ */
+export function setMatchStates(matches: MatchWithState[], state: unknown): Record<string, string | undefined>[] {
+  return matches.map((match) => {
+    const params = match.state ?? {}
+    return setStateValues(params, state)
+  })
+}
+
+/**
+ * Deserializes per-match state values. Accepts either:
+ * - An array of per-match state records (from history)
+ * - A flat state object (from user-provided values, distributed to each match)
+ */
+export function getMatchStates(matches: MatchWithState[], state: unknown): Record<string, unknown>[] {
+  if (Array.isArray(state)) {
+    return matches.map((match, index) => {
+      const params = match.state ?? {}
+      return getStateValues(params, state[index])
+    })
+  }
+
+  return matches.map((match) => {
+    const params = match.state ?? {}
+    return getStateValues(params, state)
+  })
+}
+
+/**
+ * Merges per-match state values into a single flat object. Later matches override
+ * earlier ones (child shadows parent). Optionally stops at a given match index.
+ */
+export function resolveMatchStates(matchStates: Record<string, unknown>[], upToIndex?: number): Record<string, unknown> {
+  const end = upToIndex !== undefined ? upToIndex + 1 : matchStates.length
+  const result: Record<string, unknown> = {}
+
+  for (let i = 0; i < end; i++) {
+    Object.assign(result, matchStates[i])
+  }
+
+  return result
+}

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -40,8 +40,14 @@ export type ResolvedRoute<TRoute extends Route = Route> = Readonly<{
   params: UrlParamsReading<TRoute>,
   /**
    * Type for additional data intended to be stored in history state.
+   * Merged from all matches with child values overriding parent values.
    */
   state: ExtractRouteStateParamsAsOptional<TRoute['state']>,
+  /**
+   * State values stored per match, indexed by match depth.
+   * Used to resolve state scoped to a specific match level.
+   */
+  matchStates: Record<string, unknown>[],
   /**
    * String value of the resolved URL.
    */

--- a/src/types/route.ts
+++ b/src/types/route.ts
@@ -63,15 +63,21 @@ type RouteMetaOf<TMatches extends CreatedRouteOptions[]> = CreatedRouteOptions[]
     : {}
 
 /**
- * The state of every matched route, combined. Mirrors `combineState`, which is an intersection.
- * A match without state contributes `{}` rather than `ToState<undefined>`, which widens to
- * `Record<string, Param>` and would swallow the rest of the intersection.
+ * The state of every matched route, combined. Later matches (children) override earlier ones
+ * (parents) when they share a key, mirroring `combineState` which uses spread semantics.
  */
 type RouteStateOf<TMatches extends CreatedRouteOptions[]> = CreatedRouteOptions[] extends TMatches
   ? Record<string, Param>
   : TMatches extends [infer THead, ...infer TRest extends CreatedRouteOptions[]]
-    ? (THead extends { state: infer TState extends Record<string, Param> } ? ToState<TState> : {}) & RouteStateOf<TRest>
+    ? Omit<THead extends { state: infer TState extends Record<string, Param> } ? ToState<TState> : {}, RouteStateKeysOf<TRest>> & RouteStateOf<TRest>
     : {}
+
+/**
+ * Collects all state keys from the given matches, used to determine which parent keys are shadowed.
+ */
+type RouteStateKeysOf<TMatches extends CreatedRouteOptions[]> = TMatches extends [infer THead, ...infer TRest extends CreatedRouteOptions[]]
+  ? (THead extends { state: infer TState extends Record<string, Param> } ? keyof TState : never) | RouteStateKeysOf<TRest>
+  : never
 
 /**
  * The context of every matched route, flattened from greatest ancestor to narrowest matched.

--- a/src/types/routerRoute.ts
+++ b/src/types/routerRoute.ts
@@ -39,6 +39,7 @@ export type RouterRoute<TRoute extends ResolvedRoute = ResolvedRoute> = {
 
   params: TRoute['params'],
   state: TRoute['state'],
+  matchStates: TRoute['matchStates'],
 
   get query(): URLSearchParams,
   set query(value: QuerySource),


### PR DESCRIPTION
## Summary

- Parent and child routes can now define state with the same key name (previously threw `DuplicateParamsError`)
- Child's state definition overrides the parent's using `Omit<TParent, keyof TChild> & TChild` instead of intersection
- State values are stored per-match in history (array of per-match records) rather than flat, so each route level retains its own values
- `useRoute('parentName')` scopes state to that match level — the runtime value matches the TypeScript type
- Leaf matches still return `router.route` directly (preserving reference equality)

## Test plan

- [x] Existing tests pass (882 passed, 1 expected fail)
- [x] New unit tests for `combineState` with duplicate keys
- [x] New unit tests for `setMatchStates`, `getMatchStates`, `resolveMatchStates`
- [x] New integration tests for shadowed state in router push
- [x] New test for `createRoute` with shadowed state key
- [x] Type checking passes with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)