### PR TITLE
Require a rejection to declare an http status

### DIFF
--- a/docs/advanced-concepts/rejections.md
+++ b/docs/advanced-concepts/rejections.md
@@ -11,12 +11,18 @@ import { createRejection, createRouter } from '@kitbag/router'
 
 const authNeededRejection = createRejection({
   type: 'AuthNeeded',
+  status: 401,
 })
 
 export const router = createRouter(routes, {
   rejections: [authNeededRejection]
 })
 ```
+
+The `status` is what a server should respond with while the rejection is in effect. It is required
+because no default suits every rejection: `404` for something missing, `401` or `403` for something
+gated, `503` for something temporary. Client only apps never read it, but it has to be decided
+somewhere and the rejection is the only place with enough context.
 
 ## Rejection Component
 
@@ -27,6 +33,7 @@ import LoginView from '@/views/LoginView.vue'
 
 const authNeededRejection = createRejection({
   type: 'AuthNeeded',
+  status: 401,
   component: LoginView,
 })
 ```
@@ -46,6 +53,7 @@ import NotFoundPage from '@/components/NotFoundPage.vue'
 
 const notFoundRejection = createRejection({
   type: 'NotFound',
+  status: 404,
   component: NotFoundPage,
 })
 
@@ -105,6 +113,7 @@ import { createRejection } from '@kitbag/router'
 
 const authNeededRejection = createRejection({
   type: 'AuthNeeded',
+  status: 401,
 })
 
 authNeededRejection.setTitle((to, context) => {

--- a/src/components/routerView.browser.spec.ts
+++ b/src/components/routerView.browser.spec.ts
@@ -199,6 +199,8 @@ test('Renders custom genericRejection component when the initialUrl does not mat
   const NotFound = { template: 'Custom Not Found' }
   const notFoundRejection = createRejection({
     type: 'NotFound',
+
+    status: 404,
     component: NotFound,
   })
 
@@ -608,6 +610,8 @@ test('prefetched async props trigger push when navigation is initiated', async (
 test('Renders correct component when using default slot', async () => {
   const myRejection = createRejection({
     type: 'myRejection',
+
+    status: 404,
     component: {
       template: 'My Rejection',
     },
@@ -669,6 +673,8 @@ test('Renders the rejection component when the rejection is not registered on th
   const rejectionText = 'Rejection content to render'
   const myRejection = createRejection({
     type: 'myRejection',
+
+    status: 404,
     component: {
       template: rejectionText,
     },

--- a/src/services/addView.spec-d.ts
+++ b/src/services/addView.spec-d.ts
@@ -337,7 +337,7 @@ describe('addView', () => {
         },
       })
 
-      const rejection = createRejection({ type: 'NotAuthorized' })
+      const rejection = createRejection({ type: 'NotAuthorized', status: 404 })
 
       createRoute({ name: 'route', context: [rejection] }).addView(component, {
         props: (__, context) => {

--- a/src/services/createRejection.spec-d.ts
+++ b/src/services/createRejection.spec-d.ts
@@ -1,0 +1,9 @@
+import { test } from 'vitest'
+import { createRejection } from '@/services/createRejection'
+
+test('status is required', () => {
+  createRejection({ type: 'Unauthorized', status: 401 })
+
+  // @ts-expect-error a rejection has to say what a server should respond with
+  createRejection({ type: 'Unauthorized' })
+})

--- a/src/services/createRejection.spec.ts
+++ b/src/services/createRejection.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from 'vitest'
+import { createRejection } from '@/services/createRejection'
+import { createRoute } from '@/services/createRoute'
+import { getRoutesForRouter } from '@/services/getRoutesForRouter'
+import { component } from '@/utilities/testHelpers'
+
+test('given a status, stores it on the rejection', () => {
+  const rejection = createRejection({ type: 'Unauthorized', status: 401 })
+
+  expect(rejection.status).toBe(401)
+})
+
+test('stores whatever status was given', () => {
+  const rejection = createRejection({ type: 'Maintenance', status: 503 })
+
+  expect(rejection.status).toBe(503)
+})
+
+test('the built in NotFound rejection declares 404', () => {
+  const { getRejectionByType } = getRoutesForRouter([createRoute({ name: 'route', path: '/', component })])
+
+  expect(getRejectionByType('NotFound').status).toBe(404)
+})

--- a/src/services/createRejection.ts
+++ b/src/services/createRejection.ts
@@ -1,17 +1,14 @@
 import { createRejectionHooks } from '@/services/createRejectionHooks'
 import { genericRejection } from '@/components/rejection'
 import { RejectionHooks } from '@/types/hooks'
-import { IS_REJECTION_SYMBOL, Rejection, RejectionInternal } from '@/types/rejection'
-import { Component, markRaw } from 'vue'
+import { IS_REJECTION_SYMBOL, Rejection, RejectionInternal, RejectionOptions } from '@/types/rejection'
+import { markRaw } from 'vue'
 import { createRoute } from '@/services/createRoute'
 import { RouteSetTitle } from '@/types/routeTitle'
 
-export function createRejection<TType extends string>(options: {
-  type: TType,
-  component?: Component,
-}): Rejection<TType> & RejectionHooks<TType> & RouteSetTitle
+export function createRejection<TType extends string>(options: RejectionOptions<TType>): Rejection<TType> & RejectionHooks<TType> & RouteSetTitle
 
-export function createRejection({ type, component }: { type: string, component?: Component }): Rejection {
+export function createRejection({ type, component, status }: RejectionOptions): Rejection {
   const { store, ...hooks } = createRejectionHooks()
 
   const route = createRoute({
@@ -29,6 +26,7 @@ export function createRejection({ type, component }: { type: string, component?:
 
   const rejection = {
     type,
+    status,
     setTitle,
     ...hooks,
     ...internal,

--- a/src/services/createRoute.spec-d.ts
+++ b/src/services/createRoute.spec-d.ts
@@ -553,6 +553,8 @@ describe('props', () => {
     test('accepts built in rejections and custom rejections when context is provided', () => {
       const rejection = createRejection({
         type: 'NotAuthorized',
+
+        status: 404,
       })
 
       createRoute({
@@ -888,7 +890,7 @@ describe('hooks', () => {
 })
 
 test('given parent, context is combined', () => {
-  const parentRejection = createRejection({ type: 'aRejection' })
+  const parentRejection = createRejection({ type: 'aRejection', status: 404 })
   const childRelated = createRoute({ name: 'bRoute' })
 
   const parent = createRoute({

--- a/src/services/createRoute.spec.ts
+++ b/src/services/createRoute.spec.ts
@@ -113,7 +113,7 @@ describe('combine', () => {
   })
 
   test('given parent, context is combined', () => {
-    const parentRejection = createRejection({ type: 'aRejection' })
+    const parentRejection = createRejection({ type: 'aRejection', status: 404 })
     const childRelated = createRoute({ name: 'bRoute' })
 
     const parent = createRoute({

--- a/src/services/createRouter.browser.spec.ts
+++ b/src/services/createRouter.browser.spec.ts
@@ -43,6 +43,8 @@ describe('options.rejections', () => {
 
     const customRejection = createRejection({
       type: 'CustomRejection',
+
+      status: 404,
       component: { template: '<div>This is a custom rejection</div>' },
     })
 

--- a/src/services/createRouter.spec-d.ts
+++ b/src/services/createRouter.spec-d.ts
@@ -137,6 +137,8 @@ describe('rejections', () => {
   test('custom rejections are valid', () => {
     const myCustomRejection = createRejection({
       type: 'MyCustomRejection',
+
+      status: 404,
       component,
     })
 
@@ -153,6 +155,8 @@ describe('rejections', () => {
   test('custom rejections from plugins are valid', () => {
     const myPluginRejection = createRejection({
       type: 'MyPluginRejection',
+
+      status: 404,
       component,
     })
     const plugin = createRouterPlugin({
@@ -178,6 +182,8 @@ describe('options.rejections in hooks', () => {
 
     const customRejection = createRejection({
       type: 'CustomRejection',
+
+      status: 404,
       component: { template: '<div>This is a custom rejection</div>' },
     })
 
@@ -205,6 +211,8 @@ describe('options.rejections in hooks', () => {
 
     const customRejection = createRejection({
       type: 'CustomRejection',
+
+      status: 404,
       component: { template: '<div>This is a custom rejection</div>' },
     })
 

--- a/src/services/createRouter.spec.ts
+++ b/src/services/createRouter.spec.ts
@@ -907,6 +907,8 @@ describe('router.onRejection', () => {
 
     const rejection = createRejection({
       type: 'CustomRejection',
+
+      status: 404,
       component: { template: '<div>This is a custom rejection</div>' },
     })
 

--- a/src/services/createRouterPlugin.browser.spec.ts
+++ b/src/services/createRouterPlugin.browser.spec.ts
@@ -9,6 +9,8 @@ import { createRejection } from './createRejection'
 test('given a plugin, adds the routes to the router', async () => {
   const pluginRejection = createRejection({
     type: 'plugin',
+
+    status: 404,
     component,
   })
 
@@ -27,6 +29,8 @@ test('given a plugin, adds the routes to the router', async () => {
 test('given a plugin, adds the rejections to the router', async () => {
   const pluginRejection = createRejection({
     type: 'from-plugin',
+
+    status: 404,
     component: { template: '<div>This is a plugin rejection</div>' },
   })
 

--- a/src/services/createRouterPlugin.spec-d.ts
+++ b/src/services/createRouterPlugin.spec-d.ts
@@ -10,6 +10,8 @@ import { RouterReplace } from '@/types/routerReplace'
 describe('hooks', () => {
   const NotAuthorized = createRejection({
     type: 'NotAuthorized',
+
+    status: 404,
   })
 
   const plugin = createRouterPlugin({

--- a/src/services/getRoutesForRouter.ts
+++ b/src/services/getRoutesForRouter.ts
@@ -3,7 +3,7 @@ import { RouterPlugin } from '@/types/routerPlugin'
 import { DuplicateNamesError } from '@/errors/duplicateNamesError'
 import { isNamedRoute } from '@/utilities/isNamedRoute'
 import { insertBaseRoute } from '@/services/insertBaseRoute'
-import { BUILT_IN_REJECTION_TYPES, BuiltInRejectionType, isRejection, Rejection, RejectionInternal, Rejections } from '@/types/rejection'
+import { BUILT_IN_REJECTIONS, BuiltInRejectionType, isRejection, Rejection, RejectionInternal, Rejections } from '@/types/rejection'
 import { RouterOptions } from '@/types/router'
 import { createRejection } from '@/services/createRejection'
 
@@ -24,7 +24,7 @@ export function getRoutesForRouter(routes: Routes | Routes[], plugins: RouterPlu
   ]
 
   const allRejections = [
-    ...BUILT_IN_REJECTION_TYPES.map((type) => createRejection({ type })),
+    ...Object.entries(BUILT_IN_REJECTIONS).map(([type, status]) => createRejection({ type, status })),
     ...options.rejections ?? [],
     ...plugins.map((plugin) => plugin.rejections),
   ]

--- a/src/services/hooks.browser.spec.ts
+++ b/src/services/hooks.browser.spec.ts
@@ -246,6 +246,8 @@ test('rejection hooks are called correctly', async () => {
 
   const rejection = createRejection({
     type: 'CustomRejection',
+
+    status: 404,
   })
 
   rejection.onRejection((type, { to, from }) => onRejection(type, { to, from }))

--- a/src/types/rejection.ts
+++ b/src/types/rejection.ts
@@ -1,13 +1,16 @@
-import { Ref } from 'vue'
+import { Component, Ref } from 'vue'
 import { Route } from '@/types/route'
 import { Router } from '@/types/router'
 import { RouterReject } from '@/types/routerReject'
 import { Hooks } from '@/models/hooks'
 
-export const NOT_FOUND_REJECTION_TYPE = 'NotFound'
+export const BUILT_IN_REJECTIONS = {
+  NotFound: 404,
+} as const
 
-export const BUILT_IN_REJECTION_TYPES = [NOT_FOUND_REJECTION_TYPE] as const
-export type BuiltInRejectionType = (typeof BUILT_IN_REJECTION_TYPES)[number]
+export type BuiltInRejectionType = keyof typeof BUILT_IN_REJECTIONS
+
+export const NOT_FOUND_REJECTION_TYPE = 'NotFound' satisfies BuiltInRejectionType
 
 export type RouterRejection<T extends Rejection = Rejection> = Ref<T | null>
 export type RouterRejections<TRouter extends Router> = TRouter['reject'] extends RouterReject<infer TRejections extends Rejection[]> ? TRejections[number] : never
@@ -29,12 +32,23 @@ export type RejectionInternal = {
  */
 export type Rejections = readonly Rejection[]
 
-export type Rejection<TType extends string = string> = {
+export type RejectionOptions<TType extends string = string> = {
   /**
    * The type of rejection.
    */
   type: TType,
+  /**
+   * The component rendered while this rejection is in effect.
+   */
+  component?: Component,
+  /**
+   * The http status a server should respond with while this rejection is in effect. 404 for something
+   * missing, 401 or 403 for something gated, 503 for something temporary.
+   */
+  status: number,
 }
+
+export type Rejection<TType extends string = string> = Pick<RejectionOptions<TType>, 'type' | 'status'>
 
 export type RejectionType<TRejections extends Rejections | undefined> = unknown extends TRejections
   ? never

--- a/src/types/routeTitle.browser.spec.ts
+++ b/src/types/routeTitle.browser.spec.ts
@@ -170,7 +170,7 @@ test('route without title and parent with title updates document title', async (
 })
 
 test('rejection from a hook updates document title', async () => {
-  const locked = createRejection({ type: 'Locked', component })
+  const locked = createRejection({ type: 'Locked', status: 423, component })
 
   locked.setTitle(() => 'locked')
 


### PR DESCRIPTION
# Description

A server rendering the app needs to know what to respond with, and the rejection in effect is the thing that knows.

`status` is **required** rather than defaulted, because no default suits every rejection — 404 for something missing, 401 or 403 for something gated, 503 for something temporary. A client only app never reads it, but the decision has to live somewhere and the rejection is the only place with enough context. The built in `NotFound` declares 404.

```ts
const authNeeded = createRejection({
  type: 'AuthNeeded',
  status: 401,
})
```

Breaking: every `createRejection` call needs a status. Nothing reads it yet — `router.render` does, later in the stack.
