### PR TITLE
Do not commit the url a before hook redirects away from

### DIFF
--- a/src/services/createRouter.spec.ts
+++ b/src/services/createRouter.spec.ts
@@ -57,6 +57,8 @@ test('initial state is set', async () => {
   await start()
 
   expect(route.state).toMatchObject({ zoo: 123 })
+
+  vi.restoreAllMocks()
 })
 
 test('updates the route when navigating', async () => {
@@ -1016,4 +1018,28 @@ describe('options.removeTrailingSlashes', () => {
     // rejects so has an empty path
     expect(router.route.href).toBe('/')
   })
+})
+
+test('going back from a redirect returns to the route before it', async () => {
+  const home = createRoute({ name: 'home', component, path: '/' })
+  const oldPath = createRoute({ name: 'oldPath', component, path: '/old' })
+  const newPath = createRoute({ name: 'newPath', component, path: '/new' })
+
+  const router = createRouter([home, oldPath, newPath], { initialUrl: '/' })
+
+  router.onBeforeRouteEnter((to, { push }) => {
+    if (to.name === 'oldPath') {
+      push('newPath')
+    }
+  })
+
+  await router.start()
+  await router.push('oldPath')
+
+  expect(router.route.name).toBe('newPath')
+
+  router.back()
+  await flushPromises()
+
+  expect(router.route.name).toBe('home')
 })

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -143,9 +143,8 @@ export function createRouter<
       case 'ABORT':
         return
 
-      // On push update the history, and push new route, and return
+      // On push, push the new route and return
       case 'PUSH':
-        history.update(url, options)
         await push(...beforeResponse.to)
         return
 


### PR DESCRIPTION
# Description

A before hook that calls `push` ends the current navigation and starts a new one. The navigation it starts commits its own url to history, so committing the redirected-from url first only adds an entry that immediately redirects again.

The effect is the back button appearing not to work. Given a hook on `/old` that pushes to `/new`:

| | lands on | after back |
| --- | --- | --- |
| before | `/new` | `/new` |
| after | `/new` | the page before `/old` |

Going back reached `/old`, whose hook pushed straight to `/new` again, so there was no way past it.

`ABORT` already left history alone. `REJECT` still commits the url, because nothing else will — it renders a rejection for the url that was asked for, rather than navigating somewhere else. Only the redirect case had a second navigation coming behind it.

## A related case this does not cover

Loading `/old` directly still leaves you stuck, because the browser's entry for `/old` is real rather than one we wrote, and the redirect pushes `/new` on top of it. Fixing that means treating a redirect from a before hook as replacing the entry it came from, which changes redirect semantics more broadly and is left alone here.
