### PR TITLE
Add a tracker for outstanding asynchronous work

### DIFF
--- a/src/services/createActivityTracker.spec.ts
+++ b/src/services/createActivityTracker.spec.ts
@@ -1,0 +1,82 @@
+import { describe, expect, test } from 'vitest'
+import { createActivityTracker } from '@/services/createActivityTracker'
+
+describe('createActivityTracker', () => {
+  test('given no work, idle resolves', async () => {
+    const tracker = createActivityTracker()
+
+    await expect(tracker.idle()).resolves.toBeUndefined()
+  })
+
+  test('given outstanding work, idle waits for it', async () => {
+    const tracker = createActivityTracker()
+    const { promise, resolve } = Promise.withResolvers<string>()
+    let settled = false
+
+    tracker.add(promise)
+
+    const waiting = tracker.idle().then(() => {
+      settled = true
+    })
+
+    expect(settled).toBe(false)
+
+    resolve('done')
+    await waiting
+
+    expect(settled).toBe(true)
+  })
+
+  test('given work that rejects, idle still resolves', async () => {
+    const tracker = createActivityTracker()
+
+    tracker.add(Promise.reject(new Error('nope')))
+
+    await expect(tracker.idle()).resolves.toBeUndefined()
+  })
+
+  test('given work registered while idle is waiting, waits for that too', async () => {
+    const tracker = createActivityTracker()
+    const first = Promise.withResolvers<string>()
+    const second = Promise.withResolvers<string>()
+    let settled = false
+
+    tracker.add(first.promise)
+
+    const waiting = tracker.idle().then(() => {
+      settled = true
+    })
+
+    tracker.add(second.promise)
+    first.resolve('one')
+    await Promise.resolve()
+
+    expect(settled).toBe(false)
+
+    second.resolve('two')
+    await waiting
+
+    expect(settled).toBe(true)
+  })
+
+  test('wrap tracks a call for its whole duration', async () => {
+    const tracker = createActivityTracker()
+    const { promise, resolve } = Promise.withResolvers<string>()
+    let settled = false
+
+    const wrapped = tracker.wrap(() => promise)
+    const call = wrapped()
+
+    const waiting = tracker.idle().then(() => {
+      settled = true
+    })
+
+    expect(settled).toBe(false)
+
+    resolve('done')
+    await waiting
+
+    expect(settled).toBe(true)
+    await expect(call).resolves.toBe('done')
+  })
+})

--- a/src/services/createActivityTracker.ts
+++ b/src/services/createActivityTracker.ts
@@ -1,0 +1,37 @@
+export type ActivityTracker = {
+  add: (...work: Promise<unknown>[]) => void,
+  wrap: <TArgs extends unknown[], TResult>(fn: (...args: TArgs) => Promise<TResult>) => (...args: TArgs) => Promise<TResult>,
+  idle: () => Promise<void>,
+}
+
+export function createActivityTracker(): ActivityTracker {
+  const outstanding = new Set<Promise<unknown>>()
+
+  const add: ActivityTracker['add'] = (...work) => {
+    work.forEach((promise) => {
+      outstanding.add(promise)
+
+      void promise.catch(() => undefined).finally(() => outstanding.delete(promise))
+    })
+  }
+
+  const wrap: ActivityTracker['wrap'] = (fn) => (...args) => {
+    const result = fn(...args)
+
+    add(result)
+
+    return result
+  }
+
+  const idle: ActivityTracker['idle'] = async () => {
+    while (outstanding.size > 0) {
+      await Promise.allSettled([...outstanding])
+    }
+  }
+
+  return {
+    add,
+    wrap,
+    idle,
+  }
+}


### PR DESCRIPTION
# Description

Waiting for the router to go quiet means waiting for work registered *while* earlier work settles: a props getter or loader that pushes starts a navigation whose own values must also settle. So `idle` loops rather than awaiting once.

Nothing uses it yet — `router.render` does, next in the stack.
