### PR TITLE
History listener vs. abort

### DIFF
--- a/docs/api/types/Router.md
+++ b/docs/api/types/Router.md
@@ -39,4 +39,4 @@ type Router<TRoutes, TOptions, TPlugin> = object;
 | <a id="route"></a> `route` | \| [`RouterRouteUnion`](RouterRouteUnion.md)\<`TRoutes`\> \| [`RouterRouteUnion`](RouterRouteUnion.md)\<`TPlugin`\[`"routes"`\]\> | Manages the current route state. |
 | <a id="start"></a> `start` | () => `Promise`\<`void`\> | Initializes the router based on the initial route. Automatically called when the router is installed. Calling this more than once has no effect. |
 | <a id="started"></a> `started` | `Ref`\<`boolean`\> | Returns true if the router has been started. |
-| <a id="stop"></a> `stop` | () => `void` | Stops the router and teardown any listeners. |
+| <a id="stop"></a> `stop` | () => `void` | Stops the router and tears down its history listener. Programmatic navigations can still update the route without restarting the listener. |

--- a/src/services/createRouter.spec.ts
+++ b/src/services/createRouter.spec.ts
@@ -38,7 +38,7 @@ test('initial state is set', async () => {
   }
 
   const actual = createRouterHistoryUtilities.createRouterHistory({ listener: () => {} })
-  vi.spyOn(createRouterHistoryUtilities, 'createRouterHistory').mockImplementation(() => ({
+  vi.spyOn(createRouterHistoryUtilities, 'createRouterHistory').mockImplementationOnce(() => ({
     ...actual,
     location,
   }))
@@ -93,6 +93,269 @@ test('updates the route when navigating', async () => {
   await push('/second')
 
   expect(route.matched.name).toBe('second')
+})
+
+test('continues listening to history after navigation is aborted', async () => {
+  const home = createRoute({
+    name: 'home',
+    component,
+    path: '/',
+  })
+  const first = createRoute({
+    name: 'first',
+    component,
+    path: '/first',
+  })
+  const blocked = createRoute({
+    name: 'blocked',
+    component,
+    path: '/blocked',
+  })
+
+  blocked.onBeforeRouteEnter((_to, { abort }) => {
+    abort()
+  })
+
+  const router = createRouter([home, first, blocked], {
+    initialUrl: '/',
+    historyMode: 'memory',
+  })
+
+  await router.start()
+  await router.push('first')
+  await router.push('blocked')
+
+  expect(router.route.name).toBe('first')
+
+  router.back()
+  await flushPromises()
+
+  expect(router.route.name).toBe('home')
+})
+
+test('a newer navigation supersedes a pending navigation without disabling history listening', async () => {
+  const { promise: continueNavigation, resolve } = Promise.withResolvers<undefined>()
+  const onBeforeFirst = vi.fn(() => continueNavigation)
+  const home = createRoute({
+    name: 'home',
+    component,
+    path: '/',
+  })
+  const first = createRoute({
+    name: 'first',
+    component,
+    path: '/first',
+  })
+  const current = createRoute({
+    name: 'current',
+    component,
+    path: '/current',
+  })
+  const blocked = createRoute({
+    name: 'blocked',
+    component,
+    path: '/blocked',
+  })
+
+  first.onBeforeRouteEnter(onBeforeFirst)
+  blocked.onBeforeRouteEnter((_to, { abort }) => {
+    abort()
+  })
+
+  const router = createRouter([home, first, current, blocked], {
+    initialUrl: '/',
+    historyMode: 'memory',
+  })
+
+  await router.start()
+  await router.push('current')
+
+  const firstNavigation = router.push('first')
+  await flushPromises()
+  await router.push('blocked')
+
+  router.back()
+  await flushPromises()
+
+  expect(router.route.name).toBe('home')
+
+  resolve(undefined)
+  await firstNavigation
+  await flushPromises()
+
+  expect(onBeforeFirst).toHaveBeenCalledOnce()
+  expect(router.route.name).toBe('home')
+})
+
+test('a stale navigation does not restore history listening while a newer navigation is pending', async () => {
+  const { promise: continueFirst, resolve: resolveFirst } = Promise.withResolvers<undefined>()
+  const { promise: continueSecond, resolve: resolveSecond } = Promise.withResolvers<undefined>()
+  const onBeforeSecond = vi.fn(() => continueSecond)
+  const home = createRoute({
+    name: 'home',
+    component,
+    path: '/',
+  })
+  const first = createRoute({
+    name: 'first',
+    component,
+    path: '/first',
+  })
+  const second = createRoute({
+    name: 'second',
+    component,
+    path: '/second',
+  })
+
+  first.onBeforeRouteEnter(() => continueFirst)
+  second.onBeforeRouteEnter(onBeforeSecond)
+
+  const router = createRouter([home, first, second], {
+    initialUrl: '/',
+    historyMode: 'memory',
+  })
+
+  await router.start()
+
+  const firstNavigation = router.push('first')
+  await flushPromises()
+  const secondNavigation = router.push('second')
+  await flushPromises()
+
+  resolveFirst(undefined)
+  await firstNavigation
+
+  expect(router.route.name).toBe('home')
+
+  resolveSecond(undefined)
+  await secondNavigation
+  await flushPromises()
+
+  expect(onBeforeSecond).toHaveBeenCalledOnce()
+  expect(router.route.name).toBe('second')
+})
+
+test('a stale after hook cannot redirect a newer navigation', async () => {
+  const { promise: continueAfterHook, resolve } = Promise.withResolvers<undefined>()
+  const home = createRoute({
+    name: 'home',
+    component,
+    path: '/',
+  })
+  const hijack = createRoute({
+    name: 'hijack',
+    component,
+    path: '/hijack',
+  })
+  const first = createRoute({
+    name: 'first',
+    component,
+    path: '/first',
+    context: [hijack],
+  })
+  const second = createRoute({
+    name: 'second',
+    component,
+    path: '/second',
+  })
+
+  first.onAfterRouteEnter(async (_to, { push }) => {
+    await continueAfterHook
+    push('hijack')
+  })
+
+  const router = createRouter([home, first, second, hijack], {
+    initialUrl: '/',
+    historyMode: 'memory',
+  })
+
+  await router.start()
+
+  const firstNavigation = router.push('first')
+  await flushPromises()
+
+  expect(router.route.name).toBe('first')
+
+  await router.push('second')
+  resolve(undefined)
+  await firstNavigation
+
+  expect(router.route.name).toBe('second')
+})
+
+test('does not restore history listening after the router is stopped during navigation', async () => {
+  const { promise: continueNavigation, resolve } = Promise.withResolvers<undefined>()
+  const home = createRoute({
+    name: 'home',
+    component,
+    path: '/',
+  })
+  const first = createRoute({
+    name: 'first',
+    component,
+    path: '/first',
+  })
+  const slow = createRoute({
+    name: 'slow',
+    component,
+    path: '/slow',
+  })
+
+  slow.onBeforeRouteEnter(() => continueNavigation)
+
+  const router = createRouter([home, first, slow], {
+    initialUrl: '/',
+    historyMode: 'memory',
+  })
+
+  await router.start()
+  await router.push('first')
+
+  const navigation = router.push('slow')
+  await flushPromises()
+  router.stop()
+
+  resolve(undefined)
+  await navigation
+
+  expect(router.route.name).toBe('slow')
+
+  router.back()
+  await flushPromises()
+
+  expect(router.route.name).toBe('slow')
+})
+
+test('does not restore history listening when navigating after the router is stopped', async () => {
+  const home = createRoute({
+    name: 'home',
+    component,
+    path: '/',
+  })
+  const first = createRoute({
+    name: 'first',
+    component,
+    path: '/first',
+  })
+  const second = createRoute({
+    name: 'second',
+    component,
+    path: '/second',
+  })
+  const router = createRouter([home, first, second], {
+    initialUrl: '/',
+    historyMode: 'memory',
+  })
+
+  await router.start()
+  await router.push('first')
+  router.stop()
+  await router.push('second')
+
+  router.back()
+  await flushPromises()
+
+  expect(router.route.name).toBe('second')
 })
 
 test('route update updates the current route', async () => {

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -100,6 +100,8 @@ export function createRouter<
   hooks.addGlobalRouteHooks(getGlobalHooksForRouter(plugins))
 
   const getNavigationId = createUniqueIdSequence()
+  let latestNavigationId: string | undefined
+  let historyListeningEnabled = true
   const componentsStore = createComponentsStore(routerKey)
   const visibilityObserver = createVisibilityObserver()
   const history = createRouterHistory({
@@ -130,67 +132,80 @@ export function createRouter<
 
     const navigationId = getNavigationId()
 
+    latestNavigationId = navigationId
     history.stopListening()
 
-    const to = find(url, options) ?? notFoundRoute
+    try {
+      const to = find(url, options) ?? notFoundRoute
 
-    const from = getFromRouteForHooks(navigationId)
+      const from = getFromRouteForHooks(navigationId)
 
-    const beforeResponse = await hooks.runBeforeRouteHooks({ to, from })
+      const beforeResponse = await hooks.runBeforeRouteHooks({ to, from })
 
-    switch (beforeResponse.status) {
-      // On abort do nothing
-      case 'ABORT':
+      if (navigationId !== latestNavigationId) {
         return
+      }
 
-      // On push update the history, and push new route, and return
-      case 'PUSH':
-        history.update(url, options)
-        await push(...beforeResponse.to)
+      switch (beforeResponse.status) {
+        // On abort do nothing
+        case 'ABORT':
+          return
+
+        // On push update the history, and push new route, and return
+        case 'PUSH':
+          history.update(url, options)
+          await push(...beforeResponse.to)
+          return
+
+        // On reject update the history, the route, and set the rejection type
+        case 'REJECT':
+          history.update(url, options)
+          setRejection(beforeResponse.type, to, from)
+          break
+
+        // On success update history, set the route, and clear the rejection
+        case 'SUCCESS':
+          history.update(url, options)
+          clearRejection()
+          break
+
+        default:
+          throw new Error(`Switch is not exhaustive for before hook response status: ${JSON.stringify(beforeResponse satisfies never)}`)
+      }
+
+      if (!isExternal(url)) {
+        setRouteValuesAndUpdateRoute(to, from)
+      }
+
+      const afterResponse = await hooks.runAfterRouteHooks({ to, from })
+
+      if (navigationId !== latestNavigationId) {
         return
+      }
 
-      // On reject update the history, the route, and set the rejection type
-      case 'REJECT':
-        history.update(url, options)
-        setRejection(beforeResponse.type, to, from)
-        break
+      switch (afterResponse.status) {
+        case 'PUSH':
+          await push(...afterResponse.to)
+          break
 
-      // On success update history, set the route, and clear the rejection
-      case 'SUCCESS':
-        history.update(url, options)
-        clearRejection()
-        break
+        case 'REJECT':
+          setRejection(afterResponse.type, to, from)
+          break
 
-      default:
-        throw new Error(`Switch is not exhaustive for before hook response status: ${JSON.stringify(beforeResponse satisfies never)}`)
+        case 'SUCCESS':
+          break
+
+        default:
+          const exhaustive: never = afterResponse
+          throw new Error(`Switch is not exhaustive for after hook response status: ${JSON.stringify(exhaustive)}`)
+      }
+
+      setDocumentTitle(currentRejectionRoute.value ?? to)
+    } finally {
+      if (navigationId === latestNavigationId && historyListeningEnabled) {
+        history.startListening()
+      }
     }
-
-    if (!isExternal(url)) {
-      setRouteValuesAndUpdateRoute(to, from)
-    }
-
-    const afterResponse = await hooks.runAfterRouteHooks({ to, from })
-
-    switch (afterResponse.status) {
-      case 'PUSH':
-        await push(...afterResponse.to)
-        break
-
-      case 'REJECT':
-        setRejection(afterResponse.type, to, from)
-        break
-
-      case 'SUCCESS':
-        break
-
-      default:
-        const exhaustive: never = afterResponse
-        throw new Error(`Switch is not exhaustive for after hook response status: ${JSON.stringify(exhaustive)}`)
-    }
-
-    setDocumentTitle(currentRejectionRoute.value ?? to)
-
-    history.startListening()
   }
 
   function setRouteValuesAndUpdateRoute(to: ResolvedRoute, from: ResolvedRoute | null): void {
@@ -359,7 +374,6 @@ export function createRouter<
     if (starting) {
       return initialize
     }
-
     starting = true
 
     const shouldInitZod = zodParamsDetected(routes)
@@ -370,13 +384,12 @@ export function createRouter<
 
     await set(initialUrl, { replace: true, state: initialState })
 
-    history.startListening()
-
     initialized()
     started.value = true
   }
 
   function stop(): void {
+    historyListeningEnabled = false
     history.stopListening()
   }
 

--- a/src/services/createRouterHistory.browser.spec.ts
+++ b/src/services/createRouterHistory.browser.spec.ts
@@ -36,3 +36,33 @@ test('when forward is called, forwards call to window history', () => {
 
   expect(window.history.go).toHaveBeenCalledOnce()
 })
+
+test('starting and stopping history listening is idempotent', () => {
+  const listener = vi.fn()
+  const history = createRouterHistory({
+    mode: 'memory',
+    listener,
+  })
+
+  history.startListening()
+  history.startListening()
+  history.update('/first')
+
+  expect(listener).toHaveBeenCalledOnce()
+
+  history.stopListening()
+  history.stopListening()
+  history.update('/second')
+
+  expect(listener).toHaveBeenCalledOnce()
+
+  history.startListening()
+  history.update('/third')
+
+  expect(listener).toHaveBeenCalledTimes(2)
+  expect(listener).toHaveBeenLastCalledWith(expect.objectContaining({
+    location: expect.objectContaining({
+      pathname: '/third',
+    }),
+  }))
+})

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -163,7 +163,7 @@ export type Router<
    */
   started: Ref<boolean>,
   /**
-   * Stops the router and teardown any listeners.
+   * Stops the router and tears down its history listener. Programmatic navigations can still update the route without restarting the listener.
    */
   stop: () => void,
   /**


### PR DESCRIPTION
Just ran into an issue where aborting a guarded navigation disables back/fwd. Hope this fixes it. Sorry for the llm-written test cases :)