### PR TITLE
Detect zod schemas structurally instead of importing zod

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,13 +33,7 @@
         "zod": "4.0.0"
       },
       "peerDependencies": {
-        "vue": "^3.5.0",
-        "zod": "4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
+        "vue": "^3.5.0"
       }
     },
     "node_modules/@algolia/autocomplete-core": {

--- a/package.json
+++ b/package.json
@@ -63,13 +63,7 @@
     "zod": "4.0.0"
   },
   "peerDependencies": {
-    "vue": "^3.5.0",
-    "zod": "4.0.0"
-  },
-  "peerDependenciesMeta": {
-    "zod": {
-      "optional": true
-    }
+    "vue": "^3.5.0"
   },
   "dependencies": {
     "@standard-schema/spec": "^1.0.0",

--- a/src/services/createRouter.ts
+++ b/src/services/createRouter.ts
@@ -27,7 +27,6 @@ import { EmptyRouterPlugin, RouterPlugin } from '@/types/routerPlugin'
 import { getRoutesForRouter } from './getRoutesForRouter'
 import { getGlobalHooksForRouter } from './getGlobalHooksForRouter'
 import { createComponentsStore } from './createComponentsStore'
-import { initZod, zodParamsDetected } from './zod'
 import { getComponentsStoreKey } from '@/compositions/useComponentsStore'
 import { getRouteValueStoreInjectionKey } from '@/compositions/useRouteValueStore'
 import { getRouterRejectionInjectionKey } from '@/compositions/useRejection'
@@ -361,12 +360,6 @@ export function createRouter<
     }
 
     starting = true
-
-    const shouldInitZod = zodParamsDetected(routes)
-
-    if (shouldInitZod) {
-      await initZod()
-    }
 
     await set(initialUrl, { replace: true, state: initialState })
 

--- a/src/services/params.ts
+++ b/src/services/params.ts
@@ -4,8 +4,8 @@ import { UrlParam } from '@/services/withParams'
 import { ExtractParamType, isLiteralParam, isParamGetSet, isParamGetter } from '@/types/params'
 import { LiteralParam, Param, ParamExtras, ParamGetSet } from '@/types/paramTypes'
 import { stringHasValue } from '@/utilities/guards'
-import { createZodParam, isZodParam } from './zod'
-import { createValibotParam, isValibotParam } from './valibot'
+import { createZodParam, isZodSchema } from './zod'
+import { createValibotParam, isValibotSchema } from './valibot'
 import { literal } from './literal'
 
 export function getParam(params: Record<string, Param | undefined>, paramName: string): Param {
@@ -164,11 +164,11 @@ export function getParamValue(value: string | undefined, { param = String, isOpt
     return literal(param).get(value, extras)
   }
 
-  if (isZodParam(param)) {
+  if (isZodSchema(param)) {
     return createZodParam(param).get(value, extras)
   }
 
-  if (isValibotParam(param)) {
+  if (isValibotSchema(param)) {
     return createValibotParam(param).get(value, extras)
   }
 
@@ -231,11 +231,11 @@ export function setParamValue(value: unknown, { param = String, isOptional = fal
     return literal(param).set(value as LiteralParam, extras)
   }
 
-  if (isZodParam(param)) {
+  if (isZodSchema(param)) {
     return createZodParam(param).set(value, extras)
   }
 
-  if (isValibotParam(param)) {
+  if (isValibotSchema(param)) {
     return createValibotParam(param).set(value, extras)
   }
 

--- a/src/services/valibot.ts
+++ b/src/services/valibot.ts
@@ -1,4 +1,4 @@
-import { Param, ParamGetSet } from '@/types/paramTypes'
+import { ParamGetSet } from '@/types/paramTypes'
 import { isRecord } from '@/utilities/guards'
 import { isPromise } from '@/utilities/promises'
 import { StandardSchemaV1 } from '@standard-schema/spec'
@@ -23,18 +23,14 @@ function parse(schema: ValibotSchemaLike, value: unknown) {
   return result.value
 }
 
-function isValibotSchemaLike(param: Param): param is ValibotSchemaLike {
-  return isRecord(param)
-    && 'type' in param
-    && typeof param.type === 'string'
-    && '~standard' in param
-    && isRecord(param['~standard'])
-    && 'vendor' in param['~standard']
-    && param['~standard'].vendor === 'valibot'
-}
-
-export function isValibotParam(value: Param): value is ValibotSchemaLike {
-  return isValibotSchemaLike(value)
+export function isValibotSchema(value: unknown): value is ValibotSchemaLike {
+  return isRecord(value)
+    && 'type' in value
+    && typeof value.type === 'string'
+    && '~standard' in value
+    && isRecord(value['~standard'])
+    && 'vendor' in value['~standard']
+    && value['~standard'].vendor === 'valibot'
 }
 
 export function createValibotParam<T>(schema: ValibotSchemaLike): ParamGetSet<T> {

--- a/src/services/zod.spec.ts
+++ b/src/services/zod.spec.ts
@@ -1,7 +1,6 @@
 import { safeGetParamValue, safeSetParamValue } from './params'
 import { z } from 'zod'
 import { test, expect } from 'vitest'
-import { initZod } from './zod'
 
 const discriminatedUnion = z.discriminatedUnion('type', [
   z.object({ type: z.literal('one'), value: z.string() }),
@@ -54,8 +53,6 @@ test.each([
   { schema: z.map(z.string(), z.number()), string: '[["one",1]]', parsed: new Map([['one', 1]]) },
   { schema: z.set(z.number()), string: '[1,2,3]', parsed: new Set([1, 2, 3]) },
 ])('given $schema, returns $parsed for $string', async ({ schema, string, parsed }) => {
-  await initZod()
-
   if (typeof parsed === 'string' || typeof parsed === 'number' || typeof parsed === 'boolean' || typeof parsed === 'bigint') {
     expect(safeGetParamValue(string, { param: schema })).toBe(parsed)
     expect(safeSetParamValue(parsed, { param: schema })).toBe(string)
@@ -69,8 +66,6 @@ test.each([
   { schema: z.intersection(z.object({ foo: z.string() }), z.object({ bar: z.number() })), type: 'Intersection' },
   { schema: z.promise(z.string()), type: 'Promise' },
 ])('$type schemas are not supported', async ({ schema }) => {
-  await initZod()
-
   expect(safeGetParamValue('test', { param: schema })).toBeUndefined()
   expect(safeSetParamValue('test', { param: schema })).toBeUndefined()
 })

--- a/src/services/zod.ts
+++ b/src/services/zod.ts
@@ -1,6 +1,4 @@
-import { Param, ParamGetSet } from '@/types/paramTypes'
-import { Routes } from '@/types/route'
-import { isUrl } from '@/types/url'
+import { ParamGetSet } from '@/types/paramTypes'
 import { isRecord } from '@/utilities/guards'
 import { StandardSchemaV1 } from '@standard-schema/spec'
 import { type ZodType } from 'zod'
@@ -9,124 +7,17 @@ export interface ZodSchemaLike extends StandardSchemaV1<any> {
   parse: (input: any) => any,
 }
 
-let zod: ZodSchemas | null = null
-
-// inferring the return type is preferred for this function
-// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
-async function getZodInstances() {
-  const {
-    ZodType,
-    ZodString,
-    ZodIPv4,
-    ZodIPv6,
-    ZodCIDRv4,
-    ZodCIDRv6,
-    ZodURL,
-    ZodEmail,
-    ZodUUID,
-    ZodBase64,
-    ZodCUID,
-    ZodCUID2,
-    ZodULID,
-    ZodJWT,
-    ZodBigInt,
-    ZodNaN,
-    ZodBoolean,
-    ZodDate,
-    ZodISODateTime,
-    ZodISODate,
-    ZodISOTime,
-    ZodNumber,
-    ZodLiteral,
-    ZodObject,
-    ZodEnum,
-    ZodArray,
-    ZodTuple,
-    ZodUnion,
-    ZodDiscriminatedUnion,
-    ZodRecord,
-    ZodMap,
-    ZodSet,
-    ZodIntersection,
-    ZodPromise,
-  } = await import('zod')
-
-  return {
-    ZodType,
-    ZodString,
-    ZodIPv4,
-    ZodIPv6,
-    ZodCIDRv4,
-    ZodCIDRv6,
-    ZodURL,
-    ZodEmail,
-    ZodUUID,
-    ZodBase64,
-    ZodCUID,
-    ZodCUID2,
-    ZodULID,
-    ZodJWT,
-    ZodBigInt,
-    ZodNaN,
-    ZodBoolean,
-    ZodDate,
-    ZodISODateTime,
-    ZodISODate,
-    ZodISOTime,
-    ZodNumber,
-    ZodLiteral,
-    ZodObject,
-    ZodEnum,
-    ZodArray,
-    ZodTuple,
-    ZodUnion,
-    ZodDiscriminatedUnion,
-    ZodRecord,
-    ZodMap,
-    ZodSet,
-    ZodIntersection,
-    ZodPromise,
-  }
-}
-
-type ZodSchemas = Awaited<ReturnType<typeof getZodInstances>>
-
-export function zodParamsDetected(routes: Routes): boolean {
-  return Object.values(routes).some((route) => {
-    if (!isUrl(route)) {
-      return false
-    }
-
-    return Object.values(route.schema.host.params).some(({ param }) => isZodSchemaLike(param))
-      || Object.values(route.schema.path.params).some(({ param }) => isZodSchemaLike(param))
-      || Object.values(route.schema.query.params).some(({ param }) => isZodSchemaLike(param))
-  })
-}
-
-function isZodSchemaLike(param: Param): param is ZodSchemaLike {
-  return isRecord(param)
-    && 'parse' in param
-    && typeof param.parse === 'function'
-    && '~standard' in param
-    && isRecord(param['~standard'])
-    && 'vendor' in param['~standard']
-    && param['~standard'].vendor === 'zod'
-}
-
-export async function initZod(): Promise<void> {
-  try {
-    zod = await getZodInstances()
-  } catch {
-    throw new Error('Failed to initialize Zod')
-  }
-}
-
-export function isZodParam(value: unknown): value is ZodType {
-  if (!zod) {
-    return false
-  }
-
-  return value instanceof zod.ZodType
+export function isZodSchema(value: unknown): value is ZodType {
+  return isRecord(value)
+    && 'parse' in value
+    && typeof value.parse === 'function'
+    && 'def' in value
+    && isRecord(value.def)
+    && typeof value.def.type === 'string'
+    && '~standard' in value
+    && isRecord(value['~standard'])
+    && 'vendor' in value['~standard']
+    && value['~standard'].vendor === 'zod'
 }
 
 export function createZodParam<T>(schema: ZodType<T>): ParamGetSet<T> {
@@ -178,39 +69,35 @@ function tryAll<T>(fns: (() => T)[]): T {
 
 // Sorts string schemas last
 function sortZodSchemas(schemaA: ZodType, schemaB: ZodType): number {
-  return zod?.ZodString && schemaA instanceof zod.ZodString ? 1 : zod?.ZodString && schemaB instanceof zod.ZodString ? -1 : 0
+  return schemaA.def.type === 'string' ? 1 : schemaB.def.type === 'string' ? -1 : 0
 }
 
 function parseZodValue(value: string, schema: ZodType): unknown {
-  if (!zod) {
-    throw new Error('Zod is not initialized')
-  }
-
-  if (schema instanceof zod.ZodString) {
+  if (schema.def.type === 'string') {
     return schema.parse(value)
   }
 
-  if (schema instanceof zod.ZodBoolean) {
+  if (schema.def.type === 'boolean') {
     return schema.parse(Boolean(value))
   }
 
-  if (schema instanceof zod.ZodDate) {
+  if (schema.def.type === 'date') {
     return schema.parse(new Date(value))
   }
 
-  if (schema instanceof zod.ZodNumber) {
+  if (schema.def.type === 'number') {
     return schema.parse(Number(value))
   }
 
-  if (schema instanceof zod.ZodBigInt) {
+  if (schema.def.type === 'bigint') {
     return schema.parse(BigInt(value))
   }
 
-  if (schema instanceof zod.ZodNaN) {
+  if (schema.def.type === 'nan') {
     return schema.parse(Number(value))
   }
 
-  if (schema instanceof zod.ZodLiteral) {
+  if (schema.def.type === 'literal') {
     return tryAll([
       () => schema.parse(Number(value)),
       () => schema.parse(Boolean(value)),
@@ -218,23 +105,23 @@ function parseZodValue(value: string, schema: ZodType): unknown {
     ])
   }
 
-  if (schema instanceof zod.ZodObject) {
+  if (schema.def.type === 'object') {
     return schema.parse(JSON.parse(value, reviver))
   }
 
-  if (schema instanceof zod.ZodEnum) {
+  if (schema.def.type === 'enum') {
     return schema.parse(value)
   }
 
-  if (schema instanceof zod.ZodArray) {
+  if (schema.def.type === 'array') {
     return schema.parse(JSON.parse(value, reviver))
   }
 
-  if (schema instanceof zod.ZodTuple) {
+  if (schema.def.type === 'tuple') {
     return schema.parse(JSON.parse(value, reviver))
   }
 
-  if (schema instanceof zod.ZodUnion) {
+  if (schema.def.type === 'union' && 'options' in schema.def) {
     const schemas = Array
       .from(schema.def.options as ZodType[])
       .sort(sortZodSchemas)
@@ -243,32 +130,23 @@ function parseZodValue(value: string, schema: ZodType): unknown {
     return tryAll(schemas)
   }
 
-  if (schema instanceof zod.ZodDiscriminatedUnion) {
-    const schemas = Array
-      .from(schema.options as ZodType[])
-      .sort(sortZodSchemas)
-      .map((schema: ZodType) => () => parseZodValue(value, schema))
-
-    return tryAll(schemas)
-  }
-
-  if (schema instanceof zod.ZodRecord) {
+  if (schema.def.type === 'record') {
     return schema.parse(JSON.parse(value, reviver))
   }
 
-  if (schema instanceof zod.ZodMap) {
+  if (schema.def.type === 'map') {
     return schema.parse(new Map(JSON.parse(value, reviver)))
   }
 
-  if (schema instanceof zod.ZodSet) {
+  if (schema.def.type === 'set') {
     return schema.parse(new Set(JSON.parse(value, reviver)))
   }
 
-  if (schema instanceof zod.ZodIntersection) {
+  if (schema.def.type === 'intersection') {
     throw new Error('Intersection schemas are not supported')
   }
 
-  if (schema instanceof zod.ZodPromise) {
+  if (schema.def.type === 'promise') {
     throw new Error('Promise schemas are not supported')
   }
 
@@ -276,117 +154,55 @@ function parseZodValue(value: string, schema: ZodType): unknown {
 }
 
 function stringifyZodValue(value: unknown, schema: ZodType): string {
-  if (!zod) {
-    throw new Error('Zod is not initialized')
+  if (schema.def.type === 'string') {
+    return String(schema.parse(value))
   }
 
-  if (schema instanceof zod.ZodString) {
-    return schema.parse(value)
+  if (schema.def.type === 'boolean') {
+    return String(schema.parse(value))
   }
 
-  if (schema instanceof zod.ZodISODateTime) {
-    return schema.parse(value)
+  if (schema.def.type === 'date') {
+    const parsed = schema.parse(value) as Date
+
+    return parsed.toISOString()
   }
 
-  if (schema instanceof zod.ZodISODate) {
-    return schema.parse(value)
+  if (schema.def.type === 'number') {
+    return String(schema.parse(Number(value)))
   }
 
-  if (schema instanceof zod.ZodISOTime) {
-    return schema.parse(value)
+  if (schema.def.type === 'bigint') {
+    return String(schema.parse(BigInt(String(value))))
   }
 
-  if (schema instanceof zod.ZodIPv4) {
-    return schema.parse(value)
+  if (schema.def.type === 'nan') {
+    return String(schema.parse(value))
   }
 
-  if (schema instanceof zod.ZodIPv6) {
-    return schema.parse(value)
+  if (schema.def.type === 'literal') {
+    return String(schema.parse(value))
   }
 
-  if (schema instanceof zod.ZodCIDRv4) {
-    return schema.parse(value)
-  }
-
-  if (schema instanceof zod.ZodCIDRv6) {
-    return schema.parse(value)
-  }
-
-  if (schema instanceof zod.ZodURL) {
-    return schema.parse(value)
-  }
-
-  if (schema instanceof zod.ZodEmail) {
-    return schema.parse(value)
-  }
-
-  if (schema instanceof zod.ZodUUID) {
-    return schema.parse(value)
-  }
-
-  if (schema instanceof zod.ZodBase64) {
-    return schema.parse(value)
-  }
-
-  if (schema instanceof zod.ZodCUID) {
-    return schema.parse(value)
-  }
-
-  if (schema instanceof zod.ZodCUID2) {
-    return schema.parse(value)
-  }
-
-  if (schema instanceof zod.ZodULID) {
-    return schema.parse(value)
-  }
-
-  if (schema instanceof zod.ZodJWT) {
-    return schema.parse(value)
-  }
-
-  if (schema instanceof zod.ZodBoolean) {
-    return schema.parse(value).toString()
-  }
-
-  if (schema instanceof zod.ZodDate) {
-    return schema.parse(value).toISOString()
-  }
-
-  if (schema instanceof zod.ZodNumber) {
-    return schema.parse(Number(value)).toString()
-  }
-
-  if (schema instanceof zod.ZodBigInt) {
-    return schema.parse(BigInt(String(value))).toString()
-  }
-
-  if (schema instanceof zod.ZodNaN) {
-    return schema.parse(value).toString()
-  }
-
-  if (schema instanceof zod.ZodLiteral) {
-    const parsed = schema.parse(value)
-    return parsed != null ? parsed.toString() : String(parsed)
-  }
-
-  if (schema instanceof zod.ZodObject) {
+  if (schema.def.type === 'object') {
     return JSON.stringify(schema.parse(value))
   }
 
-  if (schema instanceof zod.ZodEnum) {
+  if (schema.def.type === 'enum') {
     const parsed = schema.parse(value)
+
     return typeof parsed === 'string' ? parsed : String(parsed)
   }
 
-  if (schema instanceof zod.ZodArray) {
+  if (schema.def.type === 'array') {
     return JSON.stringify(schema.parse(value))
   }
 
-  if (schema instanceof zod.ZodTuple) {
+  if (schema.def.type === 'tuple') {
     return JSON.stringify(schema.parse(value))
   }
 
-  if (schema instanceof zod.ZodUnion) {
+  if (schema.def.type === 'union' && 'options' in schema.def) {
     const schemas = Array
       .from(schema.def.options as ZodType[])
       .sort(sortZodSchemas)
@@ -395,36 +211,27 @@ function stringifyZodValue(value: unknown, schema: ZodType): string {
     return tryAll(schemas)
   }
 
-  if (schema instanceof zod.ZodDiscriminatedUnion) {
-    const schemas = Array
-      .from(schema.options as ZodType[])
-      .sort(sortZodSchemas)
-      .map((schema: ZodType) => () => stringifyZodValue(value, schema))
-
-    return tryAll(schemas)
-  }
-
-  if (schema instanceof zod.ZodRecord) {
+  if (schema.def.type === 'record') {
     return JSON.stringify(schema.parse(value))
   }
 
-  if (schema instanceof zod.ZodMap) {
-    const parsed = schema.parse(value)
+  if (schema.def.type === 'map') {
+    const parsed = schema.parse(value) as Map<unknown, unknown>
 
     return JSON.stringify(Array.from(parsed.entries()))
   }
 
-  if (schema instanceof zod.ZodSet) {
-    const parsed = schema.parse(value)
+  if (schema.def.type === 'set') {
+    const parsed = schema.parse(value) as Set<unknown>
 
     return JSON.stringify(Array.from(parsed.values()))
   }
 
-  if (schema instanceof zod.ZodIntersection) {
+  if (schema.def.type === 'intersection') {
     throw new Error('Intersection schemas are not supported')
   }
 
-  if (schema instanceof zod.ZodPromise) {
+  if (schema.def.type === 'promise') {
     throw new Error('Promise schemas are not supported')
   }
 


### PR DESCRIPTION
# Description

The router dynamically imported zod so `initZod` could stash its classes for `instanceof` dispatch, and `start` awaited that import whenever a zod param was detected. Valibot support never needed any of this — it detects schemas by their `~standard.vendor` marker and dispatches on a type string. Zod schemas carry the same structural surface (`def.type`), so zod now works the same way and the import, `initZod`, `zodParamsDetected`, and the async step in `start` are gone.

Two collapses fall out of the mapping: all sixteen string format classes (`ZodEmail`, `ZodUUID`, `ZodIPv4`, …) carry `def.type === 'string'` and their branches were already identical to the string branch, and a discriminated union carries `def.type === 'union'`, which it was already reaching through `instanceof ZodUnion`.

## The instanceof checks were also broken

`instanceof` compares against the router's own imported zod, so a schema constructed by any other copy of zod — a second install, a CJS/ESM split — failed every check silently, and `isZodParam` returning false leaves the param unparsed rather than erroring. It misfires even within a single zod 4.0.0 install: `z.email() instanceof z.ZodString` is `false`, so format schemas sorted as non-strings inside unions. Structural checks are immune to both, and remove the "zod failed to initialize" failure mode entirely.

The zod suite's 41 round-trip cases — every dispatch branch, both union styles, maps, sets, and the unsupported schema errors — now run with no initialization at all, which is the direct proof the import was never load-bearing.

The user's app always has zod loaded when this code runs, because their route definitions construct the schemas — the router never needed its own copy. With no import left, the optional zod peer dependency is removed too, matching valibot, which was never declared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
