### PR TITLE
Reject with NotFound when a url matches no route

### DIFF
--- a/src/errors/updateWithoutRouteError.ts
+++ b/src/errors/updateWithoutRouteError.ts
@@ -1,0 +1,9 @@
+/**
+ * An error thrown when `update` is called without a route to update. Only hooks with a destination
+ * are given `update`, so this is only reachable by ignoring TypeScript.
+ */
+export class UpdateWithoutRouteError extends Error {
+  public constructor() {
+    super('update called without a route to update')
+  }
+}

--- a/src/services/createRoute.spec-d.ts
+++ b/src/services/createRoute.spec-d.ts
@@ -774,7 +774,7 @@ describe('hooks', () => {
     })
 
     route.onBeforeRouteLeave((to, { from }) => {
-      expectTypeOf(to).toEqualTypeOf<ResolvedRoute>()
+      expectTypeOf(to).toEqualTypeOf<ResolvedRoute | null>()
       expectTypeOf(from).toEqualTypeOf<ResolvedRoute<typeof route>>()
     })
 
@@ -789,7 +789,7 @@ describe('hooks', () => {
     })
 
     route.onAfterRouteLeave((to, { from }) => {
-      expectTypeOf(to).toEqualTypeOf<ResolvedRoute>()
+      expectTypeOf(to).toEqualTypeOf<ResolvedRoute | null>()
       expectTypeOf(from).toEqualTypeOf<ResolvedRoute<typeof route>>()
     })
   })

--- a/src/services/createRouter.spec-d.ts
+++ b/src/services/createRouter.spec-d.ts
@@ -127,6 +127,13 @@ describe('rejections', () => {
     expectTypeOf<Source>().toEqualTypeOf<Expect>()
   })
 
+  test('the routes a rejection happened between are not part of the public signature', () => {
+    const _router = createRouter([])
+
+    // @ts-expect-error reject only accepts a type
+    _router.reject('NotFound', { to: null, from: null })
+  })
+
   test('custom rejections are valid', () => {
     const myCustomRejection = createRejection({
       type: 'MyCustomRejection',

--- a/src/services/createRouter.spec.ts
+++ b/src/services/createRouter.spec.ts
@@ -1015,8 +1015,61 @@ describe('options.removeTrailingSlashes', () => {
 
     await router.push('/bar/')
 
-    // rejects so has an empty path
-    expect(router.route.href).toBe('/')
+    // rejects so the route is unchanged
+    expect(router.route.href).toBe('/foo/')
+  })
+})
+
+test('history keeps listening when a navigation ends early', async () => {
+  const home = createRoute({ name: 'home', component, path: '/' })
+  const foo = createRoute({ name: 'foo', component, path: '/foo' })
+  const bar = createRoute({ name: 'bar', component, path: '/bar' })
+
+  bar.onBeforeRouteEnter((_to, { abort }) => abort())
+
+  const router = createRouter([home, foo, bar], { initialUrl: '/' })
+
+  await router.start()
+  await router.push('foo')
+  await router.push('bar')
+
+  router.back()
+  await flushPromises()
+
+  expect(router.route.name).toBe('home')
+})
+
+describe('a url that matches no route', () => {
+  test('rejects with NotFound', async () => {
+    const onRejection = vi.fn()
+    const route = createRoute({ name: 'route', component, path: '/foo' })
+    const router = createRouter([route], { initialUrl: '/does-not-exist' })
+
+    router.onRejection(onRejection)
+
+    await router.start()
+
+    expect(onRejection).toHaveBeenCalledWith('NotFound', {
+      to: null,
+      from: null,
+    })
+  })
+
+  test('runs leave hooks with a null to', async () => {
+    const onBeforeRouteLeave = vi.fn()
+    const onAfterRouteLeave = vi.fn()
+    const route = createRoute({ name: 'route', component, path: '/foo' })
+    const router = createRouter([route], { initialUrl: '/foo' })
+
+    await router.start()
+
+    router.onBeforeRouteLeave(onBeforeRouteLeave)
+    router.onAfterRouteLeave(onAfterRouteLeave)
+
+    await router.push('/does-not-exist')
+
+    expect(onBeforeRouteLeave).toHaveBeenCalledWith(null, expect.anything())
+    expect(onAfterRouteLeave).toHaveBeenCalledWith(null, expect.anything())
   })
 })
 

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -10,6 +10,7 @@ import { createRouterHooks, getRouterHooksKey } from '@/services/createRouterHoo
 import { getInitialUrl } from '@/services/getInitialUrl'
 import { setStateValues } from '@/services/state'
 import { Routes } from '@/types/route'
+import { NOT_FOUND_REJECTION_TYPE } from '@/types/rejection'
 import { Router, RouterOptions } from '@/types/router'
 import { RouterPush, RouterPushOptions } from '@/types/routerPush'
 import { RouterReplace, RouterReplaceOptions } from '@/types/routerReplace'
@@ -22,7 +23,7 @@ import { RouterResolve, RouterResolveOptions } from '@/types/routerResolve'
 import { RouteNotFoundError } from '@/errors/routeNotFoundError'
 import { createResolvedRoute } from '@/services/createResolvedRoute'
 import { ResolvedRoute } from '@/types/resolved'
-import { RouterReject } from '@/types/routerReject'
+import { RejectContext, RouterRejectInternal } from '@/types/routerReject'
 import { EmptyRouterPlugin, RouterPlugin } from '@/types/routerPlugin'
 import { getRoutesForRouter } from './getRoutesForRouter'
 import { getGlobalHooksForRouter } from './getGlobalHooksForRouter'
@@ -132,64 +133,72 @@ export function createRouter<
 
     history.stopListening()
 
-    const to = find(url, options) ?? notFoundRoute
+    try {
+      const to = find(url, options) ?? null
+      const from = getFromRouteForHooks(navigationId)
 
-    const from = getFromRouteForHooks(navigationId)
+      function commitNavigation(): void {
+        if (!to) {
+          reject(NOT_FOUND_REJECTION_TYPE, { to, from })
 
-    const beforeResponse = await hooks.runBeforeRouteHooks({ to, from })
+          return
+        }
 
-    switch (beforeResponse.status) {
-      // On abort do nothing
-      case 'ABORT':
-        return
-
-      // On push, push the new route and return
-      case 'PUSH':
-        await push(...beforeResponse.to)
-        return
-
-      // On reject update the history, the route, and set the rejection type
-      case 'REJECT':
-        history.update(url, options)
-        setRejection(beforeResponse.type, to, from)
-        break
-
-      // On success update history, set the route, and clear the rejection
-      case 'SUCCESS':
-        history.update(url, options)
         clearRejection()
-        break
 
-      default:
-        throw new Error(`Switch is not exhaustive for before hook response status: ${JSON.stringify(beforeResponse satisfies never)}`)
+        if (!isExternal(url)) {
+          setRouteValuesAndUpdateRoute(to, from)
+        }
+      }
+
+      const beforeResponse = await hooks.runBeforeRouteHooks({ to, from })
+
+      switch (beforeResponse.status) {
+        case 'ABORT':
+          return
+
+        case 'PUSH':
+          await push(...beforeResponse.to)
+          return
+
+        case 'REJECT':
+          history.update(url, options)
+          reject(beforeResponse.type, { to, from })
+          return
+
+        case 'SUCCESS':
+          history.update(url, options)
+          break
+
+        default:
+          throw new Error(`Switch is not exhaustive for before hook response status: ${JSON.stringify(beforeResponse satisfies never)}`)
+      }
+
+      commitNavigation()
+
+      const afterResponse = await hooks.runAfterRouteHooks({ to, from })
+
+      switch (afterResponse.status) {
+        case 'PUSH':
+          await push(...afterResponse.to)
+          break
+
+        case 'REJECT':
+          reject(afterResponse.type, { to, from })
+          break
+
+        case 'SUCCESS':
+          break
+
+        default:
+          const exhaustive: never = afterResponse
+          throw new Error(`Switch is not exhaustive for after hook response status: ${JSON.stringify(exhaustive)}`)
+      }
+
+      setDocumentTitle(currentRejectionRoute.value ?? to)
+    } finally {
+      history.startListening()
     }
-
-    if (!isExternal(url)) {
-      setRouteValuesAndUpdateRoute(to, from)
-    }
-
-    const afterResponse = await hooks.runAfterRouteHooks({ to, from })
-
-    switch (afterResponse.status) {
-      case 'PUSH':
-        await push(...afterResponse.to)
-        break
-
-      case 'REJECT':
-        setRejection(afterResponse.type, to, from)
-        break
-
-      case 'SUCCESS':
-        break
-
-      default:
-        const exhaustive: never = afterResponse
-        throw new Error(`Switch is not exhaustive for after hook response status: ${JSON.stringify(exhaustive)}`)
-    }
-
-    setDocumentTitle(currentRejectionRoute.value ?? to)
-
-    history.startListening()
   }
 
   function setRouteValuesAndUpdateRoute(to: ResolvedRoute, from: ResolvedRoute | null): void {
@@ -218,7 +227,7 @@ export function createRouter<
             break
 
           case 'REJECT':
-            setRejection(response.type, to, from)
+            reject(response.type, { to, from })
             break
 
           default:
@@ -236,7 +245,7 @@ export function createRouter<
           }
 
           if (error instanceof ContextRejectionError) {
-            setRejection(error.response.type, to, from)
+            reject(error.response.type, { to, from })
             return
           }
 
@@ -317,7 +326,7 @@ export function createRouter<
     return push(source, options)
   }
 
-  function setRejection(type: string, to: ResolvedRoute | null = null, from: ResolvedRoute | null = null): void {
+  const reject: RouterRejectInternal<TOptions['rejections'] | TPlugin['rejections']> = (type: string, { to = null, from = null }: RejectContext = {}) => {
     const rejection = getRejectionByType(type)
 
     if (!rejection) {
@@ -327,10 +336,6 @@ export function createRouter<
     hooks.runRejectionHooks(rejection, { to, from })
 
     updateRejection(rejection)
-  }
-
-  const reject: RouterReject<TOptions['rejections'] | TPlugin['rejections']> = (type) => {
-    setRejection(type)
     setDocumentTitle(currentRejectionRoute.value)
   }
 

--- a/src/services/createRouterCallbackContext.ts
+++ b/src/services/createRouterCallbackContext.ts
@@ -1,4 +1,5 @@
 import { ContextAbortError } from '@/errors/contextAbortError'
+import { UpdateWithoutRouteError } from '@/errors/updateWithoutRouteError'
 import { ContextPushError } from '@/errors/contextPushError'
 import { ContextRejectionError } from '@/errors/contextRejectionError'
 import { RouterPush, RouterPushOptions } from '@/types/routerPush'
@@ -29,9 +30,9 @@ type RouterCallbackContext<
 export function createRouterCallbackContext<
   TRoutes extends Routes,
   TRejections extends Rejections
->({ to }: { to: ResolvedRoute }): RouterCallbackContext<TRoutes, TRejections>
+>({ to }: { to: ResolvedRoute | null }): RouterCallbackContext<TRoutes, TRejections>
 
-export function createRouterCallbackContext({ to }: { to: ResolvedRoute }): RouterCallbackContext {
+export function createRouterCallbackContext({ to }: { to: ResolvedRoute | null }): RouterCallbackContext {
   const reject: RouterCallbackContext['reject'] = (type) => {
     throw new ContextRejectionError(type)
   }
@@ -52,6 +53,10 @@ export function createRouterCallbackContext({ to }: { to: ResolvedRoute }): Rout
   }
 
   const update: RouterCallbackContext['update'] = (nameOrParams: PropertyKey | Partial<ResolvedRoute['params']>, valueOrOptions?: any, maybeOptions?: RouterPushOptions) => {
+    if (!to) {
+      throw new UpdateWithoutRouteError()
+    }
+
     if (typeof nameOrParams === 'object') {
       const params = {
         ...to.params,

--- a/src/services/createRouterHooks.ts
+++ b/src/services/createRouterHooks.ts
@@ -60,8 +60,8 @@ export function createRouterHooks(): RouterHooks {
 
     try {
       const results = allHooks.map((callback) => {
-        return Promise.resolve(runWithContext(() => callback(to, {
-          // From could be null but leave hooks require that from is not null. If from is null there will be no leave hooks so this cast is purely to satisfy the type checker.
+        // Enter and update hooks are only in this list when to is not null, and leave hooks are only in it when from is not null. These casts are purely to satisfy the type checker.
+        return Promise.resolve(runWithContext(() => callback(to as ResolvedRoute, {
           from: from as ResolvedRoute,
           reject,
           push,
@@ -124,8 +124,8 @@ export function createRouterHooks(): RouterHooks {
 
     try {
       const results = allHooks.map((callback) => {
-        return Promise.resolve(runWithContext(() => callback(to, {
-          // From could be null but leave hooks require that from is not null. If from is null there will be no leave hooks so this cast is purely to satisfy the type checker.
+        // Enter and update hooks are only in this list when to is not null, and leave hooks are only in it when from is not null. These casts are purely to satisfy the type checker.
+        return Promise.resolve(runWithContext(() => callback(to as ResolvedRoute, {
           from: from as ResolvedRoute,
           reject,
           push,
@@ -205,12 +205,15 @@ export function createRouterHooks(): RouterHooks {
     const hooks = componentStore[lifecycle]
 
     // Using `any` here for context because its just passed through to the hook and typing it is more complex than it's worth
-    const wrapped = (to: ResolvedRoute, context: any): MaybePromise<void> => {
+    const wrapped = (to: ResolvedRoute | null, context: any): MaybePromise<void> => {
       if (!condition(to, context.from, depth)) {
         return
       }
 
-      return hook(to, context)
+      // Only leave hooks pass the condition when to is null and those accept a null to.
+      const callback = hook as (to: ResolvedRoute | null, context: any) => MaybePromise<void>
+
+      return callback(to, context)
     }
 
     hooks.add(wrapped)

--- a/src/services/getGlobalRouteHooks.ts
+++ b/src/services/getGlobalRouteHooks.ts
@@ -2,10 +2,10 @@ import { ResolvedRoute } from '@/types/resolved'
 import { isRouteEnter, isRouteLeave, isRouteUpdate } from './hooks'
 import { Hooks } from '@/models/hooks'
 
-export function getGlobalBeforeHooks(to: ResolvedRoute, from: ResolvedRoute | null, globalHooks: Hooks): Hooks {
+export function getGlobalBeforeHooks(to: ResolvedRoute | null, from: ResolvedRoute | null, globalHooks: Hooks): Hooks {
   const hooks = new Hooks()
 
-  to.matches.forEach((_route, depth) => {
+  to?.matches.forEach((_route, depth) => {
     if (isRouteEnter(to, from, depth)) {
       globalHooks.onBeforeRouteEnter.forEach((hook) => hooks.onBeforeRouteEnter.add(hook))
     }
@@ -24,10 +24,10 @@ export function getGlobalBeforeHooks(to: ResolvedRoute, from: ResolvedRoute | nu
   return hooks
 }
 
-export function getGlobalAfterHooks(to: ResolvedRoute, from: ResolvedRoute | null, globalHooks: Hooks): Hooks {
+export function getGlobalAfterHooks(to: ResolvedRoute | null, from: ResolvedRoute | null, globalHooks: Hooks): Hooks {
   const hooks = new Hooks()
 
-  to.matches.forEach((_route, depth) => {
+  to?.matches.forEach((_route, depth) => {
     if (isRouteEnter(to, from, depth)) {
       globalHooks.onAfterRouteEnter.forEach((hook) => hooks.onAfterRouteEnter.add(hook))
     }

--- a/src/services/getRouteHooks.ts
+++ b/src/services/getRouteHooks.ts
@@ -3,7 +3,7 @@ import { isRouteEnter, isRouteLeave, isRouteUpdate } from '@/services/hooks'
 import { Hooks } from '@/models/hooks'
 import { getHooks } from '@/types/hooks'
 
-export function getBeforeHooksFromRoutes(to: ResolvedRoute, from: ResolvedRoute | null): Hooks {
+export function getBeforeHooksFromRoutes(to: ResolvedRoute | null, from: ResolvedRoute | null): Hooks {
   const hooks = new Hooks()
 
   getHooks(to).forEach((store, depth) => {
@@ -27,7 +27,7 @@ export function getBeforeHooksFromRoutes(to: ResolvedRoute, from: ResolvedRoute 
   return hooks
 }
 
-export function getAfterHooksFromRoutes(to: ResolvedRoute, from: ResolvedRoute | null): Hooks {
+export function getAfterHooksFromRoutes(to: ResolvedRoute | null, from: ResolvedRoute | null): Hooks {
   const hooks = new Hooks()
 
   getHooks(to).forEach((store, depth) => {

--- a/src/services/hooks.spec.ts
+++ b/src/services/hooks.spec.ts
@@ -245,3 +245,25 @@ test('when onError callback calls replace, other onError callbacks do not run', 
   expect(errorHook2).not.toHaveBeenCalled()
   expect(errorHook3).not.toHaveBeenCalled()
 })
+
+test('when to is null, only leave hooks are called', async () => {
+  const calls: string[] = []
+  const { runBeforeRouteHooks, ...hooks } = createRouterHooks()
+
+  hooks.onBeforeRouteEnter(() => {
+    calls.push('enter')
+  })
+  hooks.onBeforeRouteUpdate(() => {
+    calls.push('update')
+  })
+  hooks.onBeforeRouteLeave(() => {
+    calls.push('leave')
+  })
+
+  const fromRoute = createRoute({ name: 'routeA', component })
+  const from = createResolvedRoute(fromRoute, {})
+
+  await runBeforeRouteHooks({ to: null, from })
+
+  expect(calls).toEqual(['leave'])
+})

--- a/src/services/hooks.ts
+++ b/src/services/hooks.ts
@@ -1,24 +1,24 @@
 import { HookLifecycle } from '@/types/hooks'
 import { ResolvedRoute } from '@/types/resolved'
 
-type RouteHookCondition = (to: ResolvedRoute, from: ResolvedRoute | null, depth: number) => boolean
+type RouteHookCondition = (to: ResolvedRoute | null, from: ResolvedRoute | null, depth: number) => boolean
 
 export const isRouteEnter: RouteHookCondition = (to, from, depth) => {
-  const toMatches = to.matches
+  const toMatches = to?.matches ?? []
   const fromMatches = from?.matches ?? []
 
   return toMatches.at(depth)?.id !== fromMatches.at(depth)?.id
 }
 
 export const isRouteLeave: RouteHookCondition = (to, from, depth) => {
-  const toMatches = to.matches
+  const toMatches = to?.matches ?? []
   const fromMatches = from?.matches ?? []
 
   return toMatches.at(depth)?.id !== fromMatches.at(depth)?.id
 }
 
 export const isRouteUpdate: RouteHookCondition = (to, from, depth) => {
-  return to.matches.at(depth)?.id === from?.matches.at(depth)?.id
+  return to?.matches.at(depth)?.id === from?.matches.at(depth)?.id
 }
 
 export function getRouteHookCondition(lifecycle: HookLifecycle): RouteHookCondition {

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -194,7 +194,7 @@ export type BeforeLeaveHook<
   TRejections extends Rejections = Rejections,
   TRouteTo extends Route = TRoutes[number],
   TRouteFrom extends Route = TRoutes[number]
-> = (to: ResolvedRouteUnion<TRouteTo>, context: BeforeLeaveHookContext<TRoutes, TRejections, TRouteTo, TRouteFrom>) => MaybePromise<void>
+> = (to: ResolvedRouteUnion<TRouteTo> | null, context: BeforeLeaveHookContext<TRoutes, TRejections, TRouteTo, TRouteFrom>) => MaybePromise<void>
 
 export type AddBeforeLeaveHook<
   TRoutes extends Routes = Routes,
@@ -263,7 +263,7 @@ export type AfterLeaveHook<
   TRejections extends Rejections = Rejections,
   TRouteTo extends Route = TRoutes[number],
   TRouteFrom extends Route = TRoutes[number]
-> = (to: ResolvedRouteUnion<TRouteTo>, context: AfterLeaveHookContext<TRoutes, TRejections, TRouteTo, TRouteFrom>) => MaybePromise<void>
+> = (to: ResolvedRouteUnion<TRouteTo> | null, context: AfterLeaveHookContext<TRoutes, TRejections, TRouteTo, TRouteFrom>) => MaybePromise<void>
 
 export type AddAfterLeaveHook<
   TRoutes extends Routes = Routes,
@@ -276,11 +276,11 @@ export type BeforeHookResponse = CallbackContextSuccess | CallbackContextPush | 
 export type AfterHookResponse = CallbackContextSuccess | CallbackContextPush | CallbackContextReject
 
 export type BeforeHookRunner = <TRoutes extends Routes>(
-  context: { to: RouterResolvedRouteUnion<TRoutes>, from: RouterResolvedRouteUnion<TRoutes> | null },
+  context: { to: RouterResolvedRouteUnion<TRoutes> | null, from: RouterResolvedRouteUnion<TRoutes> | null },
 ) => Promise<BeforeHookResponse>
 
 export type AfterHookRunner = <TRoutes extends Routes>(
-  context: { to: RouterResolvedRouteUnion<TRoutes>, from: RouterResolvedRouteUnion<TRoutes> | null },
+  context: { to: RouterResolvedRouteUnion<TRoutes> | null, from: RouterResolvedRouteUnion<TRoutes> | null },
 ) => Promise<AfterHookResponse>
 
 export type RejectionHookContext<
@@ -315,7 +315,7 @@ export type ErrorHookContext<
   TRoutes extends Routes = Routes,
   TRejections extends Rejections = Rejections
 > = {
-  to: RouterResolvedRouteUnion<TRoutes>,
+  to: RouterResolvedRouteUnion<TRoutes> | null,
   from: RouterResolvedRouteUnion<TRoutes> | null,
   source: 'props' | 'loader' | 'hook' | 'component',
   reject: RouterReject<TRejections>,
@@ -334,7 +334,7 @@ export type AddErrorHook<
 > = (hook: ErrorHook<TRoutes, TRejections>) => HookRemove
 
 export type ErrorHookRunnerContext<TRoutes extends Routes = Routes> = {
-  to: RouterResolvedRouteUnion<TRoutes>,
+  to: RouterResolvedRouteUnion<TRoutes> | null,
   from: RouterResolvedRouteUnion<TRoutes> | null,
   source: 'props' | 'loader' | 'hook',
 }

--- a/src/types/rejection.ts
+++ b/src/types/rejection.ts
@@ -4,7 +4,9 @@ import { Router } from '@/types/router'
 import { RouterReject } from '@/types/routerReject'
 import { Hooks } from '@/models/hooks'
 
-export const BUILT_IN_REJECTION_TYPES = ['NotFound'] as const
+export const NOT_FOUND_REJECTION_TYPE = 'NotFound'
+
+export const BUILT_IN_REJECTION_TYPES = [NOT_FOUND_REJECTION_TYPE] as const
 export type BuiltInRejectionType = (typeof BUILT_IN_REJECTION_TYPES)[number]
 
 export type RouterRejection<T extends Rejection = Rejection> = Ref<T | null>

--- a/src/types/routeTitle.browser.spec.ts
+++ b/src/types/routeTitle.browser.spec.ts
@@ -2,6 +2,7 @@ import { expect, test, vi } from 'vitest'
 import { createRoute } from '@/services/createRoute'
 import { component } from '@/utilities/testHelpers'
 import { createRouter } from '@/services/createRouter'
+import { createRejection } from '@/services/createRejection'
 import { flushPromises } from '@vue/test-utils'
 
 test('route with title updates document title', async () => {
@@ -166,4 +167,30 @@ test('route without title and parent with title updates document title', async (
   await flushPromises()
 
   expect(document.title).toBe('parent')
+})
+
+test('rejection from a hook updates document title', async () => {
+  const locked = createRejection({ type: 'Locked', component })
+
+  locked.setTitle(() => 'locked')
+
+  const home = createRoute({ name: 'home', path: '/', component })
+  const secret = createRoute({ name: 'secret', path: '/secret', component })
+
+  const router = createRouter([home, secret], {
+    initialUrl: '/',
+    rejections: [locked],
+  })
+
+  router.onBeforeRouteEnter((to, { reject }) => {
+    if (to.name === 'secret') {
+      reject('Locked')
+    }
+  })
+
+  await router.start()
+  await router.push('secret')
+  await flushPromises()
+
+  expect(document.title).toBe('locked')
 })

--- a/src/types/routerPlugin.ts
+++ b/src/types/routerPlugin.ts
@@ -70,6 +70,26 @@ export type PluginBeforeRouteHook<
   TRejections extends Rejections = Rejections
 > = (to: ResolvedRoute, context: PluginBeforeRouteHookContext<TRoutes, TRejections>) => MaybePromise<void>
 
+export type PluginBeforeRouteLeaveHook<
+  TRoutes extends Routes = Routes,
+  TRejections extends Rejections = Rejections
+> = (to: ResolvedRoute | null, context: PluginBeforeRouteHookContext<TRoutes, TRejections>) => MaybePromise<void>
+
+type AddPluginBeforeRouteLeaveHook<
+  TRoutes extends Routes = Routes,
+  TRejections extends Rejections = Rejections
+> = (hook: PluginBeforeRouteLeaveHook<TRoutes, TRejections>) => HookRemove
+
+export type PluginAfterRouteLeaveHook<
+  TRoutes extends Routes = Routes,
+  TRejections extends Rejections = Rejections
+> = (to: ResolvedRoute | null, context: PluginAfterRouteHookContext<TRoutes, TRejections>) => MaybePromise<void>
+
+type AddPluginAfterRouteLeaveHook<
+  TRoutes extends Routes = Routes,
+  TRejections extends Rejections = Rejections
+> = (hook: PluginAfterRouteLeaveHook<TRoutes, TRejections>) => HookRemove
+
 export type PluginAfterRouteHook<
   TRoutes extends Routes = Routes,
   TRejections extends Rejections = Rejections
@@ -89,7 +109,7 @@ export type PluginErrorHookContext<
   TRoutes extends Routes = Routes,
   TRejections extends Rejections = Rejections
 > = {
-  to: ResolvedRoute,
+  to: ResolvedRoute | null,
   from: ResolvedRoute | null,
   source: 'props' | 'loader' | 'hook' | 'component',
   reject: RouterReject<TRejections>,
@@ -118,7 +138,7 @@ export type PluginRouteHooks<
   /**
    * Registers a global hook to be called before a route is left.
    */
-  onBeforeRouteLeave: AddPluginBeforeRouteHook<TRoutes, TRejections>,
+  onBeforeRouteLeave: AddPluginBeforeRouteLeaveHook<TRoutes, TRejections>,
   /**
    * Registers a global hook to be called before a route is updated.
    */
@@ -130,7 +150,7 @@ export type PluginRouteHooks<
   /**
    * Registers a global hook to be called after a route is left.
    */
-  onAfterRouteLeave: AddPluginAfterRouteHook<TRoutes, TRejections>,
+  onAfterRouteLeave: AddPluginAfterRouteLeaveHook<TRoutes, TRejections>,
   /**
    * Registers a global hook to be called after a route is updated.
    */

--- a/src/types/routerReject.ts
+++ b/src/types/routerReject.ts
@@ -1,3 +1,18 @@
 import { BuiltInRejectionType, Rejections, RejectionType } from '@/types/rejection'
+import { ResolvedRoute } from '@/types/resolved'
 
 export type RouterReject<TRejections extends Rejections | undefined> = <TSource extends (RejectionType<TRejections> | BuiltInRejectionType)>(type: TSource) => void
+
+/**
+ * The routes a rejection happened between, which rejection hooks are given.
+ */
+export type RejectContext = {
+  to?: ResolvedRoute | null,
+  from?: ResolvedRoute | null,
+}
+
+/**
+ * Reject as the router itself calls it, which may name any rejection type and supply the routes the
+ * rejection happened between. The router exposes {@link RouterReject} instead.
+ */
+export type RouterRejectInternal<TRejections extends Rejections | undefined> = RouterReject<TRejections> & ((type: string, context?: RejectContext) => void)


### PR DESCRIPTION
# Description

Replaces #838, which GitHub marked as merged when its head commit became an ancestor of its base branch. Stacked on #845, and ahead of the SSR work.

A url matching nothing cleared the rejection and rendered the NotFound screen through the *route* rather than through the rejection. So the most common rejection in any app was the one that never set one: `onRejection` never fired for a 404 and `useRejection()` reported `null`, while a hook calling `reject('NotFound')` set both.

A successful hook response for an unmatched url now becomes a rejection, so it takes the same path. Hooks still run first, so one that redirects or rejects an unknown url wins over this.

## Hooks receive a null `to`

Rather than substituting the NotFound route as the destination, the hook runner accepts `to: null`. Enter and update hooks are keyed off the destination's matches, so for an unmatched url there are none to run. Leave hooks are keyed off the route being left, so they still run and now see `to` as `null`. `onBeforeRouteLeave` and `onAfterRouteLeave` are the only hook types whose `to` widens to `ResolvedRoute | null`.

Plugins get `PluginBeforeRouteLeaveHook` and `PluginAfterRouteLeaveHook`. The existing `PluginBeforeRouteHook` covered enter, update and leave, and widening it would have given plugin enter hooks a `null` they never receive.

## `router.route` is no longer overwritten by a 404

The route committed for an unmatched url was the NotFound route, so `router.route.name` could be a name the caller never declared. Nothing rendered from it — `RouterView` reaches the rejection component through `rejection.route` — so it is no longer committed at all, and `router.route` holds the last route that actually matched. It remains non-null, so `useRoute` still needs no guard.

## Rejections set the document title

`setRejection` is folded into `reject`, which now takes the routes the rejection happened between. Every rejection path shares one implementation, so a rejection raised from a loader or an error hook updates the document title, which it previously never did.

The context argument is internal: `RouterRejectInternal` intersects the public `RouterReject` with a signature that accepts it, so `router.reject('NotFound', { to, from })` is still a compile error for callers.

## The history listener is always restored

`set` stopped listening to history at the top and only restarted at the very end, so any early return left the router deaf to back/forward. `ABORT` already had this bug on `main`. The body is now wrapped in `try`/`finally`.
