### PR TITLE
Make a resolved route's title a function rather than a promise

### DIFF
--- a/src/services/createResolvedRoute.spec.ts
+++ b/src/services/createResolvedRoute.spec.ts
@@ -82,3 +82,19 @@ test('matched is the last of the resolved matches', () => {
   expect(resolved.matched).toBe(resolved.matches.at(-1))
   expect(resolved.matched.name).toBe('child')
 })
+
+describe('getTitle', () => {
+  test('runs the callback and resolves to its value', async () => {
+    const route = createRoute({ name: 'home', path: '/', component })
+
+    route.setTitle(() => 'Home')
+
+    await expect(createResolvedRoute(route).getTitle()).resolves.toBe('Home')
+  })
+
+  test('resolves to undefined for a route with no title', async () => {
+    const route = createRoute({ name: 'home', path: '/', component })
+
+    await expect(createResolvedRoute(route).getTitle()).resolves.toBeUndefined()
+  })
+})

--- a/src/services/createResolvedRoute.ts
+++ b/src/services/createResolvedRoute.ts
@@ -12,14 +12,21 @@ export function createResolvedRoute(route: Route, params: Record<string, unknown
     hash: options.hash,
   })
   const { query, hash } = parseUrl(href)
-  const { promise: title, resolve: resolveTitle } = Promise.withResolvers<string | undefined>()
   const matched = route.matches.at(-1)
 
   if (!matched) {
     throw new Error('createResolvedRoute called with a route that has no matches')
   }
 
-  const resolvedRoute = {
+  async function getTitle(): Promise<string | undefined> {
+    if (!isRoute(route)) {
+      return undefined
+    }
+
+    return route.getTitle(resolvedRoute)
+  }
+
+  const resolvedRoute: ResolvedRoute = {
     ...route,
     matched,
     query: createResolvedRouteQuery(query),
@@ -27,18 +34,8 @@ export function createResolvedRoute(route: Route, params: Record<string, unknown
     hash,
     params,
     href,
-    title,
-  } satisfies ResolvedRoute
-
-  getRouteTitle(resolvedRoute).then(resolveTitle)
-
-  return resolvedRoute
-}
-
-async function getRouteTitle(route: ResolvedRoute): Promise<string | undefined> {
-  if (isRoute(route)) {
-    return route.getTitle(route)
+    getTitle,
   }
 
-  return undefined
+  return resolvedRoute
 }

--- a/src/services/createRouterRoute.spec.ts
+++ b/src/services/createRouterRoute.spec.ts
@@ -3,6 +3,8 @@ import { reactive } from 'vue'
 import { createRouterRoute, isRouterRoute } from '@/services/createRouterRoute'
 import { createRoute } from './createRoute'
 import { createResolvedRoute } from './createResolvedRoute'
+import { createRouter } from './createRouter'
+import { component } from '@/utilities/testHelpers'
 
 test('isRouterRoute returns correct response', () => {
   const route = createRoute({ name: 'isRouterRoute' })
@@ -39,4 +41,22 @@ test('sending state, includes state in push options', () => {
     { param: 123 },
     { state: { bar: 'bar' } },
   )
+})
+
+test('getTitle resolves the title of the current route', async () => {
+  const home = createRoute({ name: 'home', path: '/', component })
+  const other = createRoute({ name: 'other', path: '/other', component })
+
+  home.setTitle(() => 'Home')
+  other.setTitle(() => 'Other')
+
+  const router = createRouter([home, other], { initialUrl: '/' })
+
+  await router.start()
+
+  await expect(router.route.getTitle()).resolves.toBe('Home')
+
+  await router.push('other')
+
+  await expect(router.route.getTitle()).resolves.toBe('Other')
 })

--- a/src/services/createRouterRoute.ts
+++ b/src/services/createRouterRoute.ts
@@ -60,7 +60,7 @@ export function createRouterRoute<TRoute extends ResolvedRoute & WithData>(route
     updateQuery(query)
   }
 
-  const { id, matched, matches, name, hash, href, data } = toRefs(route)
+  const { id, matched, matches, name, hash, href, data, getTitle } = toRefs(route)
 
   const paramsProxy = new Proxy({}, {
     get(_target, property, receiver) {
@@ -138,6 +138,7 @@ export function createRouterRoute<TRoute extends ResolvedRoute & WithData>(route
     name,
     href,
     data,
+    getTitle,
     update,
     [isRouterRouteSymbol]: true,
     [routerKey]: true,

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -55,9 +55,10 @@ export type ResolvedRoute<TRoute extends Route = Route> = Readonly<{
    */
   hash: string,
   /**
-   * Title of the route.
+   * Returns the title of the route from its `setTitle` callback, or from the closest parent route that
+   * defines one.
    */
-  title: Promise<string | undefined>,
+  getTitle: () => Promise<string | undefined>,
 }>
 
 /**

--- a/src/types/routerRoute.ts
+++ b/src/types/routerRoute.ts
@@ -36,7 +36,7 @@ export type RouterRoute<TRoute extends ResolvedRoute = ResolvedRoute> = {
   /**
    * Title of the route.
    */
-  readonly title: TRoute['title'],
+  readonly getTitle: TRoute['getTitle'],
   /**
    * What the route's loaders resolve to, keyed by loader name. A route whose only loader is unnamed
    * exposes that loader's data here directly.

--- a/src/utilities/setDocumentTitle.ts
+++ b/src/utilities/setDocumentTitle.ts
@@ -7,7 +7,7 @@ export function setDocumentTitle(to: ResolvedRoute | null): void {
     return
   }
 
-  to.title.then((value) => {
+  to.getTitle().then((value) => {
     if (value === undefined) {
       return
     }


### PR DESCRIPTION
# Description

Resolving a route eagerly started computing its title, so every resolution ran the route's `setTitle` callback whether or not that route was ever rendered.

Measured on `main`, with a `setTitle` on `home`:

| | callback calls |
| -- | -- |
| after `router.start()` | 1 |
| + one `router.resolve('home')` | 2 |
| + ten more resolves | 12 |
| + rendering twenty `<router-link to="/">` | **52** |

Forty of those are links nobody clicked. If the callback fetches a name or reads a store, it does it forty times.

`getTitle()` replaces `title`, so the callbacks run when something asks for a title rather than when a route is resolved. The same scenario now runs it once.

```ts
// before
route.title.then(setTitle)

// after
route.getTitle().then(setTitle)
```

Two other things fall out:

- **`router.route.getTitle` works.** It was `title` before, captured once from the fallback route when the reactive route was built, so it never reflected the current route — `await router.route.title` was `undefined` forever on `main`. It is read from the route's refs now, like every other field.
- **`find` and `resolve` become free to call for probing.** They were already synchronous; the title was the only side effect. That unblocks resolving the initial route up front, which is what synchronous hydration needs — see the SSR stack starting at #826.

## Breaking

`ResolvedRoute.title` becomes `getTitle()`. This is the one to call out — it worked, and it is reachable anywhere a resolved route is: `router.resolve(name).title`, `router.find(url)?.title`, and `to`/`from` in hooks.

```ts
// before
router.onBeforeRouteEnter(async (to) => await to.title)

// after
router.onBeforeRouteEnter(async (to) => await to.getTitle())
```

`RouterRoute.title` becomes `getTitle()` as well, but only the type changes in practice — it always resolved to `undefined`, per above.

The route side is untouched. `setTitle` is unchanged, and `RouteInternal.getTitle` is not exported.
