### PR TITLE
Remove update from the context of leave and error hooks

### DIFF
--- a/src/services/createRoute.spec-d.ts
+++ b/src/services/createRoute.spec-d.ts
@@ -794,6 +794,46 @@ describe('hooks', () => {
     })
   })
 
+  test('update is given to enter and update hooks', () => {
+    const route = createRoute({
+      name: 'route',
+      path: '/[paramName]',
+      component,
+    })
+
+    route.onBeforeRouteEnter((_to, { update }) => {
+      expectTypeOf(update).toBeCallableWith('paramName', 'value')
+    })
+
+    route.onBeforeRouteUpdate((_to, { update }) => {
+      expectTypeOf(update).toBeCallableWith('paramName', 'value')
+    })
+
+    route.onAfterRouteEnter((_to, { update }) => {
+      expectTypeOf(update).toBeCallableWith('paramName', 'value')
+    })
+
+    route.onAfterRouteUpdate((_to, { update }) => {
+      expectTypeOf(update).toBeCallableWith('paramName', 'value')
+    })
+  })
+
+  test('update is not given to leave hooks, which have no destination to update', () => {
+    const route = createRoute({
+      name: 'route',
+      path: '/[paramName]',
+      component,
+    })
+
+    route.onBeforeRouteLeave((_to, context) => {
+      expectTypeOf<keyof typeof context>().toEqualTypeOf<'from' | 'reject' | 'push' | 'replace' | 'abort'>()
+    })
+
+    route.onAfterRouteLeave((_to, context) => {
+      expectTypeOf<keyof typeof context>().toEqualTypeOf<'from' | 'reject' | 'push' | 'replace'>()
+    })
+  })
+
   test('context.push', () => {
     const contextRoute = createRoute({
       name: 'contextRoute',

--- a/src/services/createRouteHooks.ts
+++ b/src/services/createRouteHooks.ts
@@ -16,7 +16,7 @@ type RouteHooks<
   onAfterRouteEnter: AddAfterEnterHook<TRoutes, TRejections>,
   onAfterRouteUpdate: AddAfterUpdateHook<TRoutes, TRejections>,
   onAfterRouteLeave: AddAfterLeaveHook<TRoutes, TRejections>,
-  onError: AddErrorHook<TRoutes[number], TRoutes, TRejections>,
+  onError: AddErrorHook<TRoutes, TRejections>,
   onRejection: AddRejectionHook<ExtractRejectionTypes<TRejections>, TRoutes>,
   store: Hooks,
 }

--- a/src/services/createRouter.spec-d.ts
+++ b/src/services/createRouter.spec-d.ts
@@ -50,7 +50,7 @@ describe('hooks', () => {
     expectTypeOf(router.onAfterRouteEnter).toEqualTypeOf<AddAfterEnterHook<Routes, never>>()
     expectTypeOf(router.onAfterRouteLeave).toEqualTypeOf<AddAfterLeaveHook<Routes, never>>()
     expectTypeOf(router.onAfterRouteUpdate).toEqualTypeOf<AddAfterUpdateHook<Routes, never>>()
-    expectTypeOf(router.onError).toEqualTypeOf<AddErrorHook<Routes[number], Routes, never>>()
+    expectTypeOf(router.onError).toEqualTypeOf<AddErrorHook<Routes, never>>()
     expectTypeOf(router.onRejection).toEqualTypeOf<AddRejectionHook<BuiltInRejectionType, Routes>>()
   })
 
@@ -96,6 +96,12 @@ describe('hooks', () => {
   test('context.reject', () => {
     router.onBeforeRouteEnter((_to, context) => {
       expectTypeOf(context.reject).toEqualTypeOf(router.reject)
+    })
+  })
+
+  test('onError context has no update, which has no destination to act on', () => {
+    router.onError((_error, context) => {
+      expectTypeOf<keyof typeof context>().toEqualTypeOf<'to' | 'from' | 'source' | 'reject' | 'push' | 'replace'>()
     })
   })
 

--- a/src/services/createRouterHooks.ts
+++ b/src/services/createRouterHooks.ts
@@ -165,11 +165,11 @@ export function createRouterHooks(): RouterHooks {
   }
 
   const runErrorHooks: ErrorHookRunner = (error, { to, from, source }) => {
-    const { reject, push, replace, update } = createRouterCallbackContext({ to })
+    const { reject, push, replace } = createRouterCallbackContext({ to })
 
     for (const hook of globalStore.onError) {
       try {
-        hook(error, { to, from, source, reject, push, replace, update })
+        hook(error, { to, from, source, reject, push, replace })
 
         return
       } catch (hookError) {

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -1,5 +1,5 @@
 import { Hooks } from '@/models/hooks'
-import { ResolvedRoute, RouterResolvedRouteUnion, ResolvedRouteUnion } from '@/types/resolved'
+import { RouterResolvedRouteUnion, ResolvedRouteUnion } from '@/types/resolved'
 import { MaybePromise } from '@/types/utilities'
 import { isRoute, Route, Routes } from '@/types/route'
 import { RouterReject } from '@/types/routerReject'
@@ -185,7 +185,7 @@ export type BeforeLeaveHookContext<
   TRejections extends Rejections = Rejections,
   TRouteTo extends Route = TRoutes[number],
   TRouteFrom extends Route = TRoutes[number]
-> = BeforeHookContext<TRouteTo, TRoutes, TRejections> & {
+> = Omit<BeforeHookContext<TRouteTo, TRoutes, TRejections>, 'update'> & {
   from: ResolvedRouteUnion<TRouteFrom>,
 }
 
@@ -254,7 +254,7 @@ export type AfterLeaveHookContext<
   TRejections extends Rejections = Rejections,
   TRouteTo extends Route = TRoutes[number],
   TRouteFrom extends Route = TRoutes[number]
-> = AfterHookContext<TRouteTo, TRoutes, TRejections> & {
+> = Omit<AfterHookContext<TRouteTo, TRoutes, TRejections>, 'update'> & {
   from: ResolvedRouteUnion<TRouteFrom>,
 }
 
@@ -312,7 +312,6 @@ export type RejectionHookRunner<TRejection extends Rejection = Rejection, TRoute
 ) => void
 
 export type ErrorHookContext<
-  TRoute extends Route = Route,
   TRoutes extends Routes = Routes,
   TRejections extends Rejections = Rejections
 > = {
@@ -322,20 +321,17 @@ export type ErrorHookContext<
   reject: RouterReject<TRejections>,
   push: RouterPush<TRoutes>,
   replace: RouterReplace<TRoutes>,
-  update: RouteUpdate<ResolvedRoute<TRoute>>,
 }
 
 export type ErrorHook<
-  TRoute extends Route = Route,
   TRoutes extends Routes = Routes,
   TRejections extends Rejections = Rejections
-> = (error: unknown, context: ErrorHookContext<TRoute, TRoutes, TRejections>) => void
+> = (error: unknown, context: ErrorHookContext<TRoutes, TRejections>) => void
 
 export type AddErrorHook<
-  TRoute extends Route = Route,
   TRoutes extends Routes = Routes,
   TRejections extends Rejections = Rejections
-> = (hook: ErrorHook<TRoute, TRoutes, TRejections>) => HookRemove
+> = (hook: ErrorHook<TRoutes, TRejections>) => HookRemove
 
 export type ErrorHookRunnerContext<TRoutes extends Routes = Routes> = {
   to: RouterResolvedRouteUnion<TRoutes>,

--- a/src/types/router.ts
+++ b/src/types/router.ts
@@ -141,7 +141,7 @@ export type Router<
    * Registers a hook to be called when an error occurs.
    * If the hook returns true, the error is considered handled and the other hooks are not run. If all hooks return false the error is rethrown
    */
-  onError: AddErrorHook<TRoutes[number] | TPlugin['routes'][number], TRoutes | TPlugin['routes'], ExtractRejections<TOptions> | ExtractRejections<TPlugin>>,
+  onError: AddErrorHook<TRoutes | TPlugin['routes'], ExtractRejections<TOptions> | ExtractRejections<TPlugin>>,
   /**
    * Registers a hook to be called when a rejection occurs.
    */


### PR DESCRIPTION
# Description

`update` re-navigates to `to` with some params changed. Two contexts hand it out without a guaranteed destination to act on: a leave hook knows the route being left, not the one being entered, and an error hook reports a navigation that may not have arrived anywhere.

## Leave hooks

Enter and update hooks bind the destination to their own route, but leave hooks bind it to the wide `Route`, so inside a leave hook `update` resolved to:

```ts
(paramName: string, paramValue: unknown, options?) => Promise<void>
```

Any param name, any value, no checking. `update('nonsense', anything)` compiled and then pushed a navigation with a param the route does not have.

## Error hooks

`PluginErrorHookContext` already omits `update`, so the router's `ErrorHookContext` was the odd one out. `push` and `replace` cover the same ground explicitly, and they do not depend on the route that failed. Dropping it leaves `ErrorHook` and `AddErrorHook` without a use for their route type parameter, which is removed too, matching `PluginErrorHook`.

Nothing in the repo or docs called `update` from either kind of hook.
