### PR TITLE
Add router.render for waiting on a navigation's data

### DIFF
--- a/src/errors/renderInBrowserError.ts
+++ b/src/errors/renderInBrowserError.ts
@@ -1,0 +1,9 @@
+/**
+ * An error thrown when router.render is called in the browser, where it is not available.
+ * @group Errors
+ */
+export class RenderInBrowserError extends Error {
+  public constructor() {
+    super('router.render is only available when server rendering')
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -87,6 +87,7 @@ export { MetaPropertyConflict } from './errors/metaPropertyConflict'
 export { NavigationAbandonedError } from './errors/navigationAbandonedError'
 export { RouterNotInstalledError } from './errors/routerNotInstalledError'
 export { UseRouteInvalidError } from './errors/useRouteInvalidError'
+export { RenderInBrowserError } from './errors/renderInBrowserError'
 
 // Services
 export { createRoute } from './services/createRoute'

--- a/src/services/createRouter.spec.ts
+++ b/src/services/createRouter.spec.ts
@@ -1098,3 +1098,147 @@ test('going back from a redirect returns to the route before it', async () => {
 
   expect(router.route.name).toBe('home')
 })
+
+describe('router.render response', () => {
+  test('given a url that matches a route, returns 200', async () => {
+    const route = createRoute({ name: 'route', component, path: '/' })
+    const router = createRouter([route], { initialUrl: '/' })
+
+    await router.start()
+
+    const result = await router.render()
+
+    expect(result).toMatchObject({ status: 200, rejection: null })
+    expect(result.location).toBeUndefined()
+  })
+
+  test('given a url that matches no route, returns 404', async () => {
+    const route = createRoute({ name: 'route', component, path: '/foo' })
+    const router = createRouter([route], { initialUrl: '/does-not-exist' })
+
+    await router.start()
+
+    const result = await router.render()
+
+    expect(result.status).toBe(404)
+  })
+
+  test('given a hook that rejects with NotFound, returns 404', async () => {
+    const route = createRoute({ name: 'route', component, path: '/' })
+
+    route.onBeforeRouteEnter((_to, { reject }) => {
+      reject('NotFound')
+    })
+
+    const router = createRouter([route], { initialUrl: '/' })
+
+    await router.start()
+
+    const result = await router.render()
+
+    expect(result).toMatchObject({ status: 404, rejection: 'NotFound' })
+  })
+
+  test('given a rejection that declares a status, returns that status', async () => {
+    const rejection = createRejection({ type: 'Unauthorized', status: 401 })
+    const route = createRoute({ name: 'route', component, path: '/' })
+    const router = createRouter([route], { initialUrl: '/', rejections: [rejection] })
+
+    router.onBeforeRouteEnter((_to, { reject }) => {
+      reject('Unauthorized')
+    })
+
+    await router.start()
+
+    const result = await router.render()
+
+    expect(result).toMatchObject({ status: 401, rejection: 'Unauthorized' })
+  })
+
+  test('given a rejection, returns the status it declared', async () => {
+    const rejection = createRejection({ type: 'Maintenance', status: 503 })
+    const route = createRoute({ name: 'route', component, path: '/' })
+    const router = createRouter([route], { initialUrl: '/', rejections: [rejection] })
+
+    router.onBeforeRouteEnter((_to, { reject }) => {
+      reject('Maintenance')
+    })
+
+    await router.start()
+
+    const result = await router.render()
+
+    expect(result).toMatchObject({ status: 503, rejection: 'Maintenance' })
+  })
+
+  test('given a url with a trailing slash, redirects to the url without it', async () => {
+    const route = createRoute({ name: 'route', component, path: '/foo' })
+    const router = createRouter([route], { initialUrl: '/foo/' })
+
+    await router.start()
+
+    const result = await router.render()
+
+    expect(result).toMatchObject({ status: 302, location: '/foo' })
+  })
+
+  test('given redirectStatus, uses it for a normalized url', async () => {
+    const route = createRoute({ name: 'route', component, path: '/foo' })
+    const router = createRouter([route], { initialUrl: '/foo/', redirectStatus: 301 })
+
+    await router.start()
+
+    const result = await router.render()
+
+    expect(result).toMatchObject({ status: 301, location: '/foo' })
+  })
+
+  test('given removeTrailingSlashes false, does not normalize', async () => {
+    const route = createRoute({ name: 'route', component, path: '/foo' })
+    const router = createRouter([route], { initialUrl: '/foo/', removeTrailingSlashes: false })
+
+    await router.start()
+
+    const result = await router.render()
+
+    expect(result.location).toBeUndefined()
+  })
+
+  test('given a route that redirects, returns 302 to the destination', async () => {
+    const from = createRoute({ name: 'from', component, path: '/from' })
+    const to = createRoute({ name: 'to', component, path: '/to' })
+
+    from.redirectTo(to)
+
+    const router = createRouter([from, to], { initialUrl: '/from' })
+
+    await router.start()
+
+    const result = await router.render()
+
+    expect(result).toMatchObject({ status: 302, location: '/to' })
+  })
+
+  test('given extra query params that the router reorders, does not report a redirect', async () => {
+    const route = createRoute({ name: 'route', component, path: '/', query: 'foo=[param]' })
+    const router = createRouter([route], { initialUrl: '/?extra=42&foo=1' })
+
+    await router.start()
+
+    const result = await router.render()
+
+    expect(result).toMatchObject({ status: 200, rejection: null })
+  })
+
+  test('calling render again resolves with the same response', async () => {
+    const route = createRoute({ name: 'route', component, path: '/' })
+    const router = createRouter([route], { initialUrl: '/' })
+
+    await router.start()
+
+    const first = await router.render()
+    const second = await router.render()
+
+    expect(second).toStrictEqual(first)
+  })
+})

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -2,6 +2,10 @@ import { createPath } from '@/services/history'
 import { App, ref } from 'vue'
 import { createCurrentRoute } from '@/services/createCurrentRoute'
 import { createIsExternal } from '@/services/createIsExternal'
+import { createActivityTracker } from '@/services/createActivityTracker'
+import { getResponse } from '@/services/getResponse'
+import { RenderInBrowserError } from '@/errors/renderInBrowserError'
+import { isBrowser } from '@/utilities/isBrowser'
 import { parseUrl, updateUrl } from '@/services/urlParser'
 import { createRouteValueStore, RouteValueResponse } from '@/services/createRouteValueStore'
 import { DataKind } from '@/services/createNavigationStores'
@@ -11,7 +15,7 @@ import { getInitialUrl } from '@/services/getInitialUrl'
 import { setStateValues } from '@/services/state'
 import { Routes } from '@/types/route'
 import { NOT_FOUND_REJECTION_TYPE } from '@/types/rejection'
-import { Router, RouterOptions } from '@/types/router'
+import { Router, RouterOptions, RenderOutcome } from '@/types/router'
 import { RouterPush, RouterPushOptions } from '@/types/routerPush'
 import { RouterReplace, RouterReplaceOptions } from '@/types/routerReplace'
 import { RoutesName } from '@/types/routesMap'
@@ -91,6 +95,8 @@ export function createRouter<
   const isGlobalRouter = options?.isGlobalRouter ?? true
   const routerKey = isGlobalRouter ? routerInjectionKey : Symbol()
   const shouldRemoveTrailingSlashes = options?.removeTrailingSlashes ?? true
+  const redirectStatus = options?.redirectStatus ?? 302
+  const activity = createActivityTracker()
   const { routes, getRouteByName, getRejectionByType } = getRoutesForRouter(routesOrArrayOfRoutes, plugins, options)
   const notFoundRejection = getRejectionByType('NotFound')
   const valueStore = createRouteValueStore()
@@ -120,7 +126,7 @@ export function createRouter<
     return getMatchForUrl(filteredRoutes, url, { ...resolveOptions, ...parseOptions })
   }
 
-  async function set(url: string, options: RouterUpdateOptions = {}): Promise<void> {
+  const set = activity.wrap(async (url: string, options: RouterUpdateOptions = {}): Promise<void> => {
     if (pathHasTrailingSlash(url) && shouldRemoveTrailingSlashes) {
       const cleanedUrl = removeTrailingSlashesFromPath(url)
 
@@ -199,13 +205,15 @@ export function createRouter<
     } finally {
       history.startListening()
     }
-  }
+  })
 
   function setRouteValuesAndUpdateRoute(to: ResolvedRoute, from: ResolvedRoute | null): void {
     const { props, loaders } = valueStore.setRouteValues(to)
 
-    handleRouteValueResponse(props, 'props', to, from)
-    handleRouteValueResponse(loaders, 'loader', to, from)
+    activity.add(
+      handleRouteValueResponse(props, 'props', to, from),
+      handleRouteValueResponse(loaders, 'loader', to, from),
+    )
 
     updateRoute(to)
   }
@@ -214,8 +222,8 @@ export function createRouter<
    * Props and loaders are handled the same way, and neither is awaited here: a push or a rejection from
    * either is acted on whenever it arrives, without holding up the navigation that started it.
    */
-  function handleRouteValueResponse(response: Promise<RouteValueResponse>, source: DataKind, to: ResolvedRoute, from: ResolvedRoute | null): void {
-    response
+  function handleRouteValueResponse(response: Promise<RouteValueResponse>, source: DataKind, to: ResolvedRoute, from: ResolvedRoute | null): Promise<void> {
+    return response
       .then((response) => {
         switch (response.status) {
           case 'SUCCESS':
@@ -380,6 +388,29 @@ export function createRouter<
     started.value = true
   }
 
+  /**
+   * Does not resolve until the router has finished everything a view needs to render completely, and
+   * reports the status a server should respond with.
+   *
+   * Only available on the server for ssr. Throws {@link RenderInBrowserError} when called in the client.
+   */
+  async function render(): Promise<RenderOutcome> {
+    if (isBrowser()) {
+      throw new RenderInBrowserError()
+    }
+
+    await start()
+    await activity.idle()
+
+    return getResponse({
+      initialUrl,
+      route: currentRoute,
+      rejection: currentRejection.value,
+      removeTrailingSlashes: shouldRemoveTrailingSlashes,
+      redirectStatus,
+    })
+  }
+
   function stop(): void {
     history.stopListening()
   }
@@ -435,6 +466,7 @@ export function createRouter<
     prefetch: options?.prefetch,
     start,
     started,
+    render,
     stop,
     key: routerKey,
     hasDevtools: false,

--- a/src/services/getResponse.spec.ts
+++ b/src/services/getResponse.spec.ts
@@ -1,0 +1,94 @@
+import { expect, test } from 'vitest'
+import { getResponse, GetResponseContext } from '@/services/getResponse'
+import { Rejection } from '@/types/rejection'
+import { ResolvedRoute } from '@/types/resolved'
+
+function route(href: string): ResolvedRoute {
+  return { href } as ResolvedRoute
+}
+
+function context(overrides: Partial<GetResponseContext> = {}): GetResponseContext {
+  return {
+    initialUrl: '/foo',
+    route: route('/foo'),
+    rejection: null,
+    removeTrailingSlashes: true,
+    redirectStatus: 302,
+    ...overrides,
+  }
+}
+
+test('given the settled route matches the initial url, returns 200', () => {
+  expect(getResponse(context())).toStrictEqual({ status: 200, rejection: null })
+})
+
+test('given a trailing slash on the initial url, redirects to the settled url', () => {
+  const response = getResponse(context({ initialUrl: '/foo/' }))
+
+  expect(response).toStrictEqual({ status: 302, location: '/foo', rejection: null })
+})
+
+test('given a redirectStatus of 301, uses it for a normalized url', () => {
+  const response = getResponse(context({ initialUrl: '/foo/', redirectStatus: 301 }))
+
+  expect(response).toStrictEqual({ status: 301, location: '/foo', rejection: null })
+})
+
+test('given removeTrailingSlashes is false, does not report a normalization', () => {
+  const response = getResponse(context({
+    initialUrl: '/foo/',
+    route: route('/foo/'),
+    removeTrailingSlashes: false,
+  }))
+
+  expect(response).toStrictEqual({ status: 200, rejection: null })
+})
+
+test('given the NotFound rejection, returns 404', () => {
+  const rejection: Rejection = { type: 'NotFound', status: 404 }
+  const response = getResponse(context({ rejection }))
+
+  expect(response).toStrictEqual({ status: 404, rejection: 'NotFound' })
+})
+
+test('given a rejection with a status, returns that status', () => {
+  const rejection: Rejection = { type: 'Unauthorized', status: 401 }
+  const response = getResponse(context({ rejection }))
+
+  expect(response).toStrictEqual({ status: 401, rejection: 'Unauthorized' })
+})
+
+test('given a rejection, returns the status it declared', () => {
+  const rejection: Rejection = { type: 'Maintenance', status: 503 }
+  const response = getResponse(context({ rejection }))
+
+  expect(response).toStrictEqual({ status: 503, rejection: 'Maintenance' })
+})
+
+test('given a rejection, prefers it over a redirect', () => {
+  const rejection: Rejection = { type: 'Unauthorized', status: 401 }
+  const response = getResponse(context({ rejection, route: route('/bar') }))
+
+  expect(response.status).toBe(401)
+})
+
+test('given the settled url differs from the initial url, returns 302 to it', () => {
+  const response = getResponse(context({ route: route('/bar') }))
+
+  expect(response).toStrictEqual({ status: 302, location: '/bar', rejection: null })
+})
+
+test('given an absolute initial url and a relative settled url, does not report a redirect', () => {
+  const response = getResponse(context({ initialUrl: 'https://kitbag.dev/foo' }))
+
+  expect(response.status).toBe(200)
+})
+
+test('given query params the router reordered, does not report a redirect', () => {
+  const response = getResponse(context({
+    initialUrl: '/foo?extra=42&bar=1',
+    route: route('/foo?bar=1&extra=42'),
+  }))
+
+  expect(response.status).toBe(200)
+})

--- a/src/services/getResponse.ts
+++ b/src/services/getResponse.ts
@@ -1,0 +1,49 @@
+import { Rejection } from '@/types/rejection'
+import { ResolvedRoute } from '@/types/resolved'
+import { RedirectStatus, RenderOutcome } from '@/types/router'
+import { isSameUrl } from '@/services/urlParser'
+import { pathHasTrailingSlash } from '@/utilities/trailingSlashes'
+
+export type GetResponseContext = {
+  /**
+   * The url the router started on.
+   */
+  initialUrl: string,
+  /**
+   * The route the router settled on.
+   */
+  route: ResolvedRoute,
+  /**
+   * The rejection in effect, or null.
+   */
+  rejection: Rejection | null,
+  /**
+   * Whether the router removes trailing slashes.
+   */
+  removeTrailingSlashes: boolean,
+  /**
+   * The status to report when the url was normalized rather than redirected by the app.
+   */
+  redirectStatus: RedirectStatus,
+}
+
+/**
+ * What a server should respond with, given where the router settled.
+ */
+export function getResponse({ initialUrl, route, rejection, removeTrailingSlashes, redirectStatus }: GetResponseContext): RenderOutcome {
+  const type = rejection?.type ?? null
+
+  if (removeTrailingSlashes && pathHasTrailingSlash(initialUrl)) {
+    return { status: redirectStatus, location: route.href, rejection: type }
+  }
+
+  if (rejection) {
+    return { status: rejection.status, rejection: type }
+  }
+
+  if (!isSameUrl(initialUrl, route.href)) {
+    return { status: 302, location: route.href, rejection: type }
+  }
+
+  return { status: 200, rejection: type }
+}

--- a/src/services/urlParser.ts
+++ b/src/services/urlParser.ts
@@ -36,6 +36,25 @@ export function parseUrl(value: string): UrlParts {
   return isRelative ? createRelativeUrl(value) : createAbsoluteUrl(value)
 }
 
+/**
+ * Ignores host, and sorts query params because the router reorders them when it separates declared
+ * params from the rest.
+ */
+export function isSameUrl(left: string, right: string): boolean {
+  const a = parseUrl(left)
+  const b = parseUrl(right)
+
+  return a.path === b.path && a.hash === b.hash && sortedQuery(a.query) === sortedQuery(b.query)
+}
+
+function sortedQuery(query: URLSearchParams): string {
+  const sorted = new URLSearchParams(query)
+
+  sorted.sort()
+
+  return sorted.toString()
+}
+
 export function updateUrl(url: string, updates: UrlPartsInput): UrlString
 export function updateUrl(url: Partial<UrlParts>, updates: UrlPartsInput): UrlParts
 export function updateUrl(url: string | Partial<UrlParts>, updates: UrlPartsInput): string | UrlParts {

--- a/src/tests/render.browser.spec.ts
+++ b/src/tests/render.browser.spec.ts
@@ -1,0 +1,14 @@
+import { expect, test } from 'vitest'
+import { createRoute } from '@/services/createRoute'
+import { createRouter } from '@/services/createRouter'
+import { RenderInBrowserError } from '@/errors/renderInBrowserError'
+import { component } from '@/utilities/testHelpers'
+
+test('throws in the browser, where the response it reports would be meaningless', async () => {
+  const route = createRoute({ name: 'route', path: '/', component })
+  const router = createRouter([route], { initialUrl: '/' })
+
+  await router.start()
+
+  await expect(router.render()).rejects.toThrow(RenderInBrowserError)
+})

--- a/src/tests/render.spec.ts
+++ b/src/tests/render.spec.ts
@@ -1,0 +1,242 @@
+import { flushPromises } from '@vue/test-utils'
+import { describe, expect, test, vi } from 'vitest'
+import { createRoute } from '@/services/createRoute'
+import { createRouter } from '@/services/createRouter'
+import { component } from '@/utilities/testHelpers'
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => {
+  setTimeout(resolve, ms)
+})
+
+describe('router.render', () => {
+  test('waits for a loader to settle', async () => {
+    const { promise, resolve } = Promise.withResolvers<string>()
+    const route = createRoute({ name: 'route', path: '/', component }).addLoader(() => promise)
+    const router = createRouter([route], { initialUrl: '/' })
+
+    await router.start()
+
+    let rendered = false
+
+    const rendering = router.render().then(() => {
+      rendered = true
+    })
+
+    await flushPromises()
+
+    expect(rendered).toBe(false)
+
+    resolve('loaded')
+    await rendering
+
+    expect(rendered).toBe(true)
+    await expect(router.route.data).resolves.toBe('loaded')
+  })
+
+  test('waits for props to settle', async () => {
+    const { promise, resolve } = Promise.withResolvers<string>()
+    const props = vi.fn(async () => ({ value: await promise }))
+    const route = createRoute({ name: 'route', path: '/' }).addView(component, { props })
+    const router = createRouter([route], { initialUrl: '/' })
+
+    await router.start()
+
+    let rendered = false
+
+    const rendering = router.render().then(() => {
+      rendered = true
+    })
+
+    await flushPromises()
+
+    expect(rendered).toBe(false)
+
+    resolve('props')
+    await rendering
+
+    expect(rendered).toBe(true)
+    expect(props).toHaveBeenCalled()
+  })
+
+  test('start does not wait for a loader', async () => {
+    const { promise, resolve } = Promise.withResolvers<string>()
+    const route = createRoute({ name: 'route', path: '/', component }).addLoader(() => promise)
+    const router = createRouter([route], { initialUrl: '/' })
+
+    await router.start()
+
+    expect(router.route.name).toBe('route')
+
+    resolve('late')
+  })
+
+  test('resolves immediately when there is nothing left to render', async () => {
+    const route = createRoute({ name: 'route', path: '/', component })
+    const router = createRouter([route], { initialUrl: '/' })
+
+    await router.start()
+
+    await expect(router.render()).resolves.toMatchObject({ status: 200, rejection: null })
+  })
+
+  test('after a push, waits for the new route data', async () => {
+    const { promise, resolve } = Promise.withResolvers<string>()
+    const other = createRoute({ name: 'other', path: '/other', component }).addLoader(() => promise)
+    const home = createRoute({ name: 'home', path: '/', component })
+    const router = createRouter([home, other], { initialUrl: '/' })
+
+    await router.start()
+    await router.push('other')
+
+    let rendered = false
+
+    const rendering = router.render().then(() => {
+      rendered = true
+    })
+
+    await flushPromises()
+
+    expect(rendered).toBe(false)
+
+    resolve('loaded')
+    await rendering
+
+    expect(rendered).toBe(true)
+    await expect(router.route.data).resolves.toBe('loaded')
+  })
+
+  test('given a loader that rejects the navigation, reports the rejection status', async () => {
+    const route = createRoute({ name: 'route', path: '/', component })
+      .addLoader(async (_route, { reject }) => {
+        await Promise.resolve()
+        reject('NotFound')
+      })
+
+    const router = createRouter([route], { initialUrl: '/' })
+
+    await router.start()
+
+    const result = await router.render()
+
+    expect(result).toMatchObject({ status: 404, rejection: 'NotFound' })
+  })
+
+  test('waits for work a cascading navigation registers after the first drain', async () => {
+    const first = Promise.withResolvers<string>()
+    const second = Promise.withResolvers<string>()
+
+    const other = createRoute({ name: 'other', path: '/other', component })
+      .addLoader(() => second.promise)
+
+    const route = createRoute({ name: 'route', path: '/', component, context: [other] })
+      .addLoader(async (_route, { push }) => {
+        await first.promise
+        push('other')
+      })
+
+    const router = createRouter([route, other], { initialUrl: '/' })
+
+    await router.start()
+
+    let rendered = false
+
+    const rendering = router.render().then(() => {
+      rendered = true
+    })
+
+    first.resolve('one')
+    await flushPromises()
+
+    expect(rendered).toBe(false)
+
+    second.resolve('two')
+    await rendering
+
+    expect(rendered).toBe(true)
+    expect(router.route.name).toBe('other')
+  })
+
+  test('given a props getter that pushes, reports the redirect before anything renders', async () => {
+    const other = createRoute({ name: 'other', path: '/other' })
+      .addView(component, { props: () => ({ value: 'other' }) })
+
+    const route = createRoute({ name: 'route', path: '/', context: [other] })
+      .addView(component, {
+        props: async (_route, { push }) => {
+          await Promise.resolve()
+          push('other')
+
+          return { value: 'route' }
+        },
+      })
+
+    const router = createRouter([route, other], { initialUrl: '/' })
+
+    await router.start()
+
+    const result = await router.render()
+
+    expect(result).toMatchObject({ status: 302, location: '/other' })
+    expect(router.route.name).toBe('other')
+  })
+
+  test('waits for a cascading navigation that registers its data behind a slow hook', async () => {
+    const other = createRoute({ name: 'other', path: '/other', component })
+      .addLoader(async () => {
+        await sleep(20)
+
+        return 'other-data'
+      })
+
+    other.onBeforeRouteEnter(async () => {
+      await sleep(20)
+    })
+
+    const route = createRoute({ name: 'route', path: '/', component, context: [other] })
+      .addLoader((_route, { push }) => push('other'))
+
+    const router = createRouter([route, other], { initialUrl: '/' })
+
+    await router.start()
+
+    const response = await router.render()
+
+    expect(response.status).toBe(302)
+    expect(router.route.name).toBe('other')
+    await expect(router.route.data).resolves.toBe('other-data')
+  })
+
+  test('given a loader that pushes, waits for the navigation it caused', async () => {
+    const other = createRoute({ name: 'other', path: '/other', component })
+    const route = createRoute({ name: 'route', path: '/', component, context: [other] })
+      .addLoader((_route, { push }) => push('other'))
+
+    const router = createRouter([route, other], { initialUrl: '/' })
+
+    await router.start()
+
+    const result = await router.render()
+
+    expect(router.route.name).toBe('other')
+    expect(result.status).toBe(302)
+  })
+})
+
+test('render starts the router when it has not been started', async () => {
+  const route = createRoute({ name: 'route', path: '/foo', component })
+  const router = createRouter([route], { initialUrl: '/foo' })
+
+  const result = await router.render()
+
+  expect(result).toMatchObject({ status: 200, rejection: null })
+  expect(router.started.value).toBe(true)
+})
+
+test('render on an unstarted router does not report a bogus success for an unmatched url', async () => {
+  const route = createRoute({ name: 'route', path: '/foo', component })
+  const router = createRouter([route], { initialUrl: '/nope' })
+
+  const result = await router.render()
+
+  expect(result.status).toBe(404)
+})

--- a/src/types/renderOutcome.spec-d.ts
+++ b/src/types/renderOutcome.spec-d.ts
@@ -1,0 +1,29 @@
+import { expectTypeOf, test } from 'vitest'
+import { createRoute } from '@/services/createRoute'
+import { createRouter } from '@/services/createRouter'
+import { createRejection } from '@/services/createRejection'
+import { component } from '@/utilities/testHelpers'
+
+test('rejection is the router\'s rejection types, not string', async () => {
+  const unauthorized = createRejection({ type: 'Unauthorized', status: 401 })
+  const route = createRoute({ name: 'route', path: '/', component })
+  const router = createRouter([route], { initialUrl: '/', rejections: [unauthorized] })
+
+  const outcome = await router.render()
+
+  expectTypeOf(outcome.rejection).toEqualTypeOf<'Unauthorized' | 'NotFound' | null>()
+})
+
+test('location narrows the status to a redirect', async () => {
+  const route = createRoute({ name: 'route', path: '/', component })
+  const router = createRouter([route], { initialUrl: '/' })
+
+  const outcome = await router.render()
+
+  if (outcome.location !== undefined) {
+    expectTypeOf(outcome.location).toEqualTypeOf<string>()
+    expectTypeOf(outcome.status).toEqualTypeOf<301 | 302>()
+  } else {
+    expectTypeOf(outcome.status).toEqualTypeOf<number>()
+  }
+})

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -55,6 +55,16 @@ export type RouterOptions = {
   removeTrailingSlashes?: boolean,
 
   /**
+   * The status `render` reports when it normalized the url it was given, such as removing a trailing
+   * slash. Defaults to 302 because a 301 is cached indefinitely by browsers and CDNs and cannot be
+   * recalled, and trailing slash removal is on by default. Set 301 to have the normalization treated as
+   * permanent.
+   *
+   * @default 302
+   */
+  redirectStatus?: RedirectStatus,
+
+  /**
    * When false, createRouterAssets must be used for component and hooks. Assets exported by the library
    * will not work with the created router instance.
    *
@@ -62,6 +72,44 @@ export type RouterOptions = {
    */
   isGlobalRouter?: boolean,
 }
+
+/**
+ * What a server should respond with for what the router rendered. `location` exists only on a redirect,
+ * so narrowing on it is what proves a `Location` header is available.
+ */
+export type RenderOutcome<TRejectionType extends string = string> = RenderResponse<TRejectionType> | RenderRedirect<TRejectionType>
+
+type RenderResponse<TRejectionType extends string> = {
+  /**
+   * Suggested http status.
+   */
+  status: number,
+  location?: undefined,
+  /**
+   * The type of rejection in effect, or null when there is none.
+   */
+  rejection: TRejectionType | null,
+}
+
+type RenderRedirect<TRejectionType extends string> = {
+  /**
+   * Suggested http status.
+   */
+  status: RedirectStatus,
+  /**
+   * Value for the `Location` header.
+   */
+  location: string,
+  /**
+   * The type of rejection in effect, or null when there is none.
+   */
+  rejection: TRejectionType | null,
+}
+
+/**
+ * The statuses the router reports for a redirect.
+ */
+export type RedirectStatus = 301 | 302
 
 export type Router<
   TRoutes extends Routes = any,
@@ -162,6 +210,16 @@ export type Router<
    * Returns true if the router has been started.
    */
   started: Ref<boolean>,
+  /**
+   * Resolves once the router has nothing left to render: every prop and loader has settled, following
+   * any navigation one of them caused, so this waits for the next *full* render rather than for one
+   * navigation. Resolves with what a server should respond with.
+   *
+   * Awaiting `push` only waits for the route to commit; this also waits for its data.
+   *
+   * Only available on the server for ssr. Throws `RenderInBrowserError` when called in the client.
+   */
+  render: () => Promise<RenderOutcome<ExtractRejectionTypes<ExtractRejections<TOptions>> | ExtractRejectionTypes<ExtractRejections<TPlugin>> | BuiltInRejectionType>>,
   /**
    * Stops the router and teardown any listeners.
    */


### PR DESCRIPTION
# Description

Awaiting `push` only waits for the route to commit, and props and loaders deliberately don't hold up a navigation. That leaves a server with no point at which the page is renderable, and no way to learn that a props getter or loader redirected or rejected. Without waiting it renders markup for a route it has already left; with something awaiting the data, the abandoning navigation rejects that promise and it renders nothing at all.

`router.render` resolves once there is nothing left to render, following any navigation the data caused, and reports what a server should respond with. `start` no longer returns anything.

```ts
await router.start()

const response = await router.render()

if (response.status >= 300) {
  return respond(response)
}

const html = await renderToString(app)
```

The response is derived rather than recorded during navigation because the ordinary 404 sets no rejection at all — it commits the `NotFound` route — so reading the rejection alone would report 200 for most of them.
