### PR TITLE
Reject rather than silently commit a route for a url that matched nothing

### DIFF
--- a/src/services/createRouter.spec.ts
+++ b/src/services/createRouter.spec.ts
@@ -1017,3 +1017,48 @@ describe('options.removeTrailingSlashes', () => {
     expect(router.route.href).toBe('/')
   })
 })
+
+describe('a url that matches no route', () => {
+  test('sets the NotFound rejection', async () => {
+    const onRejection = vi.fn()
+    const route = createRoute({ name: 'route', component, path: '/foo' })
+    const router = createRouter([route], { initialUrl: '/does-not-exist' })
+
+    router.onRejection(onRejection)
+
+    await router.start()
+
+    expect(onRejection).toHaveBeenCalledWith('NotFound', {
+      to: expect.objectContaining({ name: 'NotFound' }),
+      from: null,
+    })
+  })
+
+  test('clears the rejection once a route matches again', async () => {
+    const onRejection = vi.fn()
+    const route = createRoute({ name: 'route', component, path: '/foo' })
+    const router = createRouter([route], { initialUrl: '/does-not-exist' })
+
+    router.onRejection(onRejection)
+
+    await router.start()
+
+    expect(onRejection).toHaveBeenCalledTimes(1)
+
+    await router.push('route')
+
+    expect(router.route.name).toBe('route')
+  })
+
+  test('does not set a rejection when a route does match', async () => {
+    const onRejection = vi.fn()
+    const route = createRoute({ name: 'route', component, path: '/foo' })
+    const router = createRouter([route], { initialUrl: '/foo' })
+
+    router.onRejection(onRejection)
+
+    await router.start()
+
+    expect(onRejection).not.toHaveBeenCalled()
+  })
+})

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -132,7 +132,8 @@ export function createRouter<
 
     history.stopListening()
 
-    const to = find(url, options) ?? notFoundRoute
+    const matched = find(url, options)
+    const to = matched ?? notFoundRoute
 
     const from = getFromRouteForHooks(navigationId)
 
@@ -155,10 +156,17 @@ export function createRouter<
         setRejection(beforeResponse.type, to, from)
         break
 
-      // On success update history, set the route, and clear the rejection
+      // On success update history and set the route. A url that matched nothing is a rejection rather
+      // than a successful navigation, even though the hooks had nothing to object to.
       case 'SUCCESS':
         history.update(url, options)
-        clearRejection()
+
+        if (matched) {
+          clearRejection()
+        } else {
+          setRejection('NotFound', to, from)
+        }
+
         break
 
       default:


### PR DESCRIPTION
# Description

A url matching no route committed the `NotFound` route and *cleared* the rejection, so the most common rejection in any app was the one that never set one. `onRejection` never fired for a 404, `useRejection()` reported `null`, and the two ways of reaching the same NotFound screen — an unmatched url versus a hook calling `reject('NotFound')` — left completely different state behind.

Rendered output is unchanged: `RouterView` reaches the same component through the rejection instead of through the route.

`route` is still seeded with the NotFound route, so `useRoute` keeps working outside `RouterView`. That the seeded route isn't one of the caller's declared routes is a separate problem, noted below.
